### PR TITLE
Handle tx-pulled source-identical keys as newly synchronized

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The service is configured through a combination of YAML files and a single envir
 *   **`glossary.json`**: Provides language-specific translations for key terms to ensure consistency.
 *   **`translation_file_filter_glob`** (optional, in `config.yaml`): A glob pattern that limits which changed `.properties` files are processed by the AI translator. This is useful for workflows where you want to pull all updated files from Transifex but only run the AI step on a specific subset (e.g., `mobile_*.properties`).
 *   **`process_all_files`** (optional, in `config.yaml`): Defaults to `false`. When `true`, the pipeline scans and processes all translation files under `input_folder` instead of only git-changed files. Useful for one-time ledger bootstrap runs.
-*   **`retranslate_identical_source_strings`** (optional, in `config.yaml`): Defaults to `false`. When `false`, the pipeline avoids re-translating existing keys that already match source text unless they were newly synchronized in the current run. Set to `true` to restore legacy behavior.
+*   **`retranslate_identical_source_strings`** (optional, in `config.yaml`): Defaults to `false`. When `false`, the pipeline avoids re-translating existing keys that already match source text unless they were newly synchronized in the current run (including keys inserted/updated by `tx pull -t -f` in the current working tree). Set to `true` to restore legacy behavior.
 *   **`translation_key_ledger_file_path`** (optional, in `config.yaml`): File path for a persistent per-key hash ledger. The ledger stores source/target hashes per key and lets the pipeline retranslate only when source text changes, without repeatedly touching already-stable keys.
 
 ### Adding New Languages

