### PR TITLE
[codex] Add translation PR quality gate

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,6 +53,17 @@ dry_run: false
 # only translate newly added keys by default and reduce translation churn.
 retranslate_identical_source_strings: false
 
+# Generated PR quality gate.
+# Calibrated from current bisq2 and bisq-mobile translation files:
+# - Existing raw source-identical values are common in payment/brand keys.
+# - The gate ignores exact glossary values, enum-like uppercase keys, URLs,
+#   placeholders, and non-linguistic tokens before applying these thresholds.
+quality_gate:
+  source_identical_min_block_count: 5
+  source_identical_max_count: 20
+  source_identical_max_ratio: 0.30
+  block_on_pipeline_warnings: true
+
 # Optional persistent per-key hash ledger used to detect source changes
 # without reprocessing already-stable translations.
 translation_key_ledger_file_path: "logs/translation_key_ledger.json"

--- a/docker/config.docker.yaml
+++ b/docker/config.docker.yaml
@@ -8,6 +8,11 @@ translated_queue_folder: 'translated_queue' # Relative to /app
 dry_run: false
 retranslate_identical_source_strings: false
 translation_key_ledger_file_path: "/app/logs/translation_key_ledger.json"
+quality_gate:
+  source_identical_min_block_count: 5
+  source_identical_max_count: 20
+  source_identical_max_ratio: 0.30
+  block_on_pipeline_warnings: true
 supported_locales:
   - code: "cs"
     name: "Czech"

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
 import yaml
@@ -11,6 +11,15 @@ from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
 from src.logging_config import setup_logger
+
+
+@dataclass
+class QualityGateConfig:
+    """Configuration for generated translation PR quality gates."""
+    source_identical_min_block_count: int = 5
+    source_identical_max_count: int = 20
+    source_identical_max_ratio: float = 0.30
+    block_on_pipeline_warnings: bool = True
 
 
 @dataclass
@@ -49,6 +58,9 @@ class AppConfig:
 
     # OpenAI client
     openai_client: Optional[AsyncOpenAI]
+
+    # Generated PR quality gate
+    quality_gate: QualityGateConfig = field(default_factory=QualityGateConfig)
 
 
 def _compute_project_root() -> str:
@@ -238,6 +250,13 @@ def load_app_config() -> AppConfig:
     model_name = config.get('model_name', 'gpt-4')
     review_model_name = os.environ.get('REVIEW_MODEL_NAME', config.get('review_model_name', model_name))
     retranslate_identical_source_strings = bool(config.get('retranslate_identical_source_strings', False))
+    quality_gate_config = config.get('quality_gate', {}) or {}
+    quality_gate = QualityGateConfig(
+        source_identical_min_block_count=int(quality_gate_config.get('source_identical_min_block_count', 5)),
+        source_identical_max_count=int(quality_gate_config.get('source_identical_max_count', 20)),
+        source_identical_max_ratio=float(quality_gate_config.get('source_identical_max_ratio', 0.30)),
+        block_on_pipeline_warnings=bool(quality_gate_config.get('block_on_pipeline_warnings', True)),
+    )
 
     # Holistic review chunk size with environment override
     # Reduced default from 75 to 30 to handle content-heavy files better
@@ -282,5 +301,6 @@ def load_app_config() -> AppConfig:
         translated_queue_folder=translated_queue_folder,
         translation_key_ledger_file_path=translation_key_ledger_file_path,
         preserve_queues_for_debug=config.get('preserve_queues_for_debug', False),
-        openai_client=openai_client
+        openai_client=openai_client,
+        quality_gate=quality_gate
     )

