### PR TITLE
Fix false error when no translation keys changed

### DIFF
--- a/update-translations.sh
+++ b/update-translations.sh
@@ -325,11 +325,15 @@ else
             exit $TX_STATUS
         fi
 
-        # Verify that files have been updated
+        # Check if files have been updated
         if ! git status --porcelain | grep -qE '\.(properties|po|mo)$'; then
-            log "Error: Transifex pull did not update any translation files (.properties/.po/.mo). This might indicate an issue with the Transifex CLI or the configuration." "ERROR"
-            exit 1
+            log "Transifex pull completed successfully, but no translation files were modified. This is normal when there are no new translation keys." "INFO"
+            log "No further processing needed. Exiting gracefully."
+            send_heartbeat_if_configured
+            exit 0
         fi
+
+        log "Transifex pull successfully updated translation files. Proceeding with AI translation..."
 
     else
         log "Error: Transifex CLI not found. Please install it manually."

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -326,14 +326,15 @@ else
         fi
 
         # Check if files have been updated
-        if ! git status --porcelain | grep -qE '\.(properties|po|mo)$'; then
+        # Match translation files even when staged for deletion (D prefix) or renames (-> suffix)
+        if ! git status --porcelain | grep -qE '\.(properties|po|mo)([[:space:]]|$|->)'; then
             log "Transifex pull completed successfully, but no translation files were modified. This is normal when there are no new translation keys." "INFO"
             log "No further processing needed. Exiting gracefully."
             send_heartbeat_if_configured
             exit 0
         fi
 
-        log "Transifex pull successfully updated translation files. Proceeding with AI translation..."
+        log "Transifex pull successfully updated translation files. Starting AI translation processing..." "INFO"
 
     else
         log "Error: Transifex CLI not found. Please install it manually."


### PR DESCRIPTION
## Summary
- Fixes cron job failure when Transifex pull succeeds but no translation files are modified
- Changes error condition to graceful exit when no new translation keys exist

## Problem
The script was incorrectly reporting an error when Transifex successfully pulled translations but no files were modified. This is a valid scenario that occurs when there are no new translation keys added since the last run.

## Solution
- Convert ERROR log to INFO log explaining this is normal behavior
- Exit with code 0 (success) instead of 1 (failure)
- Send heartbeat ping before graceful exit to indicate successful completion
- Add confirmation log when translation files are actually updated

## Test plan
- [x] Verified change in local codebase
- [ ] Deploy to server and verify cron job doesn't fail when no keys changed
- [ ] Verify normal translation flow still works when files are updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents false failures when no new translations are available by exiting gracefully with success.

* **Chores**
  * Adds clear informational logs when translation files are updated.
  * Logs a follow-up message before starting AI translation after updates.
  * Sends a heartbeat when no updates are found (if configured) to improve monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->