### PR TITLE
Fix translation health-check false alerts

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -82,31 +82,19 @@ jobs:
       - name: Display Docker Image Info
         run: docker images
 
-      - name: Install Trivy
-        run: |
-          set -euo pipefail
-          TRIVY_VERSION="0.63.0"
-          TRIVY_TARBALL="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          TRIVY_CHECKSUMS="trivy_${TRIVY_VERSION}_checksums.txt"
-
-          curl -fsSL -o "${TRIVY_TARBALL}" "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_TARBALL}"
-          curl -fsSL -o "${TRIVY_CHECKSUMS}" "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_CHECKSUMS}"
-          grep " ${TRIVY_TARBALL}$" "${TRIVY_CHECKSUMS}" | sha256sum -c -
-
-          tar -xzf "${TRIVY_TARBALL}" trivy
-          mkdir -p "${HOME}/.local/bin"
-          install -m 0755 trivy "${HOME}/.local/bin/trivy"
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-
       - name: Run Trivy vulnerability scanner
         run: |
-          trivy image \
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "${{ github.workspace }}:/workspace" \
+            aquasec/trivy:latest \
+            image \
             --format table \
             --exit-code 1 \
             --ignore-unfixed \
             --vuln-type os,library \
             --severity CRITICAL,HIGH \
-            --ignorefile .trivyignore \
+            --ignorefile /workspace/.trivyignore \
             "translator-app:ci-${{ github.sha }}"
 
       # - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -82,23 +82,32 @@ jobs:
       - name: Display Docker Image Info
         run: docker images
 
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          TRIVY_VERSION="0.63.0"
+          TRIVY_TARBALL="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          TRIVY_CHECKSUMS="trivy_${TRIVY_VERSION}_checksums.txt"
+
+          curl -fsSL -o "${TRIVY_TARBALL}" "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_TARBALL}"
+          curl -fsSL -o "${TRIVY_CHECKSUMS}" "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_CHECKSUMS}"
+          grep " ${TRIVY_TARBALL}$" "${TRIVY_CHECKSUMS}" | sha256sum -c -
+
+          tar -xzf "${TRIVY_TARBALL}" trivy
+          mkdir -p "${HOME}/.local/bin"
+          install -m 0755 trivy "${HOME}/.local/bin/trivy"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
-        with:
-          image-ref: 'translator-app:ci-${{ github.sha }}'
-          # Temporarily switch to 'table' format to identify the new CVEs causing the failure.
-          format: 'table'
-          # output: 'trivy-results.sarif'
-          # Fail the build if any critical or high severity vulnerabilities are found.
-          exit-code: '1'
-          # Ignore vulnerabilities that are not yet fixed by the base image maintainers, or that
-          # are deemed not applicable to our use case.
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          # Use a .trivyignore file to manage a persistent list of ignored CVEs.
-          # This provides a clear, version-controlled record of accepted risks.
-          trivyignores: '.trivyignore'
+        run: |
+          trivy image \
+            --format table \
+            --exit-code 1 \
+            --ignore-unfixed \
+            --vuln-type os,library \
+            --severity CRITICAL,HIGH \
+            --ignorefile .trivyignore \
+            "translator-app:ci-${{ github.sha }}"
 
       # - name: Upload Trivy scan results to GitHub Security tab
       #   uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -84,10 +84,11 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         run: |
+          TRIVY_IMAGE="aquasec/trivy:0.69.2@sha256:3d1f862cb6c4fe13c1506f96f816096030d8d5ccdb2380a3069f7bf07daa86aa"
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "${{ github.workspace }}:/workspace" \
-            aquasec/trivy:latest \
+            "${TRIVY_IMAGE}" \
             image \
             --format table \
             --exit-code 1 \

