### PR TITLE
Reduce translation churn with key ledger

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -97,3 +97,17 @@ CVE-2025-58186
 CVE-2025-58187
 CVE-2025-58188
 CVE-2025-61724
+
+# CVE-2025-68121, CVE-2025-61726, CVE-2025-61728, CVE-2025-61729, CVE-2025-61730
+# Go stdlib vulnerabilities affecting vendor-supplied Go binaries in the image.
+# Affects: tx (Transifex CLI), gosu, and potentially yq depending on upstream build toolchain.
+# Rationale: These binaries are used only in controlled CI/CD/container contexts and are
+#            not exposed as user-facing services. We cannot directly patch their embedded
+#            Go stdlib; mitigation depends on upstream binary releases.
+# Added: 2026-02-17
+# Revisit by: 2026-04-15 (re-check upstream releases and rebuild provenance)
+CVE-2025-68121
+CVE-2025-61726
+CVE-2025-61728
+CVE-2025-61729
+CVE-2025-61730

--- a/.trivyignore
+++ b/.trivyignore
@@ -90,7 +90,8 @@ CVE-2025-47906
 #            is minimal given the controlled usage context. Vendors (especially Transifex with Go 1.16.15
 #            from 2022) are unlikely to release patched versions soon.
 # Added: 2025-11-06
-# Revisit by: 2026-01-15 (check for updated vendor releases)
+# Revalidated: 2026-02-17 (CI Trivy still reports embedded Go stdlib in vendor binaries)
+# Revisit by: 2026-04-15 (check for updated vendor releases)
 CVE-2025-47912
 CVE-2025-58183
 CVE-2025-58186

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The service is configured through a combination of YAML files and a single envir
 *   **`docker/config.docker.yaml`**: **Server configuration.** This is the configuration file used by the service when running inside Docker. It points to paths within the container (e.g., `/target_repo`).
 *   **`glossary.json`**: Provides language-specific translations for key terms to ensure consistency.
 *   **`translation_file_filter_glob`** (optional, in `config.yaml`): A glob pattern that limits which changed `.properties` files are processed by the AI translator. This is useful for workflows where you want to pull all updated files from Transifex but only run the AI step on a specific subset (e.g., `mobile_*.properties`).
+*   **`process_all_files`** (optional, in `config.yaml`): Defaults to `false`. When `true`, the pipeline scans and processes all translation files under `input_folder` instead of only git-changed files. Useful for one-time ledger bootstrap runs.
 *   **`retranslate_identical_source_strings`** (optional, in `config.yaml`): Defaults to `false`. When `false`, the pipeline avoids re-translating existing keys that already match source text unless they were newly synchronized in the current run. Set to `true` to restore legacy behavior.
 *   **`translation_key_ledger_file_path`** (optional, in `config.yaml`): File path for a persistent per-key hash ledger. The ledger stores source/target hashes per key and lets the pipeline retranslate only when source text changes, without repeatedly touching already-stable keys.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ The service is configured through a combination of YAML files and a single envir
 *   **`docker/config.docker.yaml`**: **Server configuration.** This is the configuration file used by the service when running inside Docker. It points to paths within the container (e.g., `/target_repo`).
 *   **`glossary.json`**: Provides language-specific translations for key terms to ensure consistency.
 *   **`translation_file_filter_glob`** (optional, in `config.yaml`): A glob pattern that limits which changed `.properties` files are processed by the AI translator. This is useful for workflows where you want to pull all updated files from Transifex but only run the AI step on a specific subset (e.g., `mobile_*.properties`).
+*   **`retranslate_identical_source_strings`** (optional, in `config.yaml`): Defaults to `false`. When `false`, the pipeline avoids re-translating existing keys that already match source text unless they were newly synchronized in the current run. Set to `true` to restore legacy behavior.
+*   **`translation_key_ledger_file_path`** (optional, in `config.yaml`): File path for a persistent per-key hash ledger. The ledger stores source/target hashes per key and lets the pipeline retranslate only when source text changes, without repeatedly touching already-stable keys.
 
 ### Adding New Languages
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,6 +43,15 @@ translated_queue_folder: "translated_queue"
 # If true, the script logs actions without altering files
 dry_run: false
 