--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -298,6 +298,8 @@ def extract_texts_to_translate(
     Identifies which texts need to be translated. A text needs translation if:
     1. The key is new (exists in source, not in target).
     2. The key was newly synchronized in this run and currently equals the source.
+       This includes keys added by file key synchronization and keys changed in
+       the current git working tree (e.g., inserted by ``tx pull -t -f``).
     3. (Optional legacy mode) Existing keys with source-identical values are also
        translated when ``retranslate_identical_existing`` is enabled.
 
@@ -396,6 +398,58 @@ def extract_texts_to_translate(
         next_new_key_index += 1
 
     return texts_to_translate, indices, keys_to_translate
+
+
+def _extract_properties_key_from_diff_line(diff_line: str) -> Optional[str]:
+    """Extract a properties key from one added git diff line."""
+    stripped_line = diff_line.strip()
+    if not stripped_line:
+        return None
+    if stripped_line.startswith('#') or stripped_line.startswith('!'):
+        return None
+    if '=' not in diff_line:
+        return None
+    key = diff_line.split('=', 1)[0].strip()
+    return key or None
+
+
+def get_working_tree_changed_keys(target_file_path: str, repo_root: str) -> Set[str]:
+    """
+    Return keys that were added/updated for ``target_file_path`` in git working tree.
+
+    This is used to capture keys that appear in locale files through ``tx pull``
+    before AI translation runs, so they can be treated as newly synchronized.
+    """
+    try:
+        relative_target_path = os.path.relpath(target_file_path, repo_root)
+        result = subprocess.run(
+            ['git', 'diff', '--unified=0', '--', relative_target_path],
+            cwd=repo_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False
+        )
+        if result.returncode != 0:
+            logger.debug(
+                "Unable to inspect git diff for '%s' (exit=%s): %s",
+                relative_target_path,
+                result.returncode,
+                result.stderr.strip()
+            )
+            return set()
+
+        changed_keys: Set[str] = set()
+        for line in result.stdout.splitlines():
+            if not line.startswith('+') or line.startswith('+++'):
+                continue
+            key = _extract_properties_key_from_diff_line(line[1:])
+            if key:
+                changed_keys.add(key)
+        return changed_keys
+    except Exception:
+        logger.debug("Failed to compute git-diff changed keys for '%s'.", target_file_path, exc_info=True)
+        return set()
 
 def count_tokens(text: str, model_name: str = 'gpt-3.5-turbo') -> int:
     """Count the number of tokens in ``text`` for ``model_name``.
@@ -1632,11 +1686,19 @@ async def process_translation_queue(
 
         # Extract texts to translate
         file_ledger_entries = key_ledger.get(translation_file, {})
+        git_changed_keys = get_working_tree_changed_keys(translation_file_path, REPO_ROOT)
+        newly_synchronized_keys = newly_added_keys.union(git_changed_keys)
+        if git_changed_keys:
+            logger.info(
+                "Detected %d git-diff key updates in '%s'; treating them as newly synchronized.",
+                len(git_changed_keys),
+                translation_file
+            )
         texts_to_translate, indices, keys_to_translate = extract_texts_to_translate(
             parsed_lines,
             source_translations,
             target_translations,
-            newly_added_keys=newly_added_keys,
+            newly_added_keys=newly_synchronized_keys,
             file_ledger_entries=file_ledger_entries,
             retranslate_identical_existing=RETRANSLATE_IDENTICAL_SOURCE_STRINGS
         )

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -353,6 +353,7 @@ class TestCoreLogic(unittest.TestCase):
             "diff --git a/mobile_pt_BR.properties b/mobile_pt_BR.properties\n"
             "@@ -1 +1,5 @@\n"
             "+mobile.bisqEasy.tradeWizard.amount.seller.limitInfo=Your maximum selling amount is {0} out of {1}.\n"
+            "+mobile.bisqEasy.colonKey:Value from colon separator\n"
             "+   # translated comment\n"
             "+! linter directive\n"
             "+mobile.bisqEasy.someOtherKey = Value\n"
@@ -368,6 +369,7 @@ class TestCoreLogic(unittest.TestCase):
         self.assertSetEqual(
             {
                 "mobile.bisqEasy.tradeWizard.amount.seller.limitInfo",
+                "mobile.bisqEasy.colonKey",
                 "mobile.bisqEasy.someOtherKey",
             },
             keys

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -16,6 +16,7 @@ from src.translate_localization_files import (
     normalize_value,
     compute_ledger_hash,
     extract_texts_to_translate,
+    get_working_tree_changed_keys,
     extract_language_from_filename,
     run_post_translation_validation
 )
@@ -345,6 +346,41 @@ class TestCoreLogic(unittest.TestCase):
         joined_logs = "\n".join(captured_logs.output)
         self.assertIn("Skipping key 'key_existing' (source==target)", joined_logs)
         self.assertIn("retranslate_identical_source_strings", joined_logs)
+
+    def test_get_working_tree_changed_keys_parses_added_entries(self):
+        """git diff added key/value lines should be parsed as newly synchronized keys."""
+        git_diff_output = (
+            "diff --git a/mobile_pt_BR.properties b/mobile_pt_BR.properties\n"
+            "@@ -1 +1,5 @@\n"
+            "+mobile.bisqEasy.tradeWizard.amount.seller.limitInfo=Your maximum selling amount is {0} out of {1}.\n"
+            "+   # translated comment\n"
+            "+! linter directive\n"
+            "+mobile.bisqEasy.someOtherKey = Value\n"
+            "+this is not a properties assignment\n"
+        )
+        mocked_result = MagicMock(returncode=0, stdout=git_diff_output, stderr="")
+        with patch("src.translate_localization_files.subprocess.run", return_value=mocked_result):
+            keys = get_working_tree_changed_keys(
+                "/repo/mobile/mobile_pt_BR.properties",
+                "/repo"
+            )
+
+        self.assertSetEqual(
+            {
+                "mobile.bisqEasy.tradeWizard.amount.seller.limitInfo",
+                "mobile.bisqEasy.someOtherKey",
+            },
+            keys
+        )
+
+    def test_get_working_tree_changed_keys_returns_empty_on_command_failure(self):
+        """git diff inspection failures should fail open and return no changed keys."""
+        with patch("src.translate_localization_files.subprocess.run", side_effect=OSError("git missing")):
+            keys = get_working_tree_changed_keys(
+                "/repo/mobile/mobile_pt_BR.properties",
+                "/repo"
+            )
+        self.assertEqual(set(), keys)
 
     def test_extract_language_from_filename(self):
         """Tests that `extract_language_from_filename` correctly identifies language codes."""


### PR DESCRIPTION
## Summary
- treat keys changed in current git working tree (e.g. inserted by `tx pull -t -f`) as newly synchronized keys
- include those keys in translation selection even when `source == target` and no ledger baseline exists
- keep anti-churn behavior for existing unchanged source-identical keys

## Why
In the standard Transifex flow, new source keys can appear in locale files with English fallback values after pull. Those were previously skipped when no ledger baseline existed, leaving English in translation files.

## Changes
- `src/translate_localization_files.py`
  - add git-diff key extraction helper
  - merge `newly_added_keys` from sync with git-diff changed keys
  - pass merged set to `extract_texts_to_translate`
- `tests/unit/test_core_logic.py`
  - add tests for git-diff key parsing and fail-open behavior
- `README.md`
  - document that newly synchronized keys include tx-pulled changes in working tree

## Validation
- `python3 -m unittest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified retranslate_identical_source_strings behavior for keys synchronized during the current run (including keys brought in by local sync).

* **Improvements**
  * Detects keys changed in the local working tree and treats them as newly synchronized so they are included in translation processing.

* **Tests**
  * Added unit tests verifying local-change detection and graceful handling of command failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->