--- a/scripts/check-translation-services.sh
+++ b/scripts/check-translation-services.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Translation Service Health Check Script
+# Created: 2025-11-27
+# Purpose: Monitor for abnormal translation service behavior
+
+set -euo pipefail
+
+ALERT_FILE="/var/log/translation-service-alerts.log"
+GITHUB_TOKEN=$(grep '^GITHUB_TOKEN=' /opt/translate-java-property-files/docker/.env | cut -d= -f2)
+
+log_alert() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] ALERT: $1" | tee -a "$ALERT_FILE"
+}
+
+log_ok() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] OK: $1"
+}
+
+count_open_translation_prs() {
+    local repo="$1"
+    curl -s -H "Authorization: token $GITHUB_TOKEN" \
+        "https://api.github.com/repos/${repo}/pulls?state=open&per_page=100" \
+        | jq '[.[] | select(.head.ref | startswith("translation-updates-"))] | length'
+}
+
+check_cron_log() {
+    local label="$1"
+    local log_file="$2"
+
+    if [ ! -f "$log_file" ]; then
+        log_alert "$label cron log not found: $log_file"
+        return
+    fi
+
+    local start_line
+    start_line=$(grep -nE "Starting Git and Transifex validation" "$log_file" | tail -n1 | cut -d: -f1 || true)
+
+    if [ -z "$start_line" ]; then
+        log_alert "$label cron job has no run markers - check $log_file"
+        return
+    fi
+
+    local start_ts
+    start_ts=$(sed -n "${start_line}p" "$log_file" | sed -n 's/^\[\([^]]*\)\].*/\1/p')
+
+    local status_segment
+    status_segment=$(tail -n +"$start_line" "$log_file" | grep -E "Translation update script finished successfully|No further processing needed|BLOCKING CONDITION DETECTED" | tail -n1 || true)
+
+    if [ -n "$status_segment" ]; then
+        log_ok "$label cron job completed successfully or blocked appropriately"
+        return
+    fi
+
+    local now_epoch start_epoch age_sec
+    now_epoch=$(date +%s)
+    start_epoch=$(date -d "$start_ts" +%s 2>/dev/null || echo 0)
+    age_sec=$((now_epoch - start_epoch))
+
+    if [ "$start_epoch" -gt 0 ] && [ "$age_sec" -lt 10800 ]; then
+        log_ok "$label cron job appears to be still running (started ${age_sec}s ago)"
+    else
+        log_alert "$label cron job may have failed or stalled - check $log_file"
+    fi
+}
+
+# Check 1: Ensure systemd service is NOT running
+if systemctl is-active --quiet translator.service 2>/dev/null; then
+    log_alert "translator.service is running - it should be disabled!"
+    systemctl stop translator.service
+    systemctl disable translator.service
+else
+    log_ok "translator.service is not running"
+fi
+
+# Check 2: Count open translation PRs (translation branches only)
+bisq2_pr_count=$(count_open_translation_prs "bisq-network/bisq2")
+mobile_pr_count=$(count_open_translation_prs "bisq-network/bisq-mobile")
+total_pr_count=$((bisq2_pr_count + mobile_pr_count))
+
+if [ "$total_pr_count" -gt 2 ]; then
+    log_alert "Too many open translation PRs: total=${total_pr_count} (bisq2=${bisq2_pr_count}, mobile=${mobile_pr_count}, expected total <= 2)"
+else
+    log_ok "Open translation PRs: total=${total_pr_count} (bisq2=${bisq2_pr_count}, mobile=${mobile_pr_count})"
+fi
+
+# Check 3: Check latest cron run result robustly
+main_log="/opt/translate-java-property-files/logs/cron_job.log"
+mobile_log="/opt/translate-java-property-files-mobile-app/logs/cron_job.log"
+check_cron_log "Main service" "$main_log"
+check_cron_log "Mobile app service" "$mobile_log"
+
+# Check 4: Disk space for Docker volumes
+disk_usage=$(df -h /var/lib/docker | tail -1 | awk '{print $5}' | sed 's/%//' )
+if [ "$disk_usage" -gt 85 ]; then
+    log_alert "Docker volume disk usage high: ${disk_usage}%"
+else
+    log_ok "Docker volume disk usage: ${disk_usage}%"
+fi
+
+echo "Health check completed at $(date)"

