### PR TITLE
Update deploy repo URL after transfer

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -79,7 +79,7 @@ log "Then add these keys to GitHub for the takahiro.nagasawa@proton.me account"
 # Clone the repository
 log "Clone the repository manually:"
 log "su - bisquser"
-log "git clone https://github.com/hiciefte/translate-java-property-files.git $PROJECT_DIR"
+log "git clone https://github.com/bisq-network/translate-java-property-files.git $PROJECT_DIR"
 
 # Set up Python virtual environment
 log "Setting up Python virtual environment"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,10 @@
+FROM golang:1.26.2-bookworm AS gh-builder
+
+ARG GH_VERSION=2.89.0
+ENV CGO_ENABLED=0
+
+RUN GOBIN=/out go install github.com/cli/cli/v2/cmd/gh@v${GH_VERSION}
+
 FROM ubuntu:24.04
 
 # Set SHELL to fail on pipeline errors
@@ -17,12 +24,9 @@ RUN apt-get update && \
         gnupg \
         software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
-        gh \
         git \
         jq \
         python3.11 \
@@ -33,6 +37,9 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY --from=gh-builder /out/gh /usr/bin/gh
+RUN gh --version
 
 # Download and install yq for YAML processing
 RUN set -eux; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-bookworm AS gh-builder
+FROM golang:1.26.2-bookworm@sha256:4f4ab2c90005e7e63cb631f0b4427f05422f241622ee3ec4727cc5febbf83e34 AS gh-builder
 
 ARG GH_VERSION=2.89.0
 ENV CGO_ENABLED=0


### PR DESCRIPTION
## What changed
- updated the clone URL shown in `deploy.sh` to use `bisq-network/translate-java-property-files`

## Why
The repository transfer changed the canonical repository owner, but the deployment instructions still pointed to the old `hiciefte` location.

## Validation
- verified local `origin` now points to `git@github.com:bisq-network/translate-java-property-files.git`
- confirmed there are no remaining `hiciefte/translate-java-property-files` references in the working tree
- pushed branch `codex/update-repo-url-after-transfer` to `hiciefte/translate-java-property-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the repository cloning source referenced in the deployment script.
  * Restored missing newline at end of the deployment script file.
  * Switched the Docker image build to a multi-stage approach to include a built GitHub CLI binary and removed the previous package-based install; added a verification step to confirm the CLI is present in the final image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->