+# If true, existing keys whose target text is identical to source text
+# are retranslated on every run (legacy behavior). Keep this false to
+# only translate newly added keys by default and reduce translation churn.
+retranslate_identical_source_strings: false
+
+# Optional persistent per-key hash ledger used to detect source changes
+# without reprocessing already-stable translations.
+translation_key_ledger_file_path: "logs/translation_key_ledger.json"
+
 # Concurrency setting for OpenAI API calls.
 # This controls how many API requests can be active at the same time.
 # A lower value (e.g., 1 or 2) is safer to avoid API rate limits.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,6 +30,11 @@ holistic_review_chunk_size: 75
 # Set to null or remove to translate all changed files.
 # translation_file_filter_glob: null
 
+# Optional: Process all translation files under input_folder instead of only git-changed files.
+# Useful for one-time ledger bootstrap or forced full retranslation runs.
+# Keep false for normal incremental operation.
+process_all_files: false
+
 # Optional: Pull source files (*_en.properties) from Transifex as well as translations.
 # Set to `true` if the canonical source of truth for English strings is Transifex.
 # The default behavior (`false`) is to only pull translation files and assume

--- a/docker/config.docker.yaml
+++ b/docker/config.docker.yaml
@@ -6,6 +6,8 @@ model_name: 'gpt-4o-mini'
 translation_queue_folder: 'translation_queue' # Relative to /app
 translated_queue_folder: 'translated_queue' # Relative to /app
 dry_run: false
+retranslate_identical_source_strings: false
+translation_key_ledger_file_path: "/app/logs/translation_key_ledger.json"
 supported_locales:
   - code: "cs"
     name: "Czech"

--- a/docker/config.docker.yaml
+++ b/docker/config.docker.yaml
@@ -469,6 +469,11 @@ brand_technical_glossary:
 # Set to null or remove to translate all changed files.
 # translation_file_filter_glob: null
 
+# Optional: Process all translation files under input_folder instead of only git-changed files.
+# Useful for one-time ledger bootstrap or forced full retranslation runs.
+# Keep false for normal incremental operation.
+process_all_files: false
+
 # Optional: Pull source files (*_en.properties) from Transifex as well as translations.
 # Set to `true` if the canonical source of truth for English strings is Transifex.
 # The default behavior (`false`) is to only pull translation files and assume

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -155,9 +155,9 @@ distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
     # via openai
-filelock==3.19.1 \
-    --hash=sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58 \
-    --hash=sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d
+filelock==3.20.3 \
+    --hash=sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1 \
+    --hash=sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1
     # via cachecontrol
 gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
@@ -952,13 +952,13 @@ typing-inspection==0.4.1 \
     --hash=sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51 \
     --hash=sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28
     # via pydantic
-urllib3==2.5.0 \
-    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
-    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
+urllib3==2.6.3 \
+    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
+    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
     # via requests
-wheel==0.45.1 \
-    --hash=sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729 \
-    --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248
+wheel==0.46.2 \
+    --hash=sha256:33ae60725d69eaa249bc1982e739943c23b34b58d51f1cb6253453773aca6e65 \
+    --hash=sha256:3d79e48fde9847618a5a181f3cc35764c349c752e2fe911e65fa17faab9809b0
     # via pip-tools
 
 # WARNING: The following packages were not pinned, but pip requires them to be

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ tiktoken==0.10.0
 tqdm==4.67.1
 typing-extensions==4.14.1
 typing-inspection==0.4.1
-urllib3==2.5.0
+urllib3==2.6.3

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -29,6 +29,7 @@ class AppConfig:
 
     # Processing settings
     dry_run: bool
+    process_all_files: bool
     holistic_review_chunk_size: int
     max_concurrent_api_calls: int
 
@@ -233,6 +234,7 @@ def load_app_config() -> AppConfig:
 
     # Get configuration values with defaults
     dry_run = config.get('dry_run', False)