--- a/scripts/check-translation-services.sh
+++ b/scripts/check-translation-services.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 ALERT_FILE="/var/log/translation-service-alerts.log"
-GITHUB_TOKEN=$(grep '^GITHUB_TOKEN=' /opt/translate-java-property-files/docker/.env | cut -d= -f2)
+GITHUB_TOKEN=$(sed -n 's/^GITHUB_TOKEN=//p' /opt/translate-java-property-files/docker/.env 2>/dev/null | tail -n1 || true)
 
 log_alert() {
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] ALERT: $1" | tee -a "$ALERT_FILE"
@@ -16,11 +16,52 @@ log_ok() {
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] OK: $1"
 }
 
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    log_alert "GITHUB_TOKEN is missing; GitHub PR checks will return 0"
+fi
+
 count_open_translation_prs() {
     local repo="$1"
-    curl -s -H "Authorization: token $GITHUB_TOKEN" \
-        "https://api.github.com/repos/${repo}/pulls?state=open&per_page=100" \
-        | jq '[.[] | select(.head.ref | startswith("translation-updates-"))] | length'
+    local page=1
+    local total=0
+    local response page_count page_size
+
+    if [ -z "${GITHUB_TOKEN:-}" ]; then
+        echo 0
+        return 0
+    fi
+
+    while :; do
+        response=$(curl -fsS \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${repo}/pulls?state=open&per_page=100&page=${page}" \
+            2>/dev/null) || {
+            log_alert "Failed to fetch PRs for ${repo}"
+            echo 0
+            return 0
+        }
+
+        page_count=$(jq -re '
+          if type != "array" then error("unexpected payload")
+          else [.[] | select((.head.ref // "") | startswith("translation-updates-"))] | length
+          end
+        ' <<<"$response" 2>/dev/null) || {
+            log_alert "Unexpected GitHub API payload while counting PRs for ${repo}"
+            echo 0
+            return 0
+        }
+
+        page_size=$(jq -re 'if type=="array" then length else 0 end' <<<"$response" 2>/dev/null || echo 0)
+        total=$((total + page_count))
+
+        if [ "$page_size" -lt 100 ]; then
+            break
+        fi
+        page=$((page + 1))
+    done
+
+    echo "$total"
 }
 
 check_cron_log() {
@@ -66,8 +107,12 @@ check_cron_log() {
 # Check 1: Ensure systemd service is NOT running
 if systemctl is-active --quiet translator.service 2>/dev/null; then
     log_alert "translator.service is running - it should be disabled!"
-    systemctl stop translator.service
-    systemctl disable translator.service
+    if ! systemctl stop translator.service; then
+        log_alert "Failed to stop translator.service"
+    fi
+    if ! systemctl disable translator.service; then
+        log_alert "Failed to disable translator.service"
+    fi
 else
     log_ok "translator.service is not running"
 fi


### PR DESCRIPTION
## Summary
- count open translation PRs using JSON-filtered head refs instead of raw grep
- include both bisq2 and bisq-mobile counts in health output
- improve cron health detection by checking the latest run segment from start marker to terminal markers
- treat recent non-terminal runs as in-progress (up to 3h) to avoid false failure alerts

## Why
Current health checks produce false positives:
- open PR count was overcounted from raw JSON string matches
- long-running jobs were flagged as failed due to a brittle tail-based heuristic

## Validation
- syntax check: `bash -n scripts/check-translation-services.sh`
- production script patched and manually executed on host; output now reports correct PR totals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a health-monitoring script for translation services that verifies cron runs, counts outstanding translation PRs, checks disk usage, ensures translator processes are stopped if needed, and emits clear OK/alert messages with completion timestamps for automated monitoring.
  * Updated CI vulnerability scanning to run Trivy via a containerized CLI invocation instead of the prior action-based step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->