### PR TITLE
Fix Transifex/AI translation cycle for community edits

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -119,3 +119,11 @@ CVE-2025-61730
 # Added: 2026-04-09
 # Revisit by: 2026-06-15
 CVE-2026-25679
+
+# CVE-2026-32280, CVE-2026-32282: Go stdlib vulnerabilities in yq (Go v1.24.6)
+# Affects: yq binary — vendor-supplied, cannot rebuild
+# Rationale: Controlled CI/CD context, no untrusted certificate chain building or symlink traversal.
+# Added: 2026-04-14
+# Revisit by: 2026-06-15
+CVE-2026-32280
+CVE-2026-32282

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,8 +3,8 @@
 
 -r requirements.in
 
-pytest
-pytest-asyncio>0.21
+pytest>=9.0.3
+pytest-asyncio>=1.2
 pip-tools
 ruff
 pip-audit 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -518,15 +518,15 @@ pyproject-hooks==1.2.0 \
     # via
     #   build
     #   pip-tools
-pytest==8.4.1 \
-    --hash=sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7 \
-    --hash=sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c
+pytest==9.0.3 \
+    --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
+    --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
     # via
     #   -r requirements-dev.in
     #   pytest-asyncio
-pytest-asyncio==1.1.0 \
-    --hash=sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf \
-    --hash=sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea
+pytest-asyncio==1.3.0 \
+    --hash=sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5 \
+    --hash=sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5
     # via -r requirements-dev.in
 python-dotenv==1.1.1 \
     --hash=sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc \
@@ -947,6 +947,7 @@ typing-extensions==4.14.1 \
     #   openai
     #   pydantic
     #   pydantic-core
+    #   pytest-asyncio
     #   referencing
     #   typing-inspection
 typing-inspection==0.4.1 \

--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -445,6 +445,43 @@ def _extract_properties_key_from_diff_line(diff_line: str) -> Optional[str]:
     return key or None
 
 