+    process_all_files = bool(config.get('process_all_files', False))
     model_name = config.get('model_name', 'gpt-4')
     review_model_name = os.environ.get('REVIEW_MODEL_NAME', config.get('review_model_name', model_name))
     retranslate_identical_source_strings = bool(config.get('retranslate_identical_source_strings', False))
@@ -267,6 +269,7 @@ def load_app_config() -> AppConfig:
         review_model_name=review_model_name,
         max_model_tokens=config.get('max_model_tokens', 4000),
         dry_run=dry_run,
+        process_all_files=process_all_files,
         holistic_review_chunk_size=holistic_review_chunk_size,
         max_concurrent_api_calls=config.get('max_concurrent_api_calls', 1),
         language_codes=language_codes,

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -35,6 +35,7 @@ class AppConfig:
     # Language configuration
     language_codes: Dict[str, str]
     name_to_code: Dict[str, str]
+    retranslate_identical_source_strings: bool
     style_rules: Dict[str, List[str]]
     precomputed_style_rules_text: Dict[str, str]
     brand_glossary: List[str]
@@ -42,6 +43,7 @@ class AppConfig:
     # Queue settings
     translation_queue_folder: str
     translated_queue_folder: str
+    translation_key_ledger_file_path: str
     preserve_queues_for_debug: bool
 
     # OpenAI client
@@ -233,6 +235,7 @@ def load_app_config() -> AppConfig:
     dry_run = config.get('dry_run', False)
     model_name = config.get('model_name', 'gpt-4')
     review_model_name = os.environ.get('REVIEW_MODEL_NAME', config.get('review_model_name', model_name))
+    retranslate_identical_source_strings = bool(config.get('retranslate_identical_source_strings', False))
 
     # Holistic review chunk size with environment override
     # Reduced default from 75 to 30 to handle content-heavy files better
@@ -245,6 +248,12 @@ def load_app_config() -> AppConfig:
     translated_queue_name = config.get('translated_queue_folder', 'translated_queue')
     translation_queue_folder = os.path.join(temp_dir, translation_queue_name)
     translated_queue_folder = os.path.join(temp_dir, translated_queue_name)
+    translation_key_ledger_file_path = config.get(
+        'translation_key_ledger_file_path',
+        os.path.join(project_root, 'logs', 'translation_key_ledger.json')
+    )
+    if not os.path.isabs(translation_key_ledger_file_path):
+        translation_key_ledger_file_path = os.path.join(project_root, translation_key_ledger_file_path)
 
     # Create OpenAI client
     openai_client = _create_openai_client(dry_run, logger)
@@ -262,11 +271,13 @@ def load_app_config() -> AppConfig:
         max_concurrent_api_calls=config.get('max_concurrent_api_calls', 1),
         language_codes=language_codes,
         name_to_code=name_to_code,
+        retranslate_identical_source_strings=retranslate_identical_source_strings,
         style_rules=style_rules,
         precomputed_style_rules_text=precomputed_style_rules_text,
         brand_glossary=config.get('brand_technical_glossary', ['MuSig', 'Bisq', 'Lightning', 'I2P', 'Tor']),
         translation_queue_folder=translation_queue_folder,
         translated_queue_folder=translated_queue_folder,
+        translation_key_ledger_file_path=translation_key_ledger_file_path,
         preserve_queues_for_debug=config.get('preserve_queues_for_debug', False),
         openai_client=openai_client
     )

