### PR TITLE
Add logrotate configuration to deployment guide

### DIFF
--- a/docs/new-project-deployment.md
+++ b/docs/new-project-deployment.md
@@ -147,4 +147,35 @@ Once the manual run is successful, schedule the service to run automatically.
     ```
 3.  Save and close the file.
 
+## Step 7: Configure Log Rotation
+
+To prevent log files from growing indefinitely, set up logrotate. **Important**: The Docker container runs as `appuser` (uid 9999), so log files must be created with the correct ownership after rotation.
+
+1.  Create a logrotate configuration file:
+    ```bash
+    sudo nano /etc/logrotate.d/translator-service
+    ```
+
+2.  Add the following configuration:
+    ```
+    /opt/translator-service/logs/*.log {
+        daily
+        rotate 7
+        compress
+        delaycompress
+        missingok
+        notifempty
+        create 0644 9999 9999
+        dateext
+        dateformat -%Y%m%d
+    }
+    ```
+
+    > **Critical**: The `create 0644 9999 9999` line ensures new log files are owned by uid 9999 (appuser). Without this, the container will fail with "Permission denied" errors after log rotation.
+
+3.  Test the configuration:
+    ```bash
+    sudo logrotate -d /etc/logrotate.d/translator-service
+    ```
+
 **Deployment is now complete.** The service will run automatically on the schedule you've set. You can check the log file at `/opt/translator-service/logs/cron_job.log` to monitor its execution.

--- a/docs/new-project-deployment.md
+++ b/docs/new-project-deployment.md
@@ -157,7 +157,7 @@ To prevent log files from growing indefinitely, set up logrotate. **Important**:
     ```
 
 2.  Add the following configuration:
-    ```
+    ```ini
     /opt/translator-service/logs/*.log {
         daily
         rotate 7


### PR DESCRIPTION
## Summary
- Adds Step 7 to deployment guide documenting logrotate configuration
- Documents critical requirement for `create 0644 9999 9999` to match container appuser uid
- Prevents permission denied errors after log rotation

## Context
Today's pipeline failure was caused by logrotate creating log files with root ownership instead of uid 9999 (appuser). This documentation ensures new deployments configure logrotate correctly from the start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Step 7 — Configure Log Rotation to the deployment guide with a logrotate snippet for service logs (daily rotation, 7 rotations, compression, date-based rotation).
  * Emphasized that rotated logs must be owned by appuser (uid 9999) to avoid "Permission denied", added a dry-run test command, and updated the deployment conclusion to reference log monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->