### PR TITLE
Use tmp dir and fix other issues with the cron job

### DIFF
--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import uuid
 from typing import Dict, List, Tuple, Optional
 
@@ -115,16 +116,14 @@ MODEL_NAME = config.get('model_name', 'gpt-4')
 MAX_MODEL_TOKENS = 4000  # You can modify this if needed
 
 # Define the translation queue folders
-# Get appuser's home directory, default to /home/appuser if not found (e.g., during testing outside container)
-APPUSER_HOME = os.path.expanduser("~")  # This will be /home/appuser inside the container when run as appuser
-if not os.path.isdir(APPUSER_HOME) or APPUSER_HOME == '/':  # Basic check if expanduser fails weirdly or returns root
-    APPUSER_HOME = "/home/appuser"
+# Use the system's temporary directory for transient data
+TEMP_DIR = tempfile.gettempdir() # This will be /tmp inside the container
 
 _translation_queue_name = config.get('translation_queue_folder', 'translation_queue')
 _translated_queue_name = config.get('translated_queue_folder', 'translated_queue')
 
-TRANSLATION_QUEUE_FOLDER = os.path.join(APPUSER_HOME, _translation_queue_name)
-TRANSLATED_QUEUE_FOLDER = os.path.join(APPUSER_HOME, _translated_queue_name)
+TRANSLATION_QUEUE_FOLDER = os.path.join(TEMP_DIR, _translation_queue_name)
+TRANSLATED_QUEUE_FOLDER = os.path.join(TEMP_DIR, _translated_queue_name)
 
 # Dry run configuration (if True, files won't be moved/copied, etc.)
 DRY_RUN = config.get('dry_run', False)

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Ensure the PATH includes /usr/local/bin where the Transifex CLI is installed.
+export PATH="/usr/local/bin:$PATH"
+
 # Define a consistent prefix for translation branches
 TRANSLATION_BRANCH_PREFIX="translation-updates"
 
@@ -184,11 +187,12 @@ setup_venv() {
 # Load configuration from YAML file
 CONFIG_FILE="config.yaml" # This should be /app/config.yaml, which is config.docker.yaml mounted
 
-# Helper function to parse values from config.yaml robustly using awk
+# Helper function to parse values from config.yaml robustly using yq
 get_config_value() {
     local key="$1"
     local config_file="$2"
-    awk -F': *| *#.*' -v k="^$key:" '$0 ~ k {gsub(/^[ \t'"'"'"]+|[ \t'"'"'"]+$/, "", $2); print $2; exit}' "$config_file"
+    # Use yq to safely read the value. The -e flag exits with non-zero status if the key is not found.
+    yq -e ".$key" "$config_file"
 }
 
 TARGET_PROJECT_ROOT=$(get_config_value "target_project_root" "$CONFIG_FILE")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage location for translation queue data to use the system's temporary directory.
  * Improved configuration value extraction in translation update script for greater reliability.
  * Ensured required command-line tools are accessible by updating the system path in the script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->