+def filter_git_changed_keys_by_source(
+        git_changed_keys: Set[str],
+        source_translations: Dict[str, str],
+        ledger_entries: Dict[str, Dict[str, str]],
+) -> Set[str]:
+    """Filter git-changed keys to only those whose source English value changed.
+
+    When ``tx pull -f`` downloads community translations from Transifex,
+    keys appear in ``git diff`` even though the English source didn't change.
+    Re-translating those keys creates an infinite cycle: our AI overwrites
+    the community version, Transifex serves the community version again next
+    run, and the key reappears in the diff.
+
+    This function breaks the cycle by keeping only keys where:
+    - The key has no ledger entry (truly new)
+    - The ledger entry has no source_hash (legacy/incomplete)
+    - The source value is missing (orphaned key, handled downstream)
+    - The current source hash differs from the ledger's source hash
+    """
+    if not git_changed_keys:
+        return set()
+
+    filtered: Set[str] = set()
+    for key in git_changed_keys:
+        ledger_entry = ledger_entries.get(key)
+        previous_source_hash = ledger_entry.get("source_hash") if ledger_entry else None
+        source_value = source_translations.get(key)
+
+        # Include key unless ledger proves the source is unchanged.
+        if (previous_source_hash is None
+                or source_value is None
+                or compute_ledger_hash(source_value) != previous_source_hash):
+            filtered.add(key)
+
+    return filtered
+
+
 def get_working_tree_changed_keys(target_file_path: str, repo_root: str) -> Set[str]:
     """
     Return keys that were added/updated for ``target_file_path`` in git working tree.
@@ -1724,10 +1761,16 @@ async def process_translation_queue(
         file_ledger_entries = key_ledger.get(translation_file, {})
         original_input_file_path = os.path.join(INPUT_FOLDER, translation_file)
         git_changed_keys = get_working_tree_changed_keys(original_input_file_path, REPO_ROOT)
+        # Only re-translate git-dirty keys if their English source actually changed.
+        # This prevents an infinite cycle where Transifex community translations
+        # are overwritten by AI, then Transifex re-serves the community version.
+        git_changed_keys = filter_git_changed_keys_by_source(
+            git_changed_keys, source_translations, file_ledger_entries
+        )
         newly_synchronized_keys = newly_added_keys.union(git_changed_keys)
         if git_changed_keys:
             logger.info(
-                "Detected %d git-diff key updates in '%s'; treating them as newly synchronized.",
+                "Detected %d git-diff key updates in '%s' with changed source; treating them as newly synchronized.",
                 len(git_changed_keys),
                 translation_file
             )

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -16,6 +16,7 @@ from src.translate_localization_files import (
     normalize_value,
     compute_ledger_hash,
     extract_texts_to_translate,
+    filter_git_changed_keys_by_source,
     get_working_tree_changed_keys,
     extract_language_from_filename,
     run_post_translation_validation
@@ -814,6 +815,74 @@ class TestFileDetectionLogic(unittest.TestCase):
             files = get_changed_translation_files(input_folder, repo_root)
 
         self.assertEqual(sorted(files), ["mobile_de.properties", "mobile_es.properties"])
+
+
+class TestFilterGitChangedKeys(unittest.TestCase):
+    """Tests for filter_git_changed_keys_by_source, which prevents the
+    Transifex ↔ AI translation cycle by only re-translating keys whose
+    English source actually changed."""
+
+    def test_filters_out_keys_with_unchanged_source(self):
+        """Keys changed by Transifex community translators (source unchanged)
+        should NOT be treated as newly synchronized."""
+        source_translations = {
+            "key.stable": "Hello world",
+            "key.changed": "Updated greeting",
+        }
+        ledger_entries = {
+            "key.stable": {"source_hash": compute_ledger_hash("Hello world")},
+            "key.changed": {"source_hash": compute_ledger_hash("Old greeting")},
+        }
+        git_changed_keys = {"key.stable", "key.changed"}
+
+        result = filter_git_changed_keys_by_source(
+            git_changed_keys, source_translations, ledger_entries
+        )
+
+        self.assertIn("key.changed", result)
+        self.assertNotIn("key.stable", result)
+
+    def test_includes_keys_with_no_ledger_entry(self):
+        """Keys not in the ledger are new — always include them."""
+        source_translations = {"key.new": "Brand new key"}
+        ledger_entries = {}
+        git_changed_keys = {"key.new"}
+
+        result = filter_git_changed_keys_by_source(
+            git_changed_keys, source_translations, ledger_entries
+        )
+
+        self.assertIn("key.new", result)
+
+    def test_includes_keys_with_no_source_hash_in_ledger(self):
+        """Ledger entries without source_hash (legacy) should be included."""
+        source_translations = {"key.legacy": "Some value"}
+        ledger_entries = {"key.legacy": {"target_hash": "abc123"}}
+        git_changed_keys = {"key.legacy"}
+
+        result = filter_git_changed_keys_by_source(
+            git_changed_keys, source_translations, ledger_entries
+        )
+
+        self.assertIn("key.legacy", result)
+
+    def test_empty_git_changed_keys(self):
+        """No git changes means no keys to filter."""
+        result = filter_git_changed_keys_by_source(set(), {}, {})
+        self.assertEqual(result, set())
+
+    def test_preserves_keys_not_in_source(self):
+        """Keys in git diff but not in source translations should be included
+        (they'll be handled/skipped by downstream logic)."""
+        source_translations = {}
+        ledger_entries = {"key.orphan": {"source_hash": compute_ledger_hash("old")}}
+        git_changed_keys = {"key.orphan"}
+
+        result = filter_git_changed_keys_by_source(
+            git_changed_keys, source_translations, ledger_entries
+        )
+
+        self.assertIn("key.orphan", result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Fix infinite translation cycle where community-edited keys on Transifex were re-translated by AI every run, then overwritten by Transifex again
- Add `filter_git_changed_keys_by_source()` to only re-translate git-dirty keys when the English source actually changed
- Community translation updates from Transifex are now accepted as-is

## Root Cause

1. Transifex community translator updates a key (e.g., `muSig.trade.guide.process.content`)
2. Pipeline runs `tx pull -t -f` → downloads community version → key appears in `git diff`
3. `get_working_tree_changed_keys()` flags it as "newly synchronized"
4. AI re-translates it (producing a different phrasing)
5. PR merged → `sync_transifex.yml` pushes AI version to Transifex
6. But Transifex still has the community version cached/preferred
7. Next run: `tx pull -f` downloads community version again → cycle repeats

Evidence: PRs #4644, #4647, #4648, #4653 all re-translated the same 2-4 keys with the German translation cycling:
- `Sobald Sie gestartet haben` → `Sobald Sie gestartet sind` → `Sobald die Initiierung erfolgt ist` → back to start

## Test plan

- [x] 5 new unit tests for `filter_git_changed_keys_by_source()` covering: unchanged source filtering, new keys without ledger, legacy ledger entries, empty input, orphaned keys
- [x] All 130 tests pass
- [x] Docker image builds successfully