### PR TITLE
Improve HTML tag and placeholder protection instructions

### DIFF
--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -775,7 +775,8 @@ async def translate_text_async(
 You are an expert translator specializing in software localization. Translate the following text from English to {target_language}, considering the context and glossary provided.
 
 **Instructions**:
-- **Do not translate or modify placeholder tokens**: Any text enclosed within double underscores `__` (e.g., `__PH_abc123__`) should remain exactly as is.
+- **Do not translate or modify placeholder tokens**: Any text enclosed within double underscores `__` (e.g., `__PH_abc123__`) should remain exactly as is. These represent placeholders like {{0}}, {{1}}, or HTML tags.
+- **CRITICAL - Translate ALL other text**: You MUST translate all regular text, even if it appears between, before, or after placeholder tokens. Do not skip text just because it is near placeholders.
 - **Strictly follow all glossaries**:
   - **Brand/Technical Glossary**: These terms MUST NOT be translated. Preserve their original casing and form.
   - **Translation Glossary**: These terms are non-negotiable. You MUST use the provided translation, matching the source term case-insensitively.
@@ -887,15 +888,16 @@ You are a lead editor and quality assurance specialist for software localization
     ```
     {keys_to_review_text}
     ```
-2.  **CRITICAL - Placeholder Protection**: You will see placeholder tokens in the format `__PH_abc123__`. These represent dynamic values like {{0}}, {{1}}, etc.
+2.  **CRITICAL - Placeholder Protection**: You will see placeholder tokens in the format `__PH_abc123__`. These represent dynamic values like {{0}}, {{1}}, HTML tags, etc.
     - DO NOT translate, modify, remove, or duplicate these tokens
     - DO NOT add new placeholder tokens
     - Maintain EXACT 1:1 correspondence with source placeholders
     - These tokens are automatically managed by the system
-3.  **Apply All Quality Rules**: Meticulously apply the language-specific quality checklist to every key in your scope.
-4.  **Do Not Escape Single Quotes**: The system will handle all necessary escaping for Java `MessageFormat`. Return single quotes (') as literal characters in the JSON values.
-5.  **Output JSON Only**: Your final output **must** be a single, valid JSON object that adheres to the required schema. This object should contain ONLY the keys listed in the "Strictly Limited Scope" section above, with their final, corrected translations as the values.
-6.  **Do Not Add Explanations**: Do not output any text, markdown, or explanations before or after the JSON object.
+3.  **CRITICAL - Translate ALL Other Text**: You MUST ensure that ALL regular text (text that is NOT a placeholder token) is properly translated, even if it appears between, before, or after placeholder tokens. Do not leave any translatable text untranslated just because it is near placeholders.
+4.  **Apply All Quality Rules**: Meticulously apply the language-specific quality checklist to every key in your scope.
+5.  **Do Not Escape Single Quotes**: The system will handle all necessary escaping for Java `MessageFormat`. Return single quotes (') as literal characters in the JSON values.
+6.  **Output JSON Only**: Your final output **must** be a single, valid JSON object that adheres to the required schema. This object should contain ONLY the keys listed in the "Strictly Limited Scope" section above, with their final, corrected translations as the values.
+7.  **Do Not Add Explanations**: Do not output any text, markdown, or explanations before or after the JSON object.
 
 {style_rules_text}
 

--- a/tests/unit/test_html_tag_protection.py
+++ b/tests/unit/test_html_tag_protection.py
@@ -30,8 +30,9 @@ class TestPlaceholderExtraction:
         assert "{0}" in mapping.values()
         assert "{1}" in mapping.values()
 
-        # The processed text should contain placeholder tokens
-        assert "__PH_" in processed
+        # The processed text should contain the generated placeholder tokens
+        for token in mapping.keys():
+            assert token in processed
 
         # Should NOT contain the original placeholders
         assert "{0}" not in processed

--- a/tests/unit/test_html_tag_protection.py
+++ b/tests/unit/test_html_tag_protection.py
@@ -7,7 +7,6 @@ This test module verifies that:
 3. Text between placeholders and HTML tags is NOT protected and can be translated
 """
 
-import pytest
 from src.translate_localization_files import (
     extract_placeholders,
     restore_placeholders,

--- a/tests/unit/test_html_tag_protection.py
+++ b/tests/unit/test_html_tag_protection.py
@@ -1,0 +1,342 @@
+"""
+Unit tests for HTML tag and placeholder protection in translations.
+
+This test module verifies that:
+1. Placeholders like {0}, {1}, etc. are properly protected
+2. HTML tags like <{0} style=code> are properly protected
+3. Text between placeholders and HTML tags is NOT protected and can be translated
+"""
+
+import pytest
+from src.translate_localization_files import (
+    extract_placeholders,
+    restore_placeholders,
+    protect_placeholders_in_properties,
+    restore_placeholders_in_properties
+)
+
+
+class TestPlaceholderExtraction:
+    """Test the extract_placeholders function for individual text strings"""
+
+    def test_simple_placeholder_protection(self):
+        """Test that simple placeholders are protected"""
+        text = "Hello {0}, welcome to {1}"
+        processed, mapping = extract_placeholders(text)
+
+        # Should have 2 placeholders protected
+        assert len(mapping) == 2
+
+        # All original placeholders should be in the mapping
+        assert "{0}" in mapping.values()
+        assert "{1}" in mapping.values()
+
+        # The processed text should contain placeholder tokens
+        assert "__PH_" in processed
+
+        # Should NOT contain the original placeholders
+        assert "{0}" not in processed
+        assert "{1}" not in processed
+
+        # The translatable text should remain
+        assert "Hello" in processed
+        assert "welcome to" in processed
+
+    def test_html_tag_protection(self):
+        """Test that HTML-like tags are protected"""
+        text = "Click <button>here</button> to continue"
+        processed, mapping = extract_placeholders(text)
+
+        # Should have 2 HTML tags protected
+        assert len(mapping) == 2
+
+        # Tags should be in mapping
+        assert "<button>" in mapping.values()
+        assert "</button>" in mapping.values()
+
+        # Translatable text should remain
+        assert "Click" in processed
+        assert "here" in processed
+        assert "to continue" in processed
+
+    def test_html_tag_with_placeholder_inside(self):
+        """Test HTML tags that contain placeholders (like <{0} style=code>)"""
+        text = "The price is <{0} style=offer-details-code>"
+        processed, mapping = extract_placeholders(text)
+
+        # The HTML tag regex matches the ENTIRE tag including the placeholder inside
+        # This is correct behavior - the whole tag is treated as one protected unit
+        assert len(mapping) == 1
+
+        # The entire HTML tag (including placeholder inside) should be in mapping
+        assert "<{0} style=offer-details-code>" in mapping.values()
+
+        # Translatable text should remain
+        assert "The price is" in processed
+
+    def test_problematic_case_1_only_placeholders(self):
+        """
+        Test case from issue: {0} <{1} style=offer-details-code>
+        This case has no translatable text - only placeholders and HTML tag.
+        """
+        text = "{0} <{1} style=offer-details-code>"
+        processed, mapping = extract_placeholders(text)
+
+        # Should protect placeholders and HTML tag
+        assert len(mapping) == 2
+        assert "{0}" in mapping.values()
+
+        # Check if HTML tag with placeholder is protected
+        html_tag_protected = any(
+            "style=offer-details-code>" in v for v in mapping.values()
+        )
+        assert html_tag_protected
+
+        # After removing all tokens, should have minimal/no translatable text
+        remaining = processed
+        for token in mapping.keys():
+            remaining = remaining.replace(token, "")
+        remaining = remaining.strip()
+
+        # Should be empty or just whitespace
+        assert len(remaining) == 0 or remaining.isspace()
+
+    def test_problematic_case_2_text_with_placeholders(self):
+        """
+        Test case from issue: Fixed price. {0} {1} market price of {2} <{3} style=offer-details-code>
+        The text "market price of" should remain translatable.
+        """
+        text = "Fixed price. {0} {1} market price of {2} <{3} style=offer-details-code>"
+        processed, mapping = extract_placeholders(text)
+
+        # Should protect 4 items: {0}, {1}, {2}, and the HTML tag
+        assert len(mapping) == 4
+
+        # All placeholders should be protected
+        assert "{0}" in mapping.values()
+        assert "{1}" in mapping.values()
+        assert "{2}" in mapping.values()
+
+        # HTML tag should be protected
+        html_tag_protected = any(
+            "style=offer-details-code>" in v for v in mapping.values()
+        )
+        assert html_tag_protected
+
+        # CRITICAL: Translatable text should remain
+        assert "Fixed price." in processed
+        assert "market price of" in processed
+
+        # Verify the translatable text after removing tokens
+        remaining = processed
+        for token in mapping.keys():
+            remaining = remaining.replace(token, "")
+        remaining = ' '.join(remaining.split())  # Normalize whitespace
+
+        # Should contain the translatable phrases
+        assert "Fixed price." in remaining
+        assert "market price of" in remaining
+
+    def test_text_between_multiple_placeholders(self):
+        """Test that text appearing between multiple placeholders is preserved"""
+        text = "Buy {0} BTC at {1} market price using {2}"
+        processed, mapping = extract_placeholders(text)
+
+        # Should protect 3 placeholders
+        assert len(mapping) == 3
+
+        # Translatable text should be preserved
+        assert "Buy" in processed
+        assert "BTC at" in processed
+        assert "market price using" in processed
+
+    def test_placeholder_restoration(self):
+        """Test that placeholders can be correctly restored after translation"""
+        text = "Hello {0}, you have {1} messages"
+        processed, mapping = extract_placeholders(text)
+
+        # Simulate a translation that keeps the tokens
+        simulated_translation = processed.replace("Hello", "Hola").replace(
+            "you have", "tienes"
+        ).replace("messages", "mensajes")
+
+        # Restore placeholders
+        restored = restore_placeholders(simulated_translation, mapping)
+
+        # Should have original placeholders back
+        assert "{0}" in restored
+        assert "{1}" in restored
+
+        # Should have translated text
+        assert "Hola" in restored
+        assert "tienes" in restored
+        assert "mensajes" in restored
+
+        # Should NOT have tokens
+        assert "__PH_" not in restored
+
+
+class TestPropertiesFileProtection:
+    """Test the protect_placeholders_in_properties function for full file content"""
+
+    def test_protect_multiple_properties(self):
+        """Test protecting placeholders across multiple property lines"""
+        content = """
+key1=Hello {0}
+key2=Fixed price. {0} {1} market price of {2} <{3} style=offer-details-code>
+key3=Simple text without placeholders
+"""
+        protected, mapping = protect_placeholders_in_properties(content)
+
+        # Should protect all placeholders and HTML tags
+        assert len(mapping) >= 4  # At least {0}, {1}, {2}, and HTML tag from key2
+
+        # All original placeholders should be protected
+        assert "{0}" not in protected
+        assert "{1}" not in protected
+
+        # Translatable text should remain
+        assert "Hello" in protected
+        assert "Fixed price." in protected
+        assert "market price of" in protected
+        assert "Simple text without placeholders" in protected
+
+    def test_restore_properties_placeholders(self):
+        """Test that placeholders can be restored in full properties content"""
+        content = "key=Hello {0}, welcome to {1}"
+        protected, mapping = protect_placeholders_in_properties(content)
+
+        # Restore
+        restored = restore_placeholders_in_properties(protected, mapping)
+
+        # Should match original
+        assert restored == content
+
+    def test_empty_content(self):
+        """Test handling of empty content"""
+        protected, mapping = protect_placeholders_in_properties("")
+
+        assert protected == ""
+        assert mapping == {}
+
+    def test_content_without_placeholders(self):
+        """Test content that has no placeholders to protect"""
+        content = "key=Simple text without any placeholders"
+        protected, mapping = protect_placeholders_in_properties(content)
+
+        # Content should be unchanged
+        assert protected == content
+
+        # No placeholders should be in mapping
+        assert len(mapping) == 0
+
+
+class TestEdgeCases:
+    """Test edge cases and complex scenarios"""
+
+    def test_nested_braces_in_html(self):
+        """Test HTML tags that contain braces"""
+        text = "Value: <span data-value='{0}'>{1}</span>"
+        processed, mapping = extract_placeholders(text)
+
+        # Should protect placeholders and HTML tags
+        assert len(mapping) >= 2
+
+        # Translatable text should remain
+        assert "Value:" in processed
+
+    def test_multiple_html_tags(self):
+        """Test multiple HTML tags in sequence"""
+        text = "Click <a href='#'>here</a> or <button>there</button>"
+        processed, mapping = extract_placeholders(text)
+
+        # Should protect multiple tags
+        assert len(mapping) == 4  # 2 opening tags, 2 closing tags
+
+        # Translatable text should remain
+        assert "Click" in processed
+        assert "here" in processed
+        assert "or" in processed
+        assert "there" in processed
+
+    def test_html_tag_without_spaces(self):
+        """Test HTML tags that are immediately adjacent to text"""
+        text = "Start<tag>middle</tag>end"
+        processed, mapping = extract_placeholders(text)
+
+        # Tags should be protected
+        assert "<tag>" in mapping.values()
+        assert "</tag>" in mapping.values()
+
+        # Text should remain
+        assert "Start" in processed
+        assert "middle" in processed
+        assert "end" in processed
+
+    def test_placeholder_at_start_and_end(self):
+        """Test placeholders at the beginning and end of text"""
+        text = "{0} some text here {1}"
+        processed, mapping = extract_placeholders(text)
+
+        # Placeholders should be protected
+        assert len(mapping) == 2
+
+        # Text should remain
+        assert "some text here" in processed
+
+    def test_only_placeholders_no_text(self):
+        """Test string that is only placeholders"""
+        text = "{0}{1}{2}"
+        processed, mapping = extract_placeholders(text)
+
+        # All placeholders protected
+        assert len(mapping) == 3
+
+        # Should be only tokens left
+        remaining = processed
+        for token in mapping.keys():
+            remaining = remaining.replace(token, "")
+
+        # Should be empty or minimal
+        assert len(remaining.strip()) == 0
+
+
+class TestRealWorldExamples:
+    """Test with actual examples from the bisq properties files"""
+
+    def test_bisq_quote_side_amount(self):
+        """Test: bisqEasy.offerDetails.quoteSideAmount={0} <{1} style=offer-details-code>"""
+        text = "{0} <{1} style=offer-details-code>"
+        processed, mapping = extract_placeholders(text)
+
+        # This case has no translatable text, which is correct
+        assert len(mapping) == 2
+
+        remaining = processed
+        for token in mapping.keys():
+            remaining = remaining.replace(token, "")
+
+        # Should be minimal/empty
+        assert len(remaining.strip()) == 0
+
+    def test_bisq_price_details_fix(self):
+        """Test: bisqEasy.offerDetails.priceDetails.fix=Fixed price. {0} {1} market price of {2} <{3} style=offer-details-code>"""
+        text = "Fixed price. {0} {1} market price of {2} <{3} style=offer-details-code>"
+        processed, mapping = extract_placeholders(text)
+
+        # Should have 4 protected items
+        assert len(mapping) == 4
+
+        # CRITICAL: The key translatable phrases must remain
+        assert "Fixed price." in processed
+        assert "market price of" in processed
+
+        # Verify by checking what remains after token removal
+        remaining = processed
+        for token in mapping.keys():
+            remaining = remaining.replace(token, "")
+        remaining = ' '.join(remaining.split())
+
+        # These phrases must be translatable
+        assert "Fixed price." in remaining
+        assert "market price of" in remaining


### PR DESCRIPTION
## Summary

This PR enhances the AI translation prompts to more explicitly instruct the model to translate ALL text that is not a placeholder token. This addresses cases where text appearing near placeholders or HTML tags was being skipped during translation.

## Changes

### AI Prompt Improvements
- **Initial Translation Prompt**: Added explicit instruction to translate all regular text even when it appears between, before, or after placeholder tokens
- **Review Prompt**: Added numbered step emphasizing the CRITICAL requirement to translate ALL non-placeholder text
- **Clarification**: Updated placeholder descriptions to note they represent both dynamic values (`{0}`, `{1}`) AND HTML tags

### Testing
- Added comprehensive test suite `tests/unit/test_html_tag_protection.py` with 18 test cases
- Tests cover:
  - Simple placeholder protection and restoration
  - HTML tag protection (including tags with placeholders inside like `<{0} style=code>`)
  - Edge cases: nested braces, multiple tags, various text positions
  - Real-world examples from Bisq translation issues

## Problem Addressed

Previously, when translatable text appeared adjacent to placeholder tokens (especially in complex cases like HTML tags with embedded placeholders), the AI would sometimes skip translating that text, treating it as part of the protected element.

Example issue:
```
Source: "quote side is <{0} style=code>{1}</STYLE> {2}"
Expected: AI should translate "quote side is" while protecting placeholders
Actual: Sometimes "quote side is" was not translated
```

## Technical Details

The existing placeholder protection mechanism (`extract_placeholders` / `restore_placeholders`) remains **unchanged**. This PR only improves the AI instructions to prevent under-translation of text adjacent to protected elements.

The enhanced prompts now:
1. Explicitly state that placeholders represent HTML tags in addition to dynamic values
2. Use "CRITICAL" emphasis to ensure the AI translates ALL regular text
3. Provide clearer separation between "what to protect" vs "what to translate"

## Test Results

All 18 new tests pass:
```bash
tests/unit/test_html_tag_protection.py::TestPlaceholderExtraction::test_simple_placeholder_protection PASSED
tests/unit/test_html_tag_protection.py::TestPlaceholderExtraction::test_html_tag_protection PASSED
tests/unit/test_html_tag_protection.py::TestPlaceholderExtraction::test_html_tag_with_placeholder_inside PASSED
tests/unit/test_html_tag_protection.py::TestPlaceholderExtraction::test_problematic_case_1_only_placeholders PASSED
tests/unit/test_html_tag_protection.py::TestPlaceholderExtraction::test_problematic_case_2_text_with_placeholders PASSED
tests/unit/test_html_tag_protection.py::TestPlaceholderExtraction::test_text_between_multiple_placeholders PASSED
tests/unit/test_html_tag_protection.py::TestPlaceholderExtraction::test_placeholder_restoration PASSED
tests/unit/test_html_tag_protection.py::TestPropertiesFileProtection::test_protect_multiple_properties PASSED
tests/unit/test_html_tag_protection.py::TestPropertiesFileProtection::test_restore_properties_placeholders PASSED
tests/unit/test_html_tag_protection.py::TestPropertiesFileProtection::test_empty_content PASSED
tests/unit/test_html_tag_protection.py::TestPropertiesFileProtection::test_content_without_placeholders PASSED
tests/unit/test_html_tag_protection.py::TestEdgeCases::test_nested_braces_in_html PASSED
tests/unit/test_html_tag_protection.py::TestEdgeCases::test_multiple_html_tags PASSED
tests/unit/test_html_tag_protection.py::TestEdgeCases::test_html_tag_without_spaces PASSED
tests/unit/test_html_tag_protection.py::TestEdgeCases::test_placeholder_at_start_and_end PASSED
tests/unit/test_html_tag_protection.py::TestEdgeCases::test_only_placeholders_no_text PASSED
tests/unit/test_html_tag_protection.py::TestRealWorldExamples::test_bisq_quote_side_amount PASSED
tests/unit/test_html_tag_protection.py::TestRealWorldExamples::test_bisq_price_details_fix PASSED
```

## Impact

- **Risk Level**: Low - Only changes AI prompt instructions, no code logic changes
- **Benefits**: Reduces under-translation issues in complex strings with HTML tags and placeholders
- **Testing**: Comprehensive test coverage ensures placeholder protection still works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved translation handling: placeholder protection now explicitly covers HTML tags and varied token formats; translation guidance reworded for clearer preservation rules and to ensure all non-placeholder text is translated.

* **Tests**
  * Added extensive unit tests covering placeholder and HTML-tag protection and restoration, multi-line and edge-case scenarios, and real-world localization examples to increase translation reliability and prevent regressions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->