--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -251,7 +251,9 @@ def save_translation_key_ledger(
         logger.info("[Dry Run] Skipping write of translation key ledger.")
         return
     try:
-        os.makedirs(os.path.dirname(ledger_file_path), exist_ok=True)
+        parent_dir = os.path.dirname(ledger_file_path)
+        if parent_dir:
+            os.makedirs(parent_dir, exist_ok=True)
         payload = {
             "version": 1,
             "updated_at": _dt.datetime.now(_dt.timezone.utc).isoformat().replace('+00:00', 'Z'),

--- a/src/translation_validator.py
+++ b/src/translation_validator.py
@@ -41,7 +41,7 @@ def check_placeholder_parity(base_string: str, target_string: str) -> bool:
 
     return base_placeholders == target_placeholders
 
-def synchronize_keys(target_file_path: str, source_file_path: str):
+def synchronize_keys(target_file_path: str, source_file_path: str) -> Tuple[Set[str], Set[str]]:
     """
     Synchronizes the keys in a target .properties file with a source file.
     - Removes keys from the target that are not in the source.
@@ -51,6 +51,9 @@ def synchronize_keys(target_file_path: str, source_file_path: str):
     Args:
         target_file_path: The path to the target locale file to be modified.
         source_file_path: The path to the source (e.g., English) file.
+
+    Returns:
+        A tuple of (missing_keys, extra_keys) that were applied to the target.
     """
     # Parse both files to get their structure and key-value pairs
     target_parsed_lines, target_translations = parse_properties_file(target_file_path)
@@ -60,7 +63,7 @@ def synchronize_keys(target_file_path: str, source_file_path: str):
     missing_keys, extra_keys = check_key_coverage(set(source_translations.keys()), set(target_translations.keys()))
 
     if not missing_keys and not extra_keys:
-        return # No changes needed
+        return missing_keys, extra_keys  # No changes needed
 
     # Filter out lines with extra keys from the target file
     final_parsed_lines = [
@@ -82,6 +85,8 @@ def synchronize_keys(target_file_path: str, source_file_path: str):
     new_content = reassemble_file(final_parsed_lines)
     with open(target_file_path, 'w', encoding='utf-8') as f:
         f.write(new_content)
+
+    return missing_keys, extra_keys
 
 def check_encoding_and_mojibake(file_path: str) -> List[str]:
     """

--- a/tests/integration/test_quote_escaping.py
+++ b/tests/integration/test_quote_escaping.py
@@ -32,8 +32,9 @@ class TestQuoteEscaping(unittest.IsolatedAsyncioTestCase):
         from src.translate_localization_files import process_translation_queue, LANGUAGE_CODES, NAME_TO_CODE
 
         # Configure the mocks
-        # The pre-validator now returns a list of errors; an empty list means success.
-        mock_pre_validator.return_value = []
+        # The pre-validator returns (errors, newly_added_keys).
+        # Mark the key as newly synchronized so it is translated in this run.
+        mock_pre_validator.return_value = ([], {"test.key"})
         mock_post_validator.return_value = True # Post-validation is now mocked
         mock_holistic_review.return_value = None
         mock_load_glossary.return_value = {}  # Mock the glossary to be empty

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -64,7 +64,7 @@ async def test_process_translation_queue_end_to_end(integration_test_environment
 async def test_handles_already_escaped_quotes_correctly(integration_test_environment):
     env = integration_test_environment
     source_content = "key.name=URL is ''{0}''"
-    target_content = "key.name=URL is ''{0}''"
+    target_content = ""
 
     source_en_path = os.path.join(env['input_folder'], 'app.properties')
     target_de_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -21,7 +21,11 @@ import src.translate_localization_files
 async def test_main_flow_no_changes(mock_move, mock_copy_back, mock_process, mock_copy_to_queue, mock_get_changed, integration_test_environment):
     mock_get_changed.return_value = []
     await src.translate_localization_files.main()
-    mock_get_changed.assert_called_once()
+    mock_get_changed.assert_called_once_with(
+        src.translate_localization_files.INPUT_FOLDER,
+        src.translate_localization_files.REPO_ROOT,
+        process_all_files=src.translate_localization_files.PROCESS_ALL_FILES
+    )
     mock_copy_to_queue.assert_not_called()
     mock_process.assert_not_called()
     mock_copy_back.assert_not_called()

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -54,6 +54,8 @@ class TestLoadAppConfig:
             "input_folder": "/custom/input",
             "model_name": "gpt-4o-mini",
             "dry_run": True,
+            "retranslate_identical_source_strings": True,
+            "translation_key_ledger_file_path": "/tmp/test-ledger.json",
             "supported_locales": [
                 {"code": "de", "name": "German"},
                 {"code": "es", "name": "Spanish"}
@@ -76,6 +78,8 @@ class TestLoadAppConfig:
         assert config.input_folder == "/custom/input"
         assert config.model_name == "gpt-4o-mini"
         assert config.dry_run is True
+        assert config.retranslate_identical_source_strings is True
+        assert config.translation_key_ledger_file_path == "/tmp/test-ledger.json"
         assert config.language_codes == {"de": "German", "es": "Spanish"}
         assert config.name_to_code == {"german": "de", "spanish": "es"}
 

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -95,6 +95,10 @@ class TestLoadAppConfig:
         assert config.dry_run is True
         assert config.holistic_review_chunk_size == 30  # Updated from 75 to 30
         assert config.max_concurrent_api_calls == 1
+        assert config.retranslate_identical_source_strings is False
+        assert config.translation_key_ledger_file_path == os.path.join(
+            config.project_root, "logs", "translation_key_ledger.json"
+        )
 
     def test_load_config_with_environment_overrides(self):
         """Test that environment variables override config file values."""

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -22,6 +22,7 @@ class TestAppConfig:
             review_model_name="gpt-4o",
             max_model_tokens=4000,
             dry_run=False,
+            process_all_files=False,
             holistic_review_chunk_size=75,
             max_concurrent_api_calls=1,
             language_codes={"de": "German"},
@@ -95,10 +96,27 @@ class TestLoadAppConfig:
         assert config.dry_run is True
         assert config.holistic_review_chunk_size == 30  # Updated from 75 to 30
         assert config.max_concurrent_api_calls == 1
+        assert config.process_all_files is False
         assert config.retranslate_identical_source_strings is False
         assert config.translation_key_ledger_file_path == os.path.join(
             config.project_root, "logs", "translation_key_ledger.json"
         )
+
+    def test_load_config_with_process_all_files_enabled(self):
+        """Test process_all_files can be enabled via config."""
+        mock_config = {
+            "dry_run": True,
+            "process_all_files": True
+        }
+
+        with patch("src.app_config._load_yaml_config", return_value=mock_config):
+            with patch("os.path.exists", return_value=False):
+                with patch("src.logging_config.setup_logger") as mock_logger:
+                    mock_logger.return_value = MagicMock()
+                    with patch.dict(os.environ, {}, clear=True):
+                        config = load_app_config()
+
+        assert config.process_all_files is True
 
     def test_load_config_with_environment_overrides(self):
         """Test that environment variables override config file values."""

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -26,11 +26,13 @@ class TestAppConfig:
             max_concurrent_api_calls=1,
             language_codes={"de": "German"},
             name_to_code={"german": "de"},
+            retranslate_identical_source_strings=False,
             style_rules={},
             precomputed_style_rules_text={},
             brand_glossary=["Bisq"],
             translation_queue_folder="/tmp/queue",
             translated_queue_folder="/tmp/translated",
+            translation_key_ledger_file_path="/tmp/ledger.json",
             preserve_queues_for_debug=False,
             openai_client=None
         )

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -296,6 +296,31 @@ class TestCoreLogic(unittest.TestCase):
         self.assertEqual(indices, [0])
         self.assertEqual(keys, ['key_existing'])
 
+    def test_extract_texts_to_translate_retries_when_target_regresses_to_source(self):
+        """Previously translated keys should be retried if target falls back to source text."""
+        parsed_lines = [
+            {'type': 'entry', 'key': 'key_existing', 'value': 'Source Existing', 'line_number': 0},
+        ]
+        target_translations = {'key_existing': 'Source Existing'}
+        source_translations = {'key_existing': 'Source Existing'}
+        file_ledger_entries = {
+            'key_existing': {
+                'source_hash': compute_ledger_hash('Source Existing'),
+                'target_hash': compute_ledger_hash('Old Real Translation')
+            }
+        }
+
+        texts, indices, keys = extract_texts_to_translate(
+            parsed_lines,
+            source_translations,
+            target_translations,
+            file_ledger_entries=file_ledger_entries
+        )
+
+        self.assertEqual(texts, ['Source Existing'])
+        self.assertEqual(indices, [0])
+        self.assertEqual(keys, ['key_existing'])
+
     def test_extract_texts_to_translate_logs_missing_ledger_baseline_skip(self):
         """Existing source-identical keys should log migration hint when no baseline hash exists."""
         parsed_lines = [

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -270,6 +270,31 @@ class TestCoreLogic(unittest.TestCase):
         self.assertEqual(indices, [0])
         self.assertEqual(keys, ['key_existing'])
 
+    def test_extract_texts_to_translate_logs_missing_ledger_baseline_skip(self):
+        """Existing source-identical keys should log migration hint when no baseline hash exists."""
+        parsed_lines = [
+            {'type': 'entry', 'key': 'key_existing', 'value': 'Source Existing', 'line_number': 0},
+        ]
+        target_translations = {'key_existing': 'Source Existing'}
+        source_translations = {'key_existing': 'Source Existing'}
+
+        with self.assertLogs('translation_script', level='INFO') as captured_logs:
+            texts, indices, keys = extract_texts_to_translate(
+                parsed_lines,
+                source_translations,
+                target_translations,
+                newly_added_keys=set(),
+                file_ledger_entries={},
+                retranslate_identical_existing=False
+            )
+
+        self.assertEqual(texts, [])
+        self.assertEqual(indices, [])
+        self.assertEqual(keys, [])
+        joined_logs = "\n".join(captured_logs.output)
+        self.assertIn("Skipping key 'key_existing' (source==target)", joined_logs)
+        self.assertIn("retranslate_identical_source_strings", joined_logs)
+
     def test_extract_language_from_filename(self):
         """Tests that `extract_language_from_filename` correctly identifies language codes."""
         supported_codes = ["de", "pt_BR", "af_ZA", "en"]

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -270,6 +270,32 @@ class TestCoreLogic(unittest.TestCase):
         self.assertEqual(indices, [0])
         self.assertEqual(keys, ['key_existing'])
 
+    def test_extract_texts_to_translate_retries_failed_ledger_keys(self):
+        """Keys marked failed in the ledger should be eligible for retranslation."""
+        parsed_lines = [
+            {'type': 'entry', 'key': 'key_existing', 'value': 'Source Existing', 'line_number': 0},
+        ]
+        target_translations = {'key_existing': 'Source Existing'}
+        source_translations = {'key_existing': 'Source Existing'}
+        file_ledger_entries = {
+            'key_existing': {
+                'source_hash': compute_ledger_hash('Source Existing'),
+                'target_hash': compute_ledger_hash('Source Existing'),
+                'status': 'failed'
+            }
+        }
+
+        texts, indices, keys = extract_texts_to_translate(
+            parsed_lines,
+            source_translations,
+            target_translations,
+            file_ledger_entries=file_ledger_entries
+        )
+
+        self.assertEqual(texts, ['Source Existing'])
+        self.assertEqual(indices, [0])
+        self.assertEqual(keys, ['key_existing'])
+
     def test_extract_texts_to_translate_logs_missing_ledger_baseline_skip(self):
         """Existing source-identical keys should log migration hint when no baseline hash exists."""
         parsed_lines = [

--- a/tests/unit/test_translation_key_ledger.py
+++ b/tests/unit/test_translation_key_ledger.py
@@ -76,7 +76,7 @@ def test_save_translation_key_ledger_with_filename_only_path():
             os.chdir(old_cwd)
 
 
-def test_build_file_key_ledger_replaces_removed_keys():
+def test_build_file_key_ledger_produces_correct_hashes():
     source_translations = {
         "key.keep": "Source Keep",
         "key.new": "Source New"
@@ -91,3 +91,16 @@ def test_build_file_key_ledger_replaces_removed_keys():
     assert set(built.keys()) == {"key.keep", "key.new"}
     assert built["key.keep"]["source_hash"] == compute_ledger_hash("Source Keep")
     assert built["key.keep"]["target_hash"] == compute_ledger_hash("Ziel Keep")
+
+
+def test_build_file_key_ledger_marks_failed_keys():
+    source_translations = {"key.one": "Source One"}
+    final_translations = {"key.one": "Source One"}
+
+    built = build_file_key_ledger(
+        source_translations,
+        final_translations,
+        failed_keys={"key.one"}
+    )
+
+    assert built["key.one"]["status"] == "failed"

--- a/tests/unit/test_translation_key_ledger.py
+++ b/tests/unit/test_translation_key_ledger.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from pathlib import Path
 
@@ -32,6 +33,25 @@ def test_translation_key_ledger_roundtrip():
         loaded = load_translation_key_ledger(str(ledger_path))
 
         assert loaded == key_ledger
+
+
+def test_translation_key_ledger_timestamp_uses_utc_z_suffix():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        ledger_path = Path(temp_dir) / "ledger.json"
+        key_ledger = {
+            "mobile_de.properties": {
+                "key.one": {
+                    "source_hash": compute_ledger_hash("Source one"),
+                    "target_hash": compute_ledger_hash("Ziel eins")
+                }
+            }
+        }
+
+        save_translation_key_ledger(str(ledger_path), key_ledger)
+        with open(ledger_path, "r", encoding="utf-8") as ledger_file:
+            payload = json.load(ledger_file)
+
+        assert payload["updated_at"].endswith("Z")
 
 
 def test_build_file_key_ledger_replaces_removed_keys():

--- a/tests/unit/test_translation_key_ledger.py
+++ b/tests/unit/test_translation_key_ledger.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 from pathlib import Path
 
@@ -52,6 +53,27 @@ def test_translation_key_ledger_timestamp_uses_utc_z_suffix():
             payload = json.load(ledger_file)
 
         assert payload["updated_at"].endswith("Z")
+
+
+def test_save_translation_key_ledger_with_filename_only_path():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        old_cwd = os.getcwd()
+        os.chdir(temp_dir)
+        try:
+            key_ledger = {
+                "mobile_de.properties": {
+                    "key.one": {
+                        "source_hash": compute_ledger_hash("Source one"),
+                        "target_hash": compute_ledger_hash("Ziel eins")
+                    }
+                }
+            }
+
+            save_translation_key_ledger("ledger.json", key_ledger)
+            loaded = load_translation_key_ledger("ledger.json")
+            assert loaded == key_ledger
+        finally:
+            os.chdir(old_cwd)
 
 
 def test_build_file_key_ledger_replaces_removed_keys():

--- a/tests/unit/test_translation_key_ledger.py
+++ b/tests/unit/test_translation_key_ledger.py
@@ -1,0 +1,51 @@
+import tempfile
+from pathlib import Path
+
+from src.translate_localization_files import (
+    build_file_key_ledger,
+    compute_ledger_hash,
+    load_translation_key_ledger,
+    save_translation_key_ledger
+)
+
+
+def test_load_translation_key_ledger_missing_file():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        ledger_path = Path(temp_dir) / "missing-ledger.json"
+        loaded = load_translation_key_ledger(str(ledger_path))
+        assert loaded == {}
+
+
+def test_translation_key_ledger_roundtrip():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        ledger_path = Path(temp_dir) / "ledger.json"
+        key_ledger = {
+            "mobile_de.properties": {
+                "key.one": {
+                    "source_hash": compute_ledger_hash("Source one"),
+                    "target_hash": compute_ledger_hash("Ziel eins")
+                }
+            }
+        }
+
+        save_translation_key_ledger(str(ledger_path), key_ledger)
+        loaded = load_translation_key_ledger(str(ledger_path))
+
+        assert loaded == key_ledger
+
+
+def test_build_file_key_ledger_replaces_removed_keys():
+    source_translations = {
+        "key.keep": "Source Keep",
+        "key.new": "Source New"
+    }
+    final_translations = {
+        "key.keep": "Ziel Keep",
+        "key.new": "Ziel New"
+    }
+
+    built = build_file_key_ledger(source_translations, final_translations)
+
+    assert set(built.keys()) == {"key.keep", "key.new"}
+    assert built["key.keep"]["source_hash"] == compute_ledger_hash("Source Keep")
+    assert built["key.keep"]["target_hash"] == compute_ledger_hash("Ziel Keep")

--- a/tests/unit/test_translation_validator.py
+++ b/tests/unit/test_translation_validator.py
@@ -145,10 +145,36 @@ class TestTranslationValidator(unittest.TestCase):
             self.assertIn("key.two=Two", modified_content)  # Missing key added from source
             self.assertNotIn("key.four", modified_content)  # Extra key removed
             self.assertIn("key.one=Eins", modified_content) # Existing key preserved
+            self.assertLess(modified_content.index("key.one=Eins"), modified_content.index("key.two=Two"))
+            self.assertLess(modified_content.index("key.two=Two"), modified_content.index("key.three=Drei"))
             self.assertEqual(len(modified_translations), 3)
             self.assertEqual(missing_keys, {"key.two"})
             self.assertEqual(extra_keys, {"key.four"})
 
+        finally:
+            os.remove(source_path)
+            os.remove(target_path)
+
+    def test_key_synchronization_preserves_comment_relative_position(self):
+        source_content = "key.one=One\nkey.two=Two\n# section marker\nkey.three=Three\n"
+        target_content = "key.one=Uno\n# section marker\nkey.three=Tres\n"
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as f_source:
+            f_source.write(source_content)
+            source_path = f_source.name
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as f_target:
+            f_target.write(target_content)
+            target_path = f_target.name
+
+        try:
+            synchronize_keys(target_path, source_path)
+
+            with open(target_path, 'r', encoding='utf-8') as f_target_mod:
+                modified_content = f_target_mod.read()
+
+            self.assertLess(modified_content.index("key.two=Two"), modified_content.index("# section marker"))
+            self.assertLess(modified_content.index("# section marker"), modified_content.index("key.three=Tres"))
         finally:
             os.remove(source_path)
             os.remove(target_path)

--- a/tests/unit/test_translation_validator.py
+++ b/tests/unit/test_translation_validator.py
@@ -132,7 +132,7 @@ class TestTranslationValidator(unittest.TestCase):
 
         try:
             # Run the synchronization
-            synchronize_keys(target_path, source_path)
+            missing_keys, extra_keys = synchronize_keys(target_path, source_path)
 
             # Read the modified target file and check its content
             with open(target_path, 'r', encoding='utf-8') as f_target_mod:
@@ -146,6 +146,8 @@ class TestTranslationValidator(unittest.TestCase):
             self.assertNotIn("key.four", modified_content)  # Extra key removed
             self.assertIn("key.one=Eins", modified_content) # Existing key preserved
             self.assertEqual(len(modified_translations), 3)
+            self.assertEqual(missing_keys, {"key.two"})
+            self.assertEqual(extra_keys, {"key.four"})
 
         finally:
             os.remove(source_path)

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -99,7 +99,7 @@ done
 # --- Execution Lock and Logging ---
 # Lock file to prevent concurrent executions for the same repository
 LOCK_FILE="/tmp/translation-${UPSTREAM_REPO_NAME//\//-}.lock"
-EXECUTION_LOG="/var/log/translation-executions.log"
+EXECUTION_LOG="${LOG_DIR}/translation-executions.log"
 
 # Log execution start
 echo "$(date -Iseconds) START ${HOSTNAME:-unknown} REPO=${UPSTREAM_REPO_NAME} PID=$$" >> "$EXECUTION_LOG" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- avoid re-translating already translated keys by default
- add a persistent per-key source-hash ledger to detect real source changes
- keep legacy retranslation behavior as an explicit opt-in setting
- extend config/docs and add unit/integration tests for the new flow

## Validation
- pytest -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation ledger to track per-key changes and avoid unnecessary retranslations
  * New optional settings: process_all_files, retranslate_identical_source_strings, translation_key_ledger_file_path
  * Expanded supported locales list

* **Documentation**
  * README and example configs updated with new options and defaults

* **Bug Fixes / Improvements**
  * Preserve source ordering when synchronizing translation keys
  * Execution log now uses application log directory

* **Chores**
  * Dependency updates

* **Tests**
  * Coverage added/updated for ledger, discovery, validation and translation flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->