--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -923,11 +923,11 @@ def run_post_translation_validation(
 
     return is_valid
 
-def run_per_key_validation(
+def run_per_key_validation_with_summary(
         final_translations: Dict[str, str],
         source_translations: Dict[str, str],
         filename: str
-) -> Tuple[Dict[str, str], List[str]]:
+) -> Tuple[Dict[str, str], Dict[str, object]]:
     """
     Validates each translation key individually and selectively reverts failed keys.
 
@@ -948,6 +948,8 @@ def run_per_key_validation(
     """
     valid_translations = {}
     failed_keys = []
+    control_character_keys = []
+    placeholder_mismatch_keys = []
 
     for key, target_value in final_translations.items():
         source_value = source_translations.get(key, "")
@@ -955,6 +957,7 @@ def run_per_key_validation(
 
         if control_character_findings:
             failed_keys.append(key)
+            control_character_keys.append(key)
             logger.warning(
                 f"Key '{key}' failed validation in '{filename}' - reverting to source due to "
                 f"disallowed control character artifact(s): {', '.join(control_character_findings[:3])}"
@@ -972,6 +975,7 @@ def run_per_key_validation(
         else:
             # Validation failed - revert to source and track the failure
             failed_keys.append(key)
+            placeholder_mismatch_keys.append(key)
 
             # Extract placeholder details for detailed logging
             placeholder_regex = re.compile(r'\{([^{}]+)\}')
@@ -1002,7 +1006,31 @@ def run_per_key_validation(
     else:
         logger.info(f"All {len(final_translations)} keys passed validation in '{filename}'.")
 
-    return valid_translations, failed_keys
+    summary = {
+        "failed_keys": failed_keys,
+        "control_character_keys": control_character_keys,
+        "placeholder_mismatch_keys": placeholder_mismatch_keys,
+        "reverted_keys_count": len(failed_keys),
+        "control_character_findings_count": len(control_character_keys),
+        "placeholder_failures_count": len(placeholder_mismatch_keys),
+    }
+    return valid_translations, summary
+
+
+def run_per_key_validation(
+        final_translations: Dict[str, str],
+        source_translations: Dict[str, str],
+        filename: str
+) -> Tuple[Dict[str, str], List[str]]:
+    """
+    Backward-compatible wrapper returning only the failed key list.
+    """
+    valid_translations, summary = run_per_key_validation_with_summary(
+        final_translations,
+        source_translations,
+        filename
+    )
+    return valid_translations, list(summary["failed_keys"])
 
 async def translate_text_async(
         text: str,
@@ -1701,7 +1729,8 @@ def copy_files_to_translation_queue(
 async def process_translation_queue(
         translation_queue_folder: str,
         translated_queue_folder: str,
-        glossary_file_path: str
+        glossary_file_path: str,
+        validation_summary: Optional[Dict[str, Dict[str, object]]] = None
 ) -> Tuple[int, List[str], Dict[str, List[str]], int]:
     """
     Process all .properties files in the translation queue folder.
@@ -1972,11 +2001,14 @@ async def process_translation_queue(
                         f"(has_tokens={has_protection_tokens}, has_placeholders={has_real_placeholders})")
 
         # Validate each key individually and selectively revert failures
-        valid_translations, failed_keys = run_per_key_validation(
+        valid_translations, per_key_summary = run_per_key_validation_with_summary(
             final_translations,
             source_translations,
             translation_file
         )
+        failed_keys = list(per_key_summary["failed_keys"])
+        if validation_summary is not None:
+            validation_summary[translation_file] = per_key_summary
 
         # Apply validated translations (valid translations + reverted source for failed keys)
         for line in draft_lines:
@@ -2092,6 +2124,24 @@ def generate_translation_summary(
         json.dump(summary, f, ensure_ascii=False, indent=2)
 
 
+def write_translation_validation_summary(
+    summary_path: str,
+    validation_files: Dict[str, Dict[str, object]],
+    skipped_files: Dict[str, List[str]],
+) -> None:
+    """Write structured validation data consumed by the PR quality gate."""
+    summary = {
+        "files": validation_files,
+        "pipeline_warnings": [
+            {"file": filename, "errors": errors}
+            for filename, errors in sorted(skipped_files.items())
+        ],
+    }
+    os.makedirs(os.path.dirname(summary_path) or '.', exist_ok=True)
+    with open(summary_path, 'w', encoding='utf-8') as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+
+
 def _build_pr_title(
     modules: List[str],
     new_keys: int,
@@ -2163,10 +2213,12 @@ async def main():
     logger.info(f"Copied changed files to '{TRANSLATION_QUEUE_FOLDER}' for processing.")
 
     # Step 4: Process the files in the translation queue.
+    validation_files: Dict[str, Dict[str, object]] = {}
     processed_files_count, processed_filenames, skipped_files, total_keys_translated = await process_translation_queue(
         translation_queue_folder=TRANSLATION_QUEUE_FOLDER,
         translated_queue_folder=TRANSLATED_QUEUE_FOLDER,
-        glossary_file_path=GLOSSARY_FILE_PATH
+        glossary_file_path=GLOSSARY_FILE_PATH,
+        validation_summary=validation_files
     )
     if processed_files_count > 0:
         logger.info(
@@ -2203,6 +2255,14 @@ async def main():
         updated_keys_count=0,
     )
     logger.info(f"Wrote translation summary to {summary_path}")
+
+    validation_summary_path = os.path.join(PROJECT_ROOT_DIR, 'logs', 'translation_validation_summary.json')
+    write_translation_validation_summary(
+        validation_summary_path,
+        validation_files=validation_files,
+        skipped_files=skipped_files,
+    )
+    logger.info(f"Wrote translation validation summary to {validation_summary_path}")
 
     # Step 7: Copy translated files back to the input folder, overwriting the originals.
     copy_translated_files_back(TRANSLATED_QUEUE_FOLDER, INPUT_FOLDER)

--- a/src/translation_quality_gate.py
+++ b/src/translation_quality_gate.py
@@ -1,0 +1,464 @@
+"""Quality gate for generated translation pull requests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import yaml
+
+from src.properties_parser import parse_properties_file
+from src.translation_validator import find_disallowed_control_characters
+
+
+@dataclass
+class QualityGateConfig:
+    """Thresholds for blocking generated translation pull requests."""
+
+    source_identical_min_block_count: int = 5
+    source_identical_max_count: int = 20
+    source_identical_max_ratio: float = 0.30
+    block_on_pipeline_warnings: bool = True
+
+
+@dataclass
+class SourceIdenticalStats:
+    changed_entries_count: int = 0
+    checked_entries_count: int = 0
+    source_identical_count: int = 0
+    expected_source_identical_count: int = 0
+    unexpected_source_identical_count: int = 0
+    unexpected_source_identical_ratio: float = 0.0
+    control_character_findings_count: int = 0
+    examples: List[Dict[str, str]] = None
+    control_character_examples: List[Dict[str, str]] = None
+
+    def __post_init__(self) -> None:
+        if self.examples is None:
+            self.examples = []
+        if self.control_character_examples is None:
+            self.control_character_examples = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+_TOKEN_PATTERNS = [
+    re.compile(r"^\{[^{}]+\}$"),
+    re.compile(r"^(https?://|www\.)\S+$", re.IGNORECASE),
+    re.compile(r"^\S+@\S+$"),
+    re.compile(r"^[A-Z0-9_.:+/#-]{2,}$"),
+]
+_ENUM_LIKE_KEY = re.compile(r"^[A-Z0-9_.$-]+$")
+
+
+def normalize_value(value: str) -> str:
+    return (value or "").strip()
+
+
+def is_expected_source_identical(key: str, value: str, brand_glossary: Iterable[str]) -> bool:
+    """Return true for values that are commonly and legitimately untranslated."""
+    normalized = normalize_value(value)
+    if not normalized:
+        return True
+    if _ENUM_LIKE_KEY.match(key):
+        return True
+    glossary = {term.strip().casefold() for term in brand_glossary if str(term).strip()}
+    if normalized.casefold() in glossary:
+        return True
+    if not any(character.isalpha() for character in normalized):
+        return True
+    return any(pattern.match(normalized) for pattern in _TOKEN_PATTERNS)
+
+
+def source_filename_for_locale_file(filename: str, locale_codes: Sequence[str]) -> Optional[str]:
+    if not filename.endswith(".properties"):
+        return None
+    base = filename[: -len(".properties")]
+    for code in sorted(locale_codes, key=len, reverse=True):
+        suffix = f"_{code}"
+        if base.endswith(suffix):
+            return f"{base[:-len(suffix)]}.properties"
+    return None
+
+
+def _extract_properties_entry(diff_line: str) -> Optional[Tuple[str, str]]:
+    stripped = diff_line.strip()
+    if not stripped or stripped.startswith(("#", "!")):
+        return None
+
+    escaped = False
+    for index, character in enumerate(diff_line):
+        if character == "\\":
+            escaped = not escaped
+            continue
+        if character in ("=", ":") and not escaped:
+            key = diff_line[:index].strip()
+            value = diff_line[index + 1 :].strip()
+            return (key, value) if key else None
+        escaped = False
+    return None
+
+
+def _iter_added_properties_entries(diff_text: str) -> Iterable[Tuple[str, str, str]]:
+    current_file: Optional[str] = None
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line[len("+++ b/") :]
+            continue
+        if line.startswith("+++ /dev/null"):
+            current_file = None
+            continue
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if not current_file or not current_file.endswith(".properties"):
+            continue
+        entry = _extract_properties_entry(line[1:])
+        if entry:
+            key, value = entry
+            yield current_file, key, value
+
+
+def _relpath(path: str, start: str) -> str:
+    try:
+        return os.path.relpath(path, start)
+    except ValueError:
+        return path
+
+
+def analyze_source_identical_changes(
+    diff_text: str,
+    repo_root: str,
+    input_folder: str,
+    locale_codes: Sequence[str],
+    brand_glossary: Iterable[str],
+    examples_limit: int = 10,
+) -> SourceIdenticalStats:
+    """Analyze staged translation changes for suspicious English-source fallbacks."""
+    repo_root_path = Path(repo_root)
+    input_folder_path = Path(input_folder)
+    source_cache: Dict[Path, Dict[str, str]] = {}
+    stats = SourceIdenticalStats()
+
+    for changed_file, key, target_value in _iter_added_properties_entries(diff_text):
+        changed_path = repo_root_path / changed_file
+        source_name = source_filename_for_locale_file(changed_path.name, locale_codes)
+        if not source_name:
+            continue
+
+        source_path = changed_path.with_name(source_name)
+        if not source_path.exists():
+            continue
+
+        if source_path not in source_cache:
+            _, source_translations = parse_properties_file(str(source_path))
+            source_cache[source_path] = source_translations
+        else:
+            source_translations = source_cache[source_path]
+
+        if key not in source_translations:
+            continue
+
+        stats.changed_entries_count += 1
+
+        control_findings = find_disallowed_control_characters(target_value)
+        if control_findings:
+            stats.control_character_findings_count += len(control_findings)
+            if len(stats.control_character_examples) < examples_limit:
+                stats.control_character_examples.append(
+                    {
+                        "file": _relpath(str(changed_path), str(input_folder_path)),
+                        "key": key,
+                        "findings": ", ".join(control_findings[:3]),
+                    }
+                )
+
+        source_value = source_translations[key]
+        if normalize_value(source_value) != normalize_value(target_value):
+            stats.checked_entries_count += 1
+            continue
+
+        stats.source_identical_count += 1
+        if is_expected_source_identical(key, source_value, brand_glossary):
+            stats.expected_source_identical_count += 1
+            continue
+
+        stats.checked_entries_count += 1
+        stats.unexpected_source_identical_count += 1
+        if len(stats.examples) < examples_limit:
+            stats.examples.append(
+                {
+                    "file": _relpath(str(changed_path), str(input_folder_path)),
+                    "key": key,
+                    "value": target_value,
+                }
+            )
+
+    if stats.checked_entries_count:
+        stats.unexpected_source_identical_ratio = (
+            stats.unexpected_source_identical_count / stats.checked_entries_count
+        )
+    return stats
+
+
+def load_quality_gate_config(config_path: str) -> Tuple[QualityGateConfig, List[str], List[str]]:
+    with open(config_path, "r", encoding="utf-8") as file:
+        raw_config = yaml.safe_load(file) or {}
+
+    quality_gate = raw_config.get("quality_gate", {}) or {}
+    locales = [
+        locale["code"]
+        for locale in raw_config.get("supported_locales", [])
+        if isinstance(locale, dict) and locale.get("code")
+    ]
+    brand_glossary = [str(term) for term in raw_config.get("brand_technical_glossary", [])]
+    return (
+        QualityGateConfig(
+            source_identical_min_block_count=int(
+                quality_gate.get("source_identical_min_block_count", 5)
+            ),
+            source_identical_max_count=int(quality_gate.get("source_identical_max_count", 20)),
+            source_identical_max_ratio=float(quality_gate.get("source_identical_max_ratio", 0.30)),
+            block_on_pipeline_warnings=bool(quality_gate.get("block_on_pipeline_warnings", True)),
+        ),
+        locales,
+        brand_glossary,
+    )
+
+
+def load_validation_summary(path: str) -> Dict[str, Any]:
+    if not path or not os.path.exists(path):
+        return {"files": {}, "pipeline_warnings": []}
+    with open(path, "r", encoding="utf-8") as file:
+        data = json.load(file)
+    if not isinstance(data, dict):
+        return {"files": {}, "pipeline_warnings": []}
+    data.setdefault("files", {})
+    data.setdefault("pipeline_warnings", [])
+    return data
+
+
+def _changed_files_relative_to_input(changed_files: Sequence[str], input_folder: str) -> set[str]:
+    input_path = Path(input_folder)
+    result = set()
+    for changed_file in changed_files:
+        changed_path = Path(changed_file)
+        if changed_path.is_absolute():
+            try:
+                result.add(str(changed_path.relative_to(input_path)))
+            except ValueError:
+                result.add(changed_path.name)
+        else:
+            result.add(changed_path.name)
+    return result
+
+
+def _aggregate_validation(
+    validation_summary: Dict[str, Any],
+    changed_files: Sequence[str],
+    input_folder: str,
+) -> Dict[str, int]:
+    changed_relative_files = _changed_files_relative_to_input(changed_files, input_folder)
+    totals = {
+        "reverted_keys_count": 0,
+        "control_character_findings_count": 0,
+        "placeholder_failures_count": 0,
+    }
+    for filename, file_summary in validation_summary.get("files", {}).items():
+        if changed_relative_files and filename not in changed_relative_files and Path(filename).name not in changed_relative_files:
+            continue
+        totals["reverted_keys_count"] += int(file_summary.get("reverted_keys_count", 0))
+        totals["control_character_findings_count"] += int(
+            file_summary.get("control_character_findings_count", 0)
+        )
+        totals["placeholder_failures_count"] += int(file_summary.get("placeholder_failures_count", 0))
+    return totals
+
+
+def build_quality_gate_report(
+    source_stats: SourceIdenticalStats,
+    validation_summary: Dict[str, Any],
+    changed_files: Sequence[str],
+    input_folder: str,
+    config: QualityGateConfig,
+) -> Dict[str, Any]:
+    validation_totals = _aggregate_validation(validation_summary, changed_files, input_folder)
+    pipeline_warnings = validation_summary.get("pipeline_warnings", [])
+    blocking_reasons: List[str] = []
+
+    source_identical_blocking = (
+        source_stats.unexpected_source_identical_count >= config.source_identical_min_block_count
+        and (
+            source_stats.unexpected_source_identical_count > config.source_identical_max_count
+            or source_stats.unexpected_source_identical_ratio > config.source_identical_max_ratio
+        )
+    )
+    if source_identical_blocking:
+        blocking_reasons.append(
+            "Unexpected source-identical changed values exceed configured quality thresholds."
+        )
+
+    if config.block_on_pipeline_warnings and pipeline_warnings:
+        blocking_reasons.append("Translation pipeline warnings require manual resolution.")
+
+    blocking = bool(blocking_reasons)
+    description = (
+        blocking_reasons[0]
+        if blocking
+        else "Translation quality gate passed."
+    )
+    description = description[:140]
+
+    return {
+        "blocking": blocking,
+        "blocking_reasons": blocking_reasons,
+        "status_state": "failure" if blocking else "success",
+        "status_description": description,
+        "source_identical": source_stats.to_dict(),
+        "validation": validation_totals,
+        "pipeline_warnings_count": len(pipeline_warnings),
+        "pipeline_warnings": pipeline_warnings,
+        "thresholds": asdict(config),
+    }
+
+
+def _format_percent(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def _truncate(value: str, limit: int = 100) -> str:
+    value = value.replace("\n", "\\n")
+    return value if len(value) <= limit else value[: limit - 3] + "..."
+
+
+def render_quality_gate_markdown(report: Dict[str, Any]) -> str:
+    source = report["source_identical"]
+    validation = report["validation"]
+    lines = ["## Translation Validation Summary", ""]
+
+    if report["blocking"]:
+        lines.append("**Status:** Blocked by `translation-quality-gate`.")
+        lines.append("")
+        for reason in report["blocking_reasons"]:
+            lines.append(f"- {reason}")
+        lines.append("")
+    else:
+        lines.append("**Status:** Passed `translation-quality-gate`.")
+        lines.append("")
+
+    lines.extend(
+        [
+            "| Check | Result |",
+            "| --- | --- |",
+            (
+                "| Unexpected source-identical changed values | "
+                f"{source['unexpected_source_identical_count']} / "
+                f"{source['checked_entries_count']} checked "
+                f"({_format_percent(source['unexpected_source_identical_ratio'])}) |"
+            ),
+            (
+                "| Expected source-identical values ignored | "
+                f"{source['expected_source_identical_count']} |"
+            ),
+            f"| Reverted keys | {validation['reverted_keys_count']} |",
+            f"| Control-character findings | {validation['control_character_findings_count']} |",
+            f"| Placeholder failures | {validation['placeholder_failures_count']} |",
+            f"| Pipeline warnings | {report['pipeline_warnings_count']} |",
+            "",
+        ]
+    )
+
+    if source.get("examples"):
+        lines.append("### Source-Identical Examples")
+        lines.append("")
+        for example in source["examples"]:
+            lines.append(
+                f"- `{example['file']}` `{example['key']}` = `{_truncate(example['value'])}`"
+            )
+        lines.append("")
+
+    if source.get("control_character_examples"):
+        lines.append("### Control-Character Examples")
+        lines.append("")
+        for example in source["control_character_examples"]:
+            lines.append(
+                f"- `{example['file']}` `{example['key']}`: {example['findings']}"
+            )
+        lines.append("")
+
+    if report["pipeline_warnings"]:
+        lines.append("### Pipeline Warnings")
+        lines.append("")
+        for warning in report["pipeline_warnings"]:
+            lines.append(f"- `{warning.get('file', 'unknown')}`")
+            for error in warning.get("errors", []):
+                lines.append(f"  - {_truncate(str(error), 180)}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def get_staged_diff(repo_root: str, changed_files: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--unified=0", "--", *changed_files],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git diff failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def write_report(report: Dict[str, Any], output_json: str, output_markdown: str) -> None:
+    Path(output_json).parent.mkdir(parents=True, exist_ok=True)
+    with open(output_json, "w", encoding="utf-8") as file:
+        json.dump(report, file, ensure_ascii=False, indent=2)
+    with open(output_markdown, "w", encoding="utf-8") as file:
+        file.write(render_quality_gate_markdown(report))
+
+
+def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--input-folder", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--validation-summary", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-markdown", required=True)
+    parser.add_argument("--changed-files", nargs="+", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parse_args(argv)
+    config, locale_codes, brand_glossary = load_quality_gate_config(args.config)
+    diff_text = get_staged_diff(args.repo_root, args.changed_files)
+    source_stats = analyze_source_identical_changes(
+        diff_text=diff_text,
+        repo_root=args.repo_root,
+        input_folder=args.input_folder,
+        locale_codes=locale_codes,
+        brand_glossary=brand_glossary,
+    )
+    report = build_quality_gate_report(
+        source_stats=source_stats,
+        validation_summary=load_validation_summary(args.validation_summary),
+        changed_files=args.changed_files,
+        input_folder=args.input_folder,
+        config=config,
+    )
+    write_report(report, args.output_json, args.output_markdown)
+    return 1 if report["blocking"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -56,6 +56,12 @@ class TestLoadAppConfig:
             "dry_run": True,
             "retranslate_identical_source_strings": True,
             "translation_key_ledger_file_path": "/tmp/test-ledger.json",
+            "quality_gate": {
+                "source_identical_min_block_count": 6,
+                "source_identical_max_count": 25,
+                "source_identical_max_ratio": 0.4,
+                "block_on_pipeline_warnings": False,
+            },
             "supported_locales": [
                 {"code": "de", "name": "German"},
                 {"code": "es", "name": "Spanish"}
@@ -80,6 +86,10 @@ class TestLoadAppConfig:
         assert config.dry_run is True
         assert config.retranslate_identical_source_strings is True
         assert config.translation_key_ledger_file_path == "/tmp/test-ledger.json"
+        assert config.quality_gate.source_identical_min_block_count == 6
+        assert config.quality_gate.source_identical_max_count == 25
+        assert config.quality_gate.source_identical_max_ratio == 0.4
+        assert config.quality_gate.block_on_pipeline_warnings is False
         assert config.language_codes == {"de": "German", "es": "Spanish"}
         assert config.name_to_code == {"german": "de", "spanish": "es"}
 
@@ -102,6 +112,10 @@ class TestLoadAppConfig:
         assert config.max_concurrent_api_calls == 1
         assert config.process_all_files is False
         assert config.retranslate_identical_source_strings is False
+        assert config.quality_gate.source_identical_min_block_count == 5
+        assert config.quality_gate.source_identical_max_count == 20
+        assert config.quality_gate.source_identical_max_ratio == 0.30
+        assert config.quality_gate.block_on_pipeline_warnings is True
         assert config.translation_key_ledger_file_path == os.path.join(
             config.project_root, "logs", "translation_key_ledger.json"
         )

--- a/tests/unit/test_per_key_validation.py
+++ b/tests/unit/test_per_key_validation.py
@@ -5,7 +5,14 @@ Tests the ability to validate individual translation keys and selectively
 revert only failed keys to source instead of discarding entire translation files.
 """
 
-from src.translate_localization_files import run_per_key_validation
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "DUMMY_KEY_FOR_TESTING")
+
+from src.translate_localization_files import (
+    run_per_key_validation,
+    run_per_key_validation_with_summary,
+)
 
 
 class TestPerKeyValidation:
@@ -253,3 +260,30 @@ class TestPerKeyValidation:
 
         assert failed_keys == []
         assert valid_translations["learn.more"] == "Cómo funciona esto →"
+
+    def test_validation_summary_categorizes_reverted_keys(self):
+        source_translations = {
+            "bad.placeholder": "Amount {0}",
+            "bad.control": "How this works →",
+            "valid": "Simple text",
+        }
+        final_translations = {
+            "bad.placeholder": "Amount",
+            "bad.control": "How this works \\u007f2192",
+            "valid": "Texto simple",
+        }
+
+        valid_translations, summary = run_per_key_validation_with_summary(
+            final_translations,
+            source_translations,
+            "mobile_es.properties",
+        )
+
+        assert valid_translations["bad.placeholder"] == "Amount {0}"
+        assert valid_translations["bad.control"] == "How this works →"
+        assert summary["failed_keys"] == ["bad.placeholder", "bad.control"]
+        assert summary["placeholder_mismatch_keys"] == ["bad.placeholder"]
+        assert summary["control_character_keys"] == ["bad.control"]
+        assert summary["reverted_keys_count"] == 2
+        assert summary["placeholder_failures_count"] == 1
+        assert summary["control_character_findings_count"] == 1

--- a/tests/unit/test_translation_quality_gate.py
+++ b/tests/unit/test_translation_quality_gate.py
@@ -1,0 +1,157 @@
+from pathlib import Path
+
+from src.translation_quality_gate import (
+    QualityGateConfig,
+    analyze_source_identical_changes,
+    build_quality_gate_report,
+    render_quality_gate_markdown,
+)
+
+
+def _write_properties(path: Path, entries: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(f"{key}={value}" for key, value in entries.items()) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_source_identical_gate_ignores_glossary_tokens_and_enum_keys(tmp_path):
+    repo_root = tmp_path
+    input_folder = repo_root / "resources"
+    _write_properties(
+        input_folder / "mobile.properties",
+        {
+            "mobile.open": "Open trades",
+            "mobile.sort": "Sort",
+            "BTC": "BTC",
+            "PAYMENT_METHOD": "MoneyGram",
+            "mobile.done": "Done",
+        },
+    )
+
+    diff_text = """diff --git a/resources/mobile_es.properties b/resources/mobile_es.properties
++++ b/resources/mobile_es.properties
++mobile.open=Open trades
++mobile.sort=Sort
++BTC=BTC
++PAYMENT_METHOD=MoneyGram
++mobile.done=Listo
+"""
+
+    stats = analyze_source_identical_changes(
+        diff_text=diff_text,
+        repo_root=str(repo_root),
+        input_folder=str(input_folder),
+        locale_codes=["es"],
+        brand_glossary=["BTC", "MoneyGram"],
+    )
+
+    assert stats.changed_entries_count == 5
+    assert stats.source_identical_count == 4
+    assert stats.expected_source_identical_count == 2
+    assert stats.unexpected_source_identical_count == 2
+    assert stats.unexpected_source_identical_ratio == 2 / 3
+
+
+def test_quality_gate_blocks_many_unexpected_source_identical_changes(tmp_path):
+    repo_root = tmp_path
+    input_folder = repo_root / "resources"
+    _write_properties(
+        input_folder / "mobile.properties",
+        {
+            "k1": "Open trades",
+            "k2": "Sort",
+            "k3": "Completed",
+            "k4": "Cancelled",
+            "k5": "Search",
+        },
+    )
+
+    diff_text = """diff --git a/resources/mobile_es.properties b/resources/mobile_es.properties
++++ b/resources/mobile_es.properties
++k1=Open trades
++k2=Sort
++k3=Completed
++k4=Cancelled
++k5=Search
+"""
+
+    stats = analyze_source_identical_changes(
+        diff_text=diff_text,
+        repo_root=str(repo_root),
+        input_folder=str(input_folder),
+        locale_codes=["es"],
+        brand_glossary=[],
+    )
+    report = build_quality_gate_report(
+        source_stats=stats,
+        validation_summary={"files": {}, "pipeline_warnings": []},
+        changed_files=["resources/mobile_es.properties"],
+        input_folder=str(input_folder),
+        config=QualityGateConfig(
+            source_identical_min_block_count=5,
+            source_identical_max_count=20,
+            source_identical_max_ratio=0.30,
+            block_on_pipeline_warnings=True,
+        ),
+    )
+
+    assert report["blocking"] is True
+    assert "source-identical" in report["blocking_reasons"][0]
+    assert report["status_state"] == "failure"
+
+
+def test_pipeline_warnings_are_blocking_when_configured():
+    report = build_quality_gate_report(
+        source_stats=analyze_source_identical_changes(
+            diff_text="",
+            repo_root=".",
+            input_folder=".",
+            locale_codes=["es"],
+            brand_glossary=[],
+        ),
+        validation_summary={
+            "files": {},
+            "pipeline_warnings": [
+                {"file": "mobile_es.properties", "errors": ["Invalid escape sequence"]}
+            ],
+        },
+        changed_files=["resources/mobile_es.properties"],
+        input_folder="resources",
+        config=QualityGateConfig(block_on_pipeline_warnings=True),
+    )
+
+    assert report["blocking"] is True
+    assert report["pipeline_warnings_count"] == 1
+    assert report["status_state"] == "failure"
+
+
+def test_quality_gate_markdown_contains_validation_summary():
+    report = {
+        "blocking": False,
+        "source_identical": {
+            "changed_entries_count": 10,
+            "checked_entries_count": 8,
+            "source_identical_count": 3,
+            "expected_source_identical_count": 2,
+            "unexpected_source_identical_count": 1,
+            "unexpected_source_identical_ratio": 0.125,
+            "examples": [],
+        },
+        "validation": {
+            "reverted_keys_count": 2,
+            "control_character_findings_count": 1,
+            "placeholder_failures_count": 1,
+        },
+        "pipeline_warnings_count": 0,
+        "pipeline_warnings": [],
+        "blocking_reasons": [],
+    }
+
+    markdown = render_quality_gate_markdown(report)
+
+    assert "Translation Validation Summary" in markdown
+    assert "Unexpected source-identical changed values" in markdown
+    assert "Reverted keys" in markdown
+    assert "Control-character findings" in markdown

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -36,3 +36,21 @@ def test_env_example_documents_max_files_per_pr_override():
     env_example = (REPO_ROOT / "docker" / ".env.example").read_text()
 
     assert "MAX_FILES_PER_PR=150" in env_example
+
+
+def test_generated_prs_publish_translation_quality_gate_status():
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    assert "src.translation_quality_gate" in script
+    assert "translation-quality-gate" in script
+    assert 'gh api "repos/$UPSTREAM_REPO_NAME/statuses/$commit_sha"' in script
+    assert "QUALITY_REPORT_MD" in script
+
+
+def test_config_file_is_normalized_before_late_quality_gate_call():
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    normalize_index = script.index("CONFIG_FILE=$(cd")
+    quality_gate_index = script.index("src.translation_quality_gate")
+
+    assert normalize_index < quality_gate_index

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -89,7 +89,7 @@ check_and_exit_if_blocked() {
 }
 
 # Check for required tools
-for tool in yq git tx curl; do
+for tool in yq git tx curl jq python3; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         log "Required tool '$tool' is not installed." "ERROR"
         exit 1
@@ -191,6 +191,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
         exit 1
     fi
 fi
+CONFIG_FILE=$(cd "$(dirname "$CONFIG_FILE")" && pwd)/$(basename "$CONFIG_FILE")
+export TRANSLATOR_CONFIG_FILE="$CONFIG_FILE"
 log "Using configuration file: $CONFIG_FILE"
 
 # Helper function to parse values from config.yaml robustly using yq
@@ -454,6 +456,10 @@ stage_and_submit_batch() {
     local branch="$1"
     local commit_msg="$2"
     local pr_title="$3"
+    local app_root="/app"
+    if [ ! -d "$app_root" ]; then
+        app_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    fi
 
     git checkout -B "$branch" "${REMOTE}/${DEFAULT_BRANCH}"
 
@@ -465,10 +471,44 @@ stage_and_submit_batch() {
         fi
     done
 
+    local report_dir="$app_root/logs"
+    local QUALITY_REPORT_JSON="$report_dir/translation_quality_report-${branch}.json"
+    local QUALITY_REPORT_MD="$report_dir/translation_quality_report-${branch}.md"
+    local VALIDATION_SUMMARY="$report_dir/translation_validation_summary.json"
+    local QUALITY_GATE_EXIT=0
+    set +e
+    (
+        cd "$app_root" && \
+        python3 -m src.translation_quality_gate \
+            --repo-root "$TARGET_PROJECT_ROOT" \
+            --input-folder "$ABSOLUTE_INPUT_FOLDER" \
+            --config "$CONFIG_FILE" \
+            --validation-summary "$VALIDATION_SUMMARY" \
+            --output-json "$QUALITY_REPORT_JSON" \
+            --output-markdown "$QUALITY_REPORT_MD" \
+            --changed-files "${BATCH_FILES[@]}"
+    )
+    QUALITY_GATE_EXIT=$?
+    set -e
+    if [ ! -s "$QUALITY_REPORT_JSON" ]; then
+        log "Translation quality gate did not produce a JSON report for branch '$branch'." "ERROR"
+        return 1
+    fi
+    if [ "$QUALITY_GATE_EXIT" -ne 0 ]; then
+        if jq -e '.blocking == true' "$QUALITY_REPORT_JSON" >/dev/null; then
+            log "Translation quality gate found blocking issues. Creating PR with failing status." "WARNING"
+        else
+            log "Translation quality gate failed unexpectedly." "ERROR"
+            return 1
+        fi
+    fi
+
     if ! commit_staged_changes "$commit_msg"; then
         log "Failed to commit changes for branch '$branch'." "ERROR"
         return 1
     fi
+    local commit_sha
+    commit_sha=$(git rev-parse HEAD)
 
     if ! git push origin "$branch"; then
         log "Failed to push branch '$branch' to origin." "ERROR"
@@ -484,8 +524,11 @@ stage_and_submit_batch() {
 
 This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT}\` fork and targets the \`$TARGET_BRANCH_FOR_PR\` branch on \`$UPSTREAM_REPO_NAME\`."
 
-    local SKIPPED_FILES_REPORT="/app/logs/skipped_files_report.log"
-    if [ -s "$SKIPPED_FILES_REPORT" ]; then
+    local SKIPPED_FILES_REPORT="$report_dir/skipped_files_report.log"
+    if [ -s "$QUALITY_REPORT_MD" ]; then
+        log "Found quality gate report. Prepending to PR description."
+        PR_BODY=$(printf "%s\n\n%s" "$(cat "$QUALITY_REPORT_MD")" "$PR_BODY")
+    elif [ -s "$SKIPPED_FILES_REPORT" ]; then
         log "Found skipped files report. Prepending to PR description."
         PR_BODY=$(printf "%s\n\n%s" "$(cat "$SKIPPED_FILES_REPORT")" "$PR_BODY")
     fi
@@ -503,6 +546,20 @@ This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT
         log "Error: Failed to create pull request. Check gh cli auth and GITHUB_TOKEN." "ERROR"
         return 1
     fi
+
+    local quality_state
+    local quality_description
+    quality_state=$(jq -r '.status_state // "success"' "$QUALITY_REPORT_JSON")
+    quality_description=$(jq -r '.status_description // "Translation quality gate passed."' "$QUALITY_REPORT_JSON" | cut -c1-140)
+    if ! gh api "repos/$UPSTREAM_REPO_NAME/statuses/$commit_sha" \
+        -f state="$quality_state" \
+        -f context="translation-quality-gate" \
+        -f description="$quality_description" \
+        -f target_url="$PR_URL" >/dev/null; then
+        log "Failed to publish translation-quality-gate commit status." "ERROR"
+        return 1
+    fi
+    log "Published translation-quality-gate status: $quality_state"
 }
 
 # Check specifically for changes in translation files


### PR DESCRIPTION
## Summary
- Add a generated-PR quality gate that detects unexpected source-identical changed values in non-source locale files.
- Ignore expected identical values such as exact glossary terms, enum-like uppercase keys, URLs, placeholders, and non-linguistic tokens.
- Include validation metrics in generated PR bodies: source-identical counts, reverted keys, control-character findings, placeholder failures, and pipeline warnings.
- Publish a `translation-quality-gate` commit status for every generated translation PR, failing it when thresholds or pipeline warnings require manual review.

## Threshold Calibration
- Current `bisq2` baseline: 8,227 / 156,546 raw source-identical values, about 5.3%.
- Current `bisq-mobile` baseline: 3,435 / 34,788 raw source-identical values, about 9.9%, with payment-method files intentionally much higher.
- Known bad `bisq-mobile#1458`: 538 / 568 changed values were source-identical, about 94.7%.
- Configured default: block from 5 unexpected values when ratio exceeds 30%, or above 20 unexpected values, after expected-identical exclusions.

## Validation
- `./venv/bin/pytest` => 150 passed
- `bash -n update-translations.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added translation quality gate to validate translations against configurable thresholds and block pull requests when standards aren't met.
  * Translation validation reports are now generated and published as GitHub PR status updates.

* **Configuration**
  * Quality gate settings added to control validation thresholds, blocking behavior, and acceptable translation patterns.

* **Tests**
  * Added comprehensive test coverage for translation quality gate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->