### PR TITLE
Harden translation semantic quality gate

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -63,6 +63,40 @@ quality_gate:
   source_identical_max_count: 20
   source_identical_max_ratio: 0.30
   block_on_pipeline_warnings: true
+  block_on_semantic_qa_findings: true
+  block_on_semantic_qa_warnings: false
+  semantic_qa_audit_scope: "changed"
+
+# Optional independent AI semantic reviewer. It reviews only changed keys and
+# appends structured findings to logs/translation_validation_summary.json.
+semantic_review:
+  enabled: true
+  model: "gpt-5.4-mini"
+
+# Deterministic semantic rules learned from reviewed translation PRs.
+semantic_quality_rules:
+  - id: "trade-history-traders-label"
+    message: "Fully localize the Trade Details traders/role label; do not retain the English term 'Traders'."
+    locales: ["*"]
+    excluded_locales: ["en", "pcm"]
+    keys: ["mobile.tradeHistory.details.tradersAndRole"]
+    forbidden_target_regex: '\bTraders\b'
+    severity: "error"
+    source: "bisq-mobile#1478 CodeRabbit"
+  - id: "af-trade-history-counts-trades"
+    message: "Afrikaans trade-count labels must count trades, not traders."
+    locales: ["af_ZA"]
+    keys: ["mobile.tradeHistory.count.many", "mobile.tradeHistory.count.filtered"]
+    forbidden_target_regex: '\bhandelaars\b'
+    severity: "error"
+    source: "bisq-mobile#1478 CodeRabbit"
+  - id: "vi-clearnet-clear-network-address"
+    message: "Vietnamese networkAddress.clear must describe a clearnet/open network address, not a delete action."
+    locales: ["vi"]
+    keys: ["mobile.tradeHistory.details.networkAddress.clear"]
+    forbidden_target_regex: '^xóa\b'
+    severity: "error"
+    source: "bisq-mobile#1478 CodeRabbit"
 
 # Optional persistent per-key hash ledger used to detect source changes
 # without reprocessing already-stable translations.
@@ -83,6 +117,8 @@ supported_locales:
     name: "German"
   - code: "es"
     name: "Spanish"
+  - code: "fr"
+    name: "French"
   - code: "id"
     name: "Indonesian"
   - code: "it"
@@ -95,6 +131,8 @@ supported_locales:
     name: "Russian"
   - code: "af_ZA"
     name: "Afrikaans"
+  - code: "vi"
+    name: "Vietnamese"
 
 # (Optional) Language-specific style and formatting rules to be injected into the AI prompt.
 # Use this to guide the AI on tone, casing, terminology, and other stylistic conventions.
@@ -110,6 +148,10 @@ style_rules:
   es:
     - "When referring to 'billetera' (wallet), use feminine pronouns (e.g., 'Configúrala', 'restáurala')."
     - "Ensure questions that open with '¿' are properly closed with '?'."
+    - "Fully localize mobile.tradeHistory.details.tradersAndRole; use 'Comerciantes / Rol', not 'Traders / Rol'."
+  fr:
+    - "Use formal 'vous' form for user address."
+    - "Fully localize mobile.tradeHistory.details.tradersAndRole; use 'Commerçants / Rôle', not 'Traders / Rôle'."
   id:
     - "Prefer natural Indonesian phrasing over literal calques; for 'How it works', use 'Cara kerjanya' rather than 'Cara kerja ini'."
   pcm:
@@ -121,6 +163,9 @@ style_rules:
   af_ZA:
     - "Use standard Afrikaans grammar and spelling throughout."
     - "Preserve the Afrikaans indefinite article apostrophe: write 'n, including in parenthesized phrases such as ('n per-installasie identifiseerder), never (n ...)."
+    - "For mobile.tradeHistory.count.many and mobile.tradeHistory.count.filtered, count trades ('handel'), not traders ('handelaars')."
+  vi:
+    - "For mobile.tradeHistory.details.networkAddress.clear, 'clear' means clearnet/open network, not delete/clear action; use 'Địa chỉ mạng công khai: {0}'."
   it: []
   pt_BR: []
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -41,3 +41,7 @@ TARGET_BRANCH_FOR_PR=main
 # Maximum changed translation files per generated PR.
 # CodeRabbit reviews up to 150 files; lower this only if reviewers prefer smaller PRs.
 MAX_FILES_PER_PR=150
+
+# Translation quality gate audit scope: changed or all.
+# Keep "changed" for normal runs; use "all" in scheduled audit jobs.
+TRANSLATION_QUALITY_AUDIT_SCOPE=changed

--- a/docker/config.docker.yaml
+++ b/docker/config.docker.yaml
@@ -13,6 +13,35 @@ quality_gate:
   source_identical_max_count: 20
   source_identical_max_ratio: 0.30
   block_on_pipeline_warnings: true
+  block_on_semantic_qa_findings: true
+  block_on_semantic_qa_warnings: false
+  semantic_qa_audit_scope: "changed"
+semantic_review:
+  enabled: true
+  model: "gpt-5.4-mini"
+semantic_quality_rules:
+  - id: "trade-history-traders-label"
+    message: "Fully localize the Trade Details traders/role label; do not retain the English term 'Traders'."
+    locales: ["*"]
+    excluded_locales: ["en", "pcm"]
+    keys: ["mobile.tradeHistory.details.tradersAndRole"]
+    forbidden_target_regex: '\bTraders\b'
+    severity: "error"
+    source: "bisq-mobile#1478 CodeRabbit"
+  - id: "af-trade-history-counts-trades"
+    message: "Afrikaans trade-count labels must count trades, not traders."
+    locales: ["af_ZA"]
+    keys: ["mobile.tradeHistory.count.many", "mobile.tradeHistory.count.filtered"]
+    forbidden_target_regex: '\bhandelaars\b'
+    severity: "error"
+    source: "bisq-mobile#1478 CodeRabbit"
+  - id: "vi-clearnet-clear-network-address"
+    message: "Vietnamese networkAddress.clear must describe a clearnet/open network address, not a delete action."
+    locales: ["vi"]
+    keys: ["mobile.tradeHistory.details.networkAddress.clear"]
+    forbidden_target_regex: '^xóa\b'
+    severity: "error"
+    source: "bisq-mobile#1478 CodeRabbit"
 supported_locales:
   - code: "cs"
     name: "Czech"
@@ -145,6 +174,7 @@ style_rules:
   es:
     - "When referring to 'billetera' (wallet), use feminine pronouns (e.g., 'Configúrala', 'restáurala')."
     - "Ensure questions that open with '¿' are properly closed with '?'."
+    - "Fully localize mobile.tradeHistory.details.tradersAndRole; use 'Comerciantes / Rol', not 'Traders / Rol'."
   et:
     - "Use standard Estonian throughout."
     - "Maintain formal and polite tone appropriate for financial applications."
@@ -154,6 +184,7 @@ style_rules:
   fr:
     - "Use formal 'vous' form for user address."
     - "When referring to 'portefeuille' (wallet), use masculine pronouns."
+    - "Fully localize mobile.tradeHistory.details.tradersAndRole; use 'Commerçants / Rôle', not 'Traders / Rôle'."
   ga:
     - "Use standard Irish (Gaeilge) throughout."
     - "Maintain formal and polite tone appropriate for financial applications."
@@ -299,6 +330,7 @@ style_rules:
   af_ZA:
     - "Use standard Afrikaans grammar and spelling throughout."
     - "Preserve the Afrikaans indefinite article apostrophe: write 'n, including in parenthesized phrases such as ('n per-installasie identifiseerder), never (n ...)."
+    - "For mobile.tradeHistory.count.many and mobile.tradeHistory.count.filtered, count trades ('handel'), not traders ('handelaars')."
   am:
     - "Use Ge'ez/Ethiopic script (Amharic alphabet) throughout."
     - "Maintain formal and polite tone appropriate for financial applications."
@@ -397,6 +429,7 @@ style_rules:
     - "Use formal address forms and respectful language for user interactions."
     - "Technical crypto terms may be transliterated or kept in English when no established Vietnamese term exists."
     - "Ensure consistent transliteration and terminology across the application."
+    - "For mobile.tradeHistory.details.networkAddress.clear, 'clear' means clearnet/open network, not delete/clear action; use 'Địa chỉ mạng công khai: {0}'."
   pt_BR: []
   zh-Hans:
     - "Use Simplified Chinese characters (mainland China standard)."

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -190,6 +190,19 @@ def _precompute_style_rules(style_rules: Dict[str, List[str]], language_codes: D
     return precomputed_style_rules_text
 
 
+def _as_bool(value: Any, default: bool) -> bool:
+    """Parse config booleans without treating non-empty strings as true."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    return default
+
+
 def _create_openai_client(dry_run: bool, logger: logging.Logger) -> Optional[AsyncOpenAI]:
     """Create OpenAI client if not in dry run mode with enhanced error handling."""
     if dry_run:
@@ -259,8 +272,14 @@ def load_app_config() -> AppConfig:
         source_identical_max_count=int(quality_gate_config.get('source_identical_max_count', 20)),
         source_identical_max_ratio=float(quality_gate_config.get('source_identical_max_ratio', 0.30)),
         block_on_pipeline_warnings=bool(quality_gate_config.get('block_on_pipeline_warnings', True)),
-        block_on_semantic_qa_findings=bool(quality_gate_config.get('block_on_semantic_qa_findings', True)),
-        block_on_semantic_qa_warnings=bool(quality_gate_config.get('block_on_semantic_qa_warnings', False)),
+        block_on_semantic_qa_findings=_as_bool(
+            quality_gate_config.get('block_on_semantic_qa_findings', True),
+            default=True,
+        ),
+        block_on_semantic_qa_warnings=_as_bool(
+            quality_gate_config.get('block_on_semantic_qa_warnings', False),
+            default=False,
+        ),
         semantic_qa_audit_scope=str(quality_gate_config.get('semantic_qa_audit_scope', 'changed')),
     )
 

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -20,6 +20,9 @@ class QualityGateConfig:
     source_identical_max_count: int = 20
     source_identical_max_ratio: float = 0.30
     block_on_pipeline_warnings: bool = True
+    block_on_semantic_qa_findings: bool = True
+    block_on_semantic_qa_warnings: bool = False
+    semantic_qa_audit_scope: str = "changed"
 
 
 @dataclass
@@ -256,6 +259,9 @@ def load_app_config() -> AppConfig:
         source_identical_max_count=int(quality_gate_config.get('source_identical_max_count', 20)),
         source_identical_max_ratio=float(quality_gate_config.get('source_identical_max_ratio', 0.30)),
         block_on_pipeline_warnings=bool(quality_gate_config.get('block_on_pipeline_warnings', True)),
+        block_on_semantic_qa_findings=bool(quality_gate_config.get('block_on_semantic_qa_findings', True)),
+        block_on_semantic_qa_warnings=bool(quality_gate_config.get('block_on_semantic_qa_warnings', False)),
+        semantic_qa_audit_scope=str(quality_gate_config.get('semantic_qa_audit_scope', 'changed')),
     )
 
     # Holistic review chunk size with environment override

--- a/src/semantic_quality.py
+++ b/src/semantic_quality.py
@@ -296,18 +296,18 @@ def evaluate_semantic_rules(
             if rule.source_regex and not _regex_matches(rule.source_regex, change.source_value):
                 continue
 
-            matched = False
+            violation = False
             if rule.forbidden_target_regex and _regex_matches(
                 rule.forbidden_target_regex,
                 change.new_value,
             ):
-                matched = True
+                violation = True
             if rule.required_target_regex and not _regex_matches(
                 rule.required_target_regex,
                 change.new_value,
             ):
-                matched = True
-            if not matched:
+                violation = True
+            if not violation:
                 continue
 
             findings.append(

--- a/src/semantic_quality.py
+++ b/src/semantic_quality.py
@@ -1,0 +1,448 @@
+"""Semantic translation quality policy evaluation."""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from src.properties_parser import parse_properties_file
+
+
+@dataclass(frozen=True)
+class TranslationChange:
+    file: str
+    locale_code: str
+    key: str
+    source_value: Optional[str]
+    old_value: Optional[str]
+    new_value: str
+
+
+@dataclass(frozen=True)
+class SemanticRule:
+    id: str
+    message: str
+    locales: Tuple[str, ...] = ("*",)
+    excluded_locales: Tuple[str, ...] = ()
+    keys: Tuple[str, ...] = ("*",)
+    severity: str = "error"
+    forbidden_target_regex: Optional[str] = None
+    required_target_regex: Optional[str] = None
+    source_regex: Optional[str] = None
+    source: str = "semantic-rule"
+
+
+@dataclass(frozen=True)
+class SemanticFinding:
+    file: str
+    key: str
+    value: str
+    reason: str
+    severity: str
+    rule_id: str
+    source: str
+    suggested_value: Optional[str] = None
+
+    def to_example(self) -> Dict[str, str]:
+        result = {
+            "file": self.file,
+            "key": self.key,
+            "value": self.value,
+            "reason": self.reason,
+            "severity": self.severity,
+            "rule_id": self.rule_id,
+            "source": self.source,
+        }
+        if self.suggested_value:
+            result["suggested_value"] = self.suggested_value
+        return result
+
+
+@dataclass
+class SemanticQAStats:
+    findings_count: int = 0
+    errors_count: int = 0
+    warnings_count: int = 0
+    examples: List[Dict[str, str]] = None
+
+    def __post_init__(self) -> None:
+        if self.examples is None:
+            self.examples = []
+
+    @classmethod
+    def from_findings(
+        cls,
+        findings: Sequence[SemanticFinding],
+        examples_limit: int = 10,
+    ) -> "SemanticQAStats":
+        return cls(
+            findings_count=len(findings),
+            errors_count=sum(1 for finding in findings if finding.severity == "error"),
+            warnings_count=sum(1 for finding in findings if finding.severity == "warning"),
+            examples=[finding.to_example() for finding in findings[:examples_limit]],
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+_SOURCE_WORD_RE = re.compile(r"[A-Za-z][A-Za-z'-]{6,}")
+_SOURCE_WORD_ALLOWLIST = {
+    "clearnet",
+    "routing",
+}
+_SOURCE_WORD_STOPWORDS = {
+    "another",
+    "because",
+    "between",
+    "through",
+    "without",
+}
+
+
+def normalize_value(value: Optional[str]) -> str:
+    return (value or "").strip()
+
+
+def source_filename_for_locale_file(filename: str, locale_codes: Sequence[str]) -> Optional[str]:
+    if not filename.endswith(".properties"):
+        return None
+    base = filename[: -len(".properties")]
+    for code in sorted(locale_codes, key=len, reverse=True):
+        suffix = f"_{code}"
+        if base.endswith(suffix):
+            return f"{base[:-len(suffix)]}.properties"
+    return None
+
+
+def locale_code_for_locale_file(filename: str, locale_codes: Sequence[str]) -> Optional[str]:
+    if not filename.endswith(".properties"):
+        return None
+    base = filename[: -len(".properties")]
+    for code in sorted(locale_codes, key=len, reverse=True):
+        if base.endswith(f"_{code}"):
+            return code
+    return None
+
+
+def _extract_properties_entry(diff_line: str) -> Optional[Tuple[str, str]]:
+    stripped = diff_line.strip()
+    if not stripped or stripped.startswith(("#", "!")):
+        return None
+
+    escaped = False
+    for index, character in enumerate(diff_line):
+        if character == "\\":
+            escaped = not escaped
+            continue
+        if character in ("=", ":") and not escaped:
+            key = diff_line[:index].strip()
+            value = diff_line[index + 1 :].strip()
+            return (key, value) if key else None
+        escaped = False
+    return None
+
+
+def iter_added_properties_entries(diff_text: str) -> Iterable[Tuple[str, str, str]]:
+    for change in iter_translation_changes_from_diff(
+        diff_text=diff_text,
+        repo_root=".",
+        input_folder=".",
+        locale_codes=[],
+        hydrate_source=False,
+    ):
+        yield change.file, change.key, change.new_value
+
+
+def _relpath(path: str, start: str) -> str:
+    try:
+        return os.path.relpath(path, start)
+    except ValueError:
+        return path
+
+
+def iter_translation_changes_from_diff(
+    diff_text: str,
+    repo_root: str,
+    input_folder: str,
+    locale_codes: Sequence[str],
+    hydrate_source: bool = True,
+) -> Iterable[TranslationChange]:
+    repo_root_path = Path(repo_root)
+    input_folder_path = Path(input_folder)
+    source_cache: Dict[Path, Dict[str, str]] = {}
+    current_file: Optional[str] = None
+    removed_values: Dict[str, str] = {}
+
+    for line in diff_text.splitlines():
+        if line.startswith("+++ /dev/null"):
+            current_file = None
+            removed_values = {}
+            continue
+        if line.startswith("+++ b/"):
+            current_file = line[len("+++ b/") :]
+            removed_values = {}
+            continue
+        if not current_file or not current_file.endswith(".properties"):
+            continue
+        if line.startswith("---"):
+            continue
+        if line.startswith("-"):
+            entry = _extract_properties_entry(line[1:])
+            if entry:
+                key, value = entry
+                removed_values[key] = value
+            continue
+        if not line.startswith("+"):
+            continue
+
+        entry = _extract_properties_entry(line[1:])
+        if not entry:
+            continue
+        key, target_value = entry
+        changed_path = repo_root_path / current_file
+        locale_code = locale_code_for_locale_file(changed_path.name, locale_codes) or ""
+        source_value = None
+
+        if hydrate_source and locale_code:
+            source_name = source_filename_for_locale_file(changed_path.name, locale_codes)
+            source_path = changed_path.with_name(source_name) if source_name else None
+            if source_path and source_path.exists():
+                if source_path not in source_cache:
+                    _, source_translations = parse_properties_file(str(source_path))
+                    source_cache[source_path] = source_translations
+                source_value = source_cache[source_path].get(key)
+
+        yield TranslationChange(
+            file=_relpath(str(changed_path), str(input_folder_path)),
+            locale_code=locale_code,
+            key=key,
+            source_value=source_value,
+            old_value=removed_values.pop(key, None),
+            new_value=target_value,
+        )
+
+
+def load_semantic_rules(raw_rules: Iterable[Dict[str, Any]]) -> List[SemanticRule]:
+    rules: List[SemanticRule] = []
+    for raw_rule in raw_rules or []:
+        if not isinstance(raw_rule, dict):
+            continue
+        rule_id = str(raw_rule.get("id", "")).strip()
+        message = str(raw_rule.get("message", "")).strip()
+        if not rule_id or not message:
+            continue
+        severity = str(raw_rule.get("severity", "error")).strip().lower()
+        if severity not in {"error", "warning"}:
+            severity = "error"
+        rules.append(
+            SemanticRule(
+                id=rule_id,
+                message=message,
+                locales=_as_tuple(raw_rule.get("locales", ["*"])),
+                excluded_locales=_as_tuple(raw_rule.get("excluded_locales", []), default=()),
+                keys=_as_tuple(raw_rule.get("keys", ["*"])),
+                severity=severity,
+                forbidden_target_regex=_optional_string(raw_rule.get("forbidden_target_regex")),
+                required_target_regex=_optional_string(raw_rule.get("required_target_regex")),
+                source_regex=_optional_string(raw_rule.get("source_regex")),
+                source=str(raw_rule.get("source", "semantic-rule")),
+            )
+        )
+    return rules
+
+
+def _as_tuple(value: Any, default: Tuple[str, ...] = ("*",)) -> Tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Iterable):
+        result = tuple(str(item) for item in value if str(item).strip())
+        return result or default
+    return default
+
+
+def _optional_string(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _matches_any(value: str, patterns: Sequence[str]) -> bool:
+    return any(pattern == "*" or fnmatch.fnmatchcase(value, pattern) for pattern in patterns)
+
+
+def _regex_matches(pattern: str, value: Optional[str]) -> bool:
+    return re.search(pattern, value or "", re.IGNORECASE) is not None
+
+
+def evaluate_semantic_rules(
+    changes: Iterable[TranslationChange],
+    rules: Sequence[SemanticRule],
+) -> List[SemanticFinding]:
+    findings: List[SemanticFinding] = []
+    for change in changes:
+        for rule in rules:
+            if not _matches_any(change.locale_code, rule.locales):
+                continue
+            if rule.excluded_locales and _matches_any(change.locale_code, rule.excluded_locales):
+                continue
+            if not _matches_any(change.key, rule.keys):
+                continue
+            if rule.source_regex and not _regex_matches(rule.source_regex, change.source_value):
+                continue
+
+            matched = False
+            if rule.forbidden_target_regex and _regex_matches(
+                rule.forbidden_target_regex,
+                change.new_value,
+            ):
+                matched = True
+            if rule.required_target_regex and not _regex_matches(
+                rule.required_target_regex,
+                change.new_value,
+            ):
+                matched = True
+            if not matched:
+                continue
+
+            findings.append(
+                SemanticFinding(
+                    file=change.file,
+                    key=change.key,
+                    value=change.new_value,
+                    reason=rule.message,
+                    severity=rule.severity,
+                    rule_id=rule.id,
+                    source=rule.source,
+                )
+            )
+    return findings
+
+
+def evaluate_retained_source_words(
+    changes: Iterable[TranslationChange],
+    brand_glossary: Iterable[str],
+) -> List[SemanticFinding]:
+    findings: List[SemanticFinding] = []
+    for change in changes:
+        if change.locale_code in {"en", "pcm"}:
+            continue
+        if not change.source_value:
+            continue
+        if normalize_value(change.source_value) == normalize_value(change.new_value):
+            continue
+        retained_words = _retained_source_words(
+            source_value=change.source_value,
+            target_value=change.new_value,
+            brand_glossary=brand_glossary,
+        )
+        if not retained_words:
+            continue
+        findings.append(
+            SemanticFinding(
+                file=change.file,
+                key=change.key,
+                value=change.new_value,
+                reason="Target may retain untranslated source term(s): "
+                f"{', '.join(retained_words[:3])}.",
+                severity="warning",
+                rule_id="retained-source-word",
+                source="heuristic",
+            )
+        )
+    return findings
+
+
+def _contains_word(value: str, word: str) -> bool:
+    return re.search(rf"(?<![A-Za-z]){re.escape(word)}(?![A-Za-z])", value, re.IGNORECASE) is not None
+
+
+def _glossary_words(brand_glossary: Iterable[str]) -> set[str]:
+    words: set[str] = set()
+    for term in brand_glossary:
+        words.update(word.casefold() for word in _SOURCE_WORD_RE.findall(str(term)))
+    return words
+
+
+def _retained_source_words(
+    source_value: str,
+    target_value: str,
+    brand_glossary: Iterable[str],
+) -> List[str]:
+    glossary_words = _glossary_words(brand_glossary)
+    retained: List[str] = []
+    seen: set[str] = set()
+
+    for source_word in _SOURCE_WORD_RE.findall(source_value):
+        normalized = source_word.casefold()
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        if normalized in glossary_words:
+            continue
+        if normalized in _SOURCE_WORD_ALLOWLIST:
+            continue
+        if normalized in _SOURCE_WORD_STOPWORDS:
+            continue
+        if _contains_word(target_value, source_word):
+            retained.append(source_word)
+
+    return retained
+
+
+def analyze_translation_changes(
+    changes: Sequence[TranslationChange],
+    semantic_rules: Sequence[SemanticRule],
+    brand_glossary: Iterable[str],
+    examples_limit: int = 10,
+) -> SemanticQAStats:
+    findings = evaluate_semantic_rules(changes, semantic_rules)
+    findings.extend(evaluate_retained_source_words(changes, brand_glossary))
+    return SemanticQAStats.from_findings(findings, examples_limit=examples_limit)
+
+
+def analyze_all_translation_entries(
+    repo_root: str,
+    input_folder: str,
+    locale_codes: Sequence[str],
+    brand_glossary: Iterable[str],
+    semantic_rules: Sequence[SemanticRule],
+    examples_limit: int = 10,
+) -> SemanticQAStats:
+    input_folder_path = Path(input_folder)
+    changes: List[TranslationChange] = []
+
+    for target_path in sorted(input_folder_path.glob("*.properties")):
+        locale_code = locale_code_for_locale_file(target_path.name, locale_codes)
+        if not locale_code:
+            continue
+        source_name = source_filename_for_locale_file(target_path.name, locale_codes)
+        source_path = target_path.with_name(source_name) if source_name else None
+        if not source_path or not source_path.exists():
+            continue
+        _, source_translations = parse_properties_file(str(source_path))
+        _, target_translations = parse_properties_file(str(target_path))
+
+        for key, target_value in target_translations.items():
+            changes.append(
+                TranslationChange(
+                    file=_relpath(str(target_path), str(input_folder_path)),
+                    locale_code=locale_code,
+                    key=key,
+                    source_value=source_translations.get(key),
+                    old_value=None,
+                    new_value=target_value,
+                )
+            )
+
+    return analyze_translation_changes(
+        changes=changes,
+        semantic_rules=semantic_rules,
+        brand_glossary=brand_glossary,
+        examples_limit=examples_limit,
+    )

--- a/src/translation_quality_gate.py
+++ b/src/translation_quality_gate.py
@@ -14,6 +14,18 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 import yaml
 
 from src.properties_parser import parse_properties_file
+from src.semantic_quality import (
+    SemanticFinding,
+    SemanticQAStats,
+    SemanticRule,
+    analyze_all_translation_entries,
+    analyze_translation_changes,
+    iter_added_properties_entries as _iter_added_properties_entries,
+    iter_translation_changes_from_diff,
+    load_semantic_rules,
+    normalize_value,
+    source_filename_for_locale_file,
+)
 from src.translation_validator import find_disallowed_control_characters
 
 
@@ -25,6 +37,9 @@ class QualityGateConfig:
     source_identical_max_count: int = 20
     source_identical_max_ratio: float = 0.30
     block_on_pipeline_warnings: bool = True
+    block_on_semantic_qa_findings: bool = True
+    block_on_semantic_qa_warnings: bool = False
+    semantic_qa_audit_scope: str = "changed"
 
 
 @dataclass
@@ -58,10 +73,6 @@ _TOKEN_PATTERNS = [
 _ENUM_LIKE_KEY = re.compile(r"^[A-Z0-9_.$-]+$")
 
 
-def normalize_value(value: str) -> str:
-    return (value or "").strip()
-
-
 def is_expected_source_identical(key: str, value: str, brand_glossary: Iterable[str]) -> bool:
     """Return true for values that are commonly and legitimately untranslated."""
     normalized = normalize_value(value)
@@ -75,54 +86,6 @@ def is_expected_source_identical(key: str, value: str, brand_glossary: Iterable[
     if not any(character.isalpha() for character in normalized):
         return True
     return any(pattern.match(normalized) for pattern in _TOKEN_PATTERNS)
-
-
-def source_filename_for_locale_file(filename: str, locale_codes: Sequence[str]) -> Optional[str]:
-    if not filename.endswith(".properties"):
-        return None
-    base = filename[: -len(".properties")]
-    for code in sorted(locale_codes, key=len, reverse=True):
-        suffix = f"_{code}"
-        if base.endswith(suffix):
-            return f"{base[:-len(suffix)]}.properties"
-    return None
-
-
-def _extract_properties_entry(diff_line: str) -> Optional[Tuple[str, str]]:
-    stripped = diff_line.strip()
-    if not stripped or stripped.startswith(("#", "!")):
-        return None
-
-    escaped = False
-    for index, character in enumerate(diff_line):
-        if character == "\\":
-            escaped = not escaped
-            continue
-        if character in ("=", ":") and not escaped:
-            key = diff_line[:index].strip()
-            value = diff_line[index + 1 :].strip()
-            return (key, value) if key else None
-        escaped = False
-    return None
-
-
-def _iter_added_properties_entries(diff_text: str) -> Iterable[Tuple[str, str, str]]:
-    current_file: Optional[str] = None
-    for line in diff_text.splitlines():
-        if line.startswith("+++ b/"):
-            current_file = line[len("+++ b/") :]
-            continue
-        if line.startswith("+++ /dev/null"):
-            current_file = None
-            continue
-        if not line.startswith("+") or line.startswith("+++"):
-            continue
-        if not current_file or not current_file.endswith(".properties"):
-            continue
-        entry = _extract_properties_entry(line[1:])
-        if entry:
-            key, value = entry
-            yield current_file, key, value
 
 
 def _relpath(path: str, start: str) -> str:
@@ -207,7 +170,35 @@ def analyze_source_identical_changes(
     return stats
 
 
-def load_quality_gate_config(config_path: str) -> Tuple[QualityGateConfig, List[str], List[str]]:
+def analyze_semantic_qa_changes(
+    diff_text: str,
+    repo_root: str,
+    input_folder: str,
+    locale_codes: Sequence[str],
+    brand_glossary: Iterable[str] = (),
+    semantic_rules: Sequence[SemanticRule] = (),
+    examples_limit: int = 10,
+) -> SemanticQAStats:
+    """Scan changed translations for configured semantic regressions."""
+    changes = list(
+        iter_translation_changes_from_diff(
+            diff_text=diff_text,
+            repo_root=repo_root,
+            input_folder=input_folder,
+            locale_codes=locale_codes,
+        )
+    )
+    return analyze_translation_changes(
+        changes=changes,
+        semantic_rules=semantic_rules,
+        brand_glossary=brand_glossary,
+        examples_limit=examples_limit,
+    )
+
+
+def load_quality_gate_config(
+    config_path: str,
+) -> Tuple[QualityGateConfig, List[str], List[str], List[SemanticRule]]:
     with open(config_path, "r", encoding="utf-8") as file:
         raw_config = yaml.safe_load(file) or {}
 
@@ -226,9 +217,19 @@ def load_quality_gate_config(config_path: str) -> Tuple[QualityGateConfig, List[
             source_identical_max_count=int(quality_gate.get("source_identical_max_count", 20)),
             source_identical_max_ratio=float(quality_gate.get("source_identical_max_ratio", 0.30)),
             block_on_pipeline_warnings=bool(quality_gate.get("block_on_pipeline_warnings", True)),
+            block_on_semantic_qa_findings=bool(
+                quality_gate.get("block_on_semantic_qa_findings", True)
+            ),
+            block_on_semantic_qa_warnings=bool(
+                quality_gate.get("block_on_semantic_qa_warnings", False)
+            ),
+            semantic_qa_audit_scope=str(
+                quality_gate.get("semantic_qa_audit_scope", "changed")
+            ),
         ),
         locales,
         brand_glossary,
+        load_semantic_rules(raw_config.get("semantic_quality_rules", [])),
     )
 
 
@@ -308,8 +309,59 @@ def _filter_pipeline_warnings(
     ]
 
 
+def _semantic_review_stats_from_validation(
+    validation_summary: Dict[str, Any],
+    changed_files: Sequence[str],
+    input_folder: str,
+) -> SemanticQAStats:
+    changed_relative_files = _changed_files_relative_to_input(changed_files, input_folder)
+    findings: List[SemanticFinding] = []
+    for raw_finding in validation_summary.get("semantic_review_findings", []):
+        if not isinstance(raw_finding, dict):
+            continue
+        filename = str(raw_finding.get("file", ""))
+        if changed_relative_files and not _file_matches_changed_files(filename, changed_relative_files):
+            continue
+        severity = str(raw_finding.get("severity", "warning")).lower()
+        if severity not in {"error", "warning"}:
+            severity = "warning"
+        findings.append(
+            SemanticFinding(
+                file=filename,
+                key=str(raw_finding.get("key", "")),
+                value=str(raw_finding.get("value", raw_finding.get("new_value", ""))),
+                reason=str(raw_finding.get("reason", "")),
+                severity=severity,
+                rule_id=str(raw_finding.get("rule_id", "ai-review")),
+                source=str(raw_finding.get("source", "ai-review")),
+                suggested_value=(
+                    str(raw_finding["suggested_value"])
+                    if raw_finding.get("suggested_value")
+                    else None
+                ),
+            )
+        )
+    return SemanticQAStats.from_findings(findings)
+
+
+def _merge_semantic_stats(
+    first: Optional[SemanticQAStats],
+    second: Optional[SemanticQAStats],
+    examples_limit: int = 10,
+) -> SemanticQAStats:
+    first = first or SemanticQAStats()
+    second = second or SemanticQAStats()
+    return SemanticQAStats(
+        findings_count=first.findings_count + second.findings_count,
+        errors_count=first.errors_count + second.errors_count,
+        warnings_count=first.warnings_count + second.warnings_count,
+        examples=[*first.examples, *second.examples][:examples_limit],
+    )
+
+
 def build_quality_gate_report(
     source_stats: SourceIdenticalStats,
+    semantic_stats: Optional[SemanticQAStats],
     validation_summary: Dict[str, Any],
     changed_files: Sequence[str],
     input_folder: str,
@@ -318,6 +370,10 @@ def build_quality_gate_report(
     validation_totals = _aggregate_validation(validation_summary, changed_files, input_folder)
     pipeline_warnings = _filter_pipeline_warnings(validation_summary, changed_files, input_folder)
     blocking_reasons: List[str] = []
+    semantic_stats = _merge_semantic_stats(
+        semantic_stats,
+        _semantic_review_stats_from_validation(validation_summary, changed_files, input_folder),
+    )
 
     source_identical_blocking = (
         source_stats.unexpected_source_identical_count >= config.source_identical_min_block_count
@@ -334,6 +390,11 @@ def build_quality_gate_report(
     if config.block_on_pipeline_warnings and pipeline_warnings:
         blocking_reasons.append("Translation pipeline warnings require manual resolution.")
 
+    if config.block_on_semantic_qa_findings and semantic_stats.errors_count:
+        blocking_reasons.append("Semantic translation QA findings require manual resolution.")
+    elif config.block_on_semantic_qa_warnings and semantic_stats.warnings_count:
+        blocking_reasons.append("Semantic translation QA warnings require manual resolution.")
+
     blocking = bool(blocking_reasons)
     description = (
         blocking_reasons[0]
@@ -348,6 +409,7 @@ def build_quality_gate_report(
         "status_state": "failure" if blocking else "success",
         "status_description": description,
         "source_identical": source_stats.to_dict(),
+        "semantic_qa": semantic_stats.to_dict(),
         "validation": validation_totals,
         "pipeline_warnings_count": len(pipeline_warnings),
         "pipeline_warnings": pipeline_warnings,
@@ -366,6 +428,7 @@ def _truncate(value: str, limit: int = 100) -> str:
 
 def render_quality_gate_markdown(report: Dict[str, Any]) -> str:
     source = report["source_identical"]
+    semantic_qa = report.get("semantic_qa", {"findings_count": 0, "examples": []})
     validation = report["validation"]
     lines = ["## Translation Validation Summary", ""]
 
@@ -393,6 +456,12 @@ def render_quality_gate_markdown(report: Dict[str, Any]) -> str:
                 "| Expected source-identical values ignored | "
                 f"{source['expected_source_identical_count']} |"
             ),
+            (
+                "| Semantic QA findings | "
+                f"{semantic_qa['findings_count']} "
+                f"({semantic_qa.get('errors_count', 0)} errors, "
+                f"{semantic_qa.get('warnings_count', 0)} warnings) |"
+            ),
             f"| Reverted keys | {validation['reverted_keys_count']} |",
             f"| Control-character findings | {validation['control_character_findings_count']} |",
             f"| Placeholder failures | {validation['placeholder_failures_count']} |",
@@ -407,6 +476,16 @@ def render_quality_gate_markdown(report: Dict[str, Any]) -> str:
         for example in source["examples"]:
             lines.append(
                 f"- `{example['file']}` `{example['key']}` = `{_truncate(example['value'])}`"
+            )
+        lines.append("")
+
+    if semantic_qa.get("examples"):
+        lines.append("### Semantic QA Examples")
+        lines.append("")
+        for example in semantic_qa["examples"]:
+            lines.append(
+                f"- `{example['file']}` `{example['key']}`: "
+                f"{example['reason']} Value: `{_truncate(example['value'])}`"
             )
         lines.append("")
 
@@ -462,12 +541,13 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
     parser.add_argument("--output-json", required=True)
     parser.add_argument("--output-markdown", required=True)
     parser.add_argument("--changed-files", nargs="+", required=True)
+    parser.add_argument("--audit-scope", choices=["changed", "all"], default=None)
     return parser.parse_args(argv)
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     args = _parse_args(argv)
-    config, locale_codes, brand_glossary = load_quality_gate_config(args.config)
+    config, locale_codes, brand_glossary, semantic_rules = load_quality_gate_config(args.config)
     diff_text = get_staged_diff(args.repo_root, args.changed_files)
     source_stats = analyze_source_identical_changes(
         diff_text=diff_text,
@@ -476,8 +556,27 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         locale_codes=locale_codes,
         brand_glossary=brand_glossary,
     )
+    audit_scope = args.audit_scope or config.semantic_qa_audit_scope
+    if audit_scope == "all":
+        semantic_stats = analyze_all_translation_entries(
+            repo_root=args.repo_root,
+            input_folder=args.input_folder,
+            locale_codes=locale_codes,
+            brand_glossary=brand_glossary,
+            semantic_rules=semantic_rules,
+        )
+    else:
+        semantic_stats = analyze_semantic_qa_changes(
+            diff_text=diff_text,
+            repo_root=args.repo_root,
+            input_folder=args.input_folder,
+            locale_codes=locale_codes,
+            brand_glossary=brand_glossary,
+            semantic_rules=semantic_rules,
+        )
     report = build_quality_gate_report(
         source_stats=source_stats,
+        semantic_stats=semantic_stats,
         validation_summary=load_validation_summary(args.validation_summary),
         changed_files=args.changed_files,
         input_folder=args.input_folder,

--- a/src/translation_semantic_reviewer.py
+++ b/src/translation_semantic_reviewer.py
@@ -1,0 +1,257 @@
+"""Optional AI semantic reviewer for generated translation changes."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import jsonschema
+import yaml
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam
+
+from src.semantic_quality import (
+    TranslationChange,
+    iter_translation_changes_from_diff,
+)
+from src.translation_quality_gate import get_staged_diff
+
+
+SEMANTIC_REVIEW_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["key", "severity", "reason"],
+                "properties": {
+                    "key": {"type": "string"},
+                    "severity": {"type": "string", "enum": ["error", "warning"]},
+                    "reason": {"type": "string"},
+                    "suggested_value": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["findings"],
+    "additionalProperties": False,
+}
+
+
+def build_semantic_review_messages(
+    target_language: str,
+    changes: Sequence[TranslationChange],
+    style_rules: Sequence[str],
+    brand_glossary: Sequence[str],
+) -> List[Dict[str, str]]:
+    scoped_changes = [
+        {
+            "file": change.file,
+            "key": change.key,
+            "source_value": change.source_value or "",
+            "old_target_value": change.old_value or "",
+            "new_target_value": change.new_value,
+        }
+        for change in changes
+    ]
+    system_prompt = (
+        "You are an independent semantic QA reviewer for software localization. "
+        "Review only the provided changed keys. Return JSON only. Do not return markdown, "
+        "explanations, or corrected translations outside the JSON schema."
+    )
+    user_payload = {
+        "task": "Find semantic translation issues that deterministic checks may miss.",
+        "target_language": target_language,
+        "style_rules": list(style_rules),
+        "brand_glossary": list(brand_glossary),
+        "allowed_severities": ["error", "warning"],
+        "response_schema": {
+            "findings": [
+                {
+                    "key": "changed.key.only",
+                    "severity": "error|warning",
+                    "reason": "Short reviewer rationale.",
+                    "suggested_value": "Optional corrected value.",
+                }
+            ]
+        },
+        "changes": scoped_changes,
+    }
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": json.dumps(user_payload, ensure_ascii=False, indent=2)},
+    ]
+
+
+def normalize_review_response(
+    response_text: str,
+    changes: Sequence[TranslationChange],
+) -> List[Dict[str, str]]:
+    parsed = json.loads(response_text)
+    jsonschema.validate(instance=parsed, schema=SEMANTIC_REVIEW_SCHEMA)
+    changes_by_key = {change.key: change for change in changes}
+    findings: List[Dict[str, str]] = []
+
+    for raw_finding in parsed.get("findings", []):
+        key = raw_finding["key"]
+        change = changes_by_key.get(key)
+        if not change:
+            continue
+        finding = {
+            "file": Path(change.file).name,
+            "key": key,
+            "severity": raw_finding["severity"],
+            "reason": raw_finding["reason"],
+            "value": change.new_value,
+            "source": "ai-review",
+            "rule_id": "ai-review",
+        }
+        if raw_finding.get("suggested_value"):
+            finding["suggested_value"] = raw_finding["suggested_value"]
+        findings.append(finding)
+    return findings
+
+
+def append_semantic_review_findings(
+    validation_summary_path: str,
+    findings: Sequence[Dict[str, str]],
+) -> None:
+    if os.path.exists(validation_summary_path):
+        with open(validation_summary_path, "r", encoding="utf-8") as file:
+            summary = json.load(file)
+    else:
+        summary = {"files": {}, "pipeline_warnings": []}
+
+    summary.setdefault("files", {})
+    summary.setdefault("pipeline_warnings", [])
+    summary.setdefault("semantic_review_findings", [])
+    summary["semantic_review_findings"].extend(findings)
+
+    Path(validation_summary_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(validation_summary_path, "w", encoding="utf-8") as file:
+        json.dump(summary, file, ensure_ascii=False, indent=2)
+
+
+async def review_translation_changes(
+    client: AsyncOpenAI,
+    model: str,
+    target_language: str,
+    changes: Sequence[TranslationChange],
+    style_rules: Sequence[str],
+    brand_glossary: Sequence[str],
+) -> List[Dict[str, str]]:
+    if not changes:
+        return []
+    messages = build_semantic_review_messages(
+        target_language=target_language,
+        changes=changes,
+        style_rules=style_rules,
+        brand_glossary=brand_glossary,
+    )
+    response = await client.chat.completions.create(
+        model=model,
+        messages=[
+            ChatCompletionSystemMessageParam(role="system", content=messages[0]["content"]),
+            ChatCompletionUserMessageParam(role="user", content=messages[1]["content"]),
+        ],
+        temperature=0,
+        response_format={"type": "json_object"},
+        max_tokens=4096,
+        timeout=120.0,
+    )
+    response_text = response.choices[0].message.content or ""
+    return normalize_review_response(response_text, changes)
+
+
+def _load_config(config_path: str) -> Dict[str, Any]:
+    with open(config_path, "r", encoding="utf-8") as file:
+        return yaml.safe_load(file) or {}
+
+
+def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--input-folder", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--validation-summary", required=True)
+    parser.add_argument("--changed-files", nargs="+", required=True)
+    return parser.parse_args(argv)
+
+
+async def _run(argv: Optional[Sequence[str]]) -> int:
+    args = _parse_args(argv)
+    config = _load_config(args.config)
+    semantic_review_config = config.get("semantic_review", {}) or {}
+    if not bool(semantic_review_config.get("enabled", False)):
+        return 0
+    if bool(config.get("dry_run", False)):
+        append_semantic_review_findings(args.validation_summary, [])
+        return 0
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        return 0
+
+    locales = [
+        locale["code"]
+        for locale in config.get("supported_locales", [])
+        if isinstance(locale, dict) and locale.get("code")
+    ]
+    language_names = {
+        locale["code"]: locale.get("name", locale["code"])
+        for locale in config.get("supported_locales", [])
+        if isinstance(locale, dict) and locale.get("code")
+    }
+    diff_text = get_staged_diff(args.repo_root, args.changed_files)
+    changes = list(
+        iter_translation_changes_from_diff(
+            diff_text=diff_text,
+            repo_root=args.repo_root,
+            input_folder=args.input_folder,
+            locale_codes=locales,
+        )
+    )
+    if not changes:
+        append_semantic_review_findings(args.validation_summary, [])
+        return 0
+
+    brand_glossary = [str(term) for term in config.get("brand_technical_glossary", [])]
+    style_rules_by_locale = config.get("style_rules", {}) or {}
+    model = str(
+        semantic_review_config.get(
+            "model",
+            config.get("review_model_name", config.get("model_name", "gpt-4o")),
+        )
+    )
+    client = AsyncOpenAI(api_key=api_key)
+    findings: List[Dict[str, str]] = []
+
+    for locale_code in sorted({change.locale_code for change in changes if change.locale_code}):
+        locale_changes = [change for change in changes if change.locale_code == locale_code]
+        findings.extend(
+            await review_translation_changes(
+                client=client,
+                model=model,
+                target_language=language_names.get(locale_code, locale_code),
+                changes=locale_changes,
+                style_rules=style_rules_by_locale.get(locale_code, []),
+                brand_glossary=brand_glossary,
+            )
+        )
+
+    append_semantic_review_findings(args.validation_summary, findings)
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    return asyncio.run(_run(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/translation_semantic_reviewer.py
+++ b/src/translation_semantic_reviewer.py
@@ -28,8 +28,9 @@ SEMANTIC_REVIEW_SCHEMA = {
             "type": "array",
             "items": {
                 "type": "object",
-                "required": ["key", "severity", "reason"],
+                "required": ["file", "key", "severity", "reason"],
                 "properties": {
+                    "file": {"type": "string"},
                     "key": {"type": "string"},
                     "severity": {"type": "string", "enum": ["error", "warning"]},
                     "reason": {"type": "string"},
@@ -74,6 +75,7 @@ def build_semantic_review_messages(
         "response_schema": {
             "findings": [
                 {
+                    "file": "relative/path/to/file.properties",
                     "key": "changed.key.only",
                     "severity": "error|warning",
                     "reason": "Short reviewer rationale.",
@@ -95,16 +97,17 @@ def normalize_review_response(
 ) -> List[Dict[str, str]]:
     parsed = json.loads(response_text)
     jsonschema.validate(instance=parsed, schema=SEMANTIC_REVIEW_SCHEMA)
-    changes_by_key = {change.key: change for change in changes}
+    changes_by_identity = {(change.file, change.key): change for change in changes}
     findings: List[Dict[str, str]] = []
 
     for raw_finding in parsed.get("findings", []):
+        file = raw_finding["file"]
         key = raw_finding["key"]
-        change = changes_by_key.get(key)
+        change = changes_by_identity.get((file, key))
         if not change:
             continue
         finding = {
-            "file": Path(change.file).name,
+            "file": change.file,
             "key": key,
             "severity": raw_finding["severity"],
             "reason": raw_finding["reason"],

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -61,6 +61,9 @@ class TestLoadAppConfig:
                 "source_identical_max_count": 25,
                 "source_identical_max_ratio": 0.4,
                 "block_on_pipeline_warnings": False,
+                "block_on_semantic_qa_findings": False,
+                "block_on_semantic_qa_warnings": True,
+                "semantic_qa_audit_scope": "all",
             },
             "supported_locales": [
                 {"code": "de", "name": "German"},
@@ -90,6 +93,9 @@ class TestLoadAppConfig:
         assert config.quality_gate.source_identical_max_count == 25
         assert config.quality_gate.source_identical_max_ratio == 0.4
         assert config.quality_gate.block_on_pipeline_warnings is False
+        assert config.quality_gate.block_on_semantic_qa_findings is False
+        assert config.quality_gate.block_on_semantic_qa_warnings is True
+        assert config.quality_gate.semantic_qa_audit_scope == "all"
         assert config.language_codes == {"de": "German", "es": "Spanish"}
         assert config.name_to_code == {"german": "de", "spanish": "es"}
 
@@ -116,6 +122,9 @@ class TestLoadAppConfig:
         assert config.quality_gate.source_identical_max_count == 20
         assert config.quality_gate.source_identical_max_ratio == 0.30
         assert config.quality_gate.block_on_pipeline_warnings is True
+        assert config.quality_gate.block_on_semantic_qa_findings is True
+        assert config.quality_gate.block_on_semantic_qa_warnings is False
+        assert config.quality_gate.semantic_qa_audit_scope == "changed"
         assert config.translation_key_ledger_file_path == os.path.join(
             config.project_root, "logs", "translation_key_ledger.json"
         )

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -61,8 +61,8 @@ class TestLoadAppConfig:
                 "source_identical_max_count": 25,
                 "source_identical_max_ratio": 0.4,
                 "block_on_pipeline_warnings": False,
-                "block_on_semantic_qa_findings": False,
-                "block_on_semantic_qa_warnings": True,
+                "block_on_semantic_qa_findings": "false",
+                "block_on_semantic_qa_warnings": "yes",
                 "semantic_qa_audit_scope": "all",
             },
             "supported_locales": [

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -21,6 +21,7 @@ def test_recent_coderabbit_translation_nits_are_encoded_as_style_rules(config_pa
     style_rules = config["style_rules"]
     semantic_review = config.get("semantic_review", {})
     semantic_rules = config.get("semantic_quality_rules", [])
+    assert all("id" in rule for rule in semantic_rules)
     semantic_rules_by_id = {
         rule["id"]: rule
         for rule in semantic_rules

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -19,6 +19,12 @@ def test_recent_coderabbit_translation_nits_are_encoded_as_style_rules(config_pa
     """Keep prompt rules aligned with translation issues found in reviewed PRs."""
     config = yaml.safe_load((PROJECT_ROOT / config_path).read_text(encoding="utf-8"))
     style_rules = config["style_rules"]
+    semantic_review = config.get("semantic_review", {})
+    semantic_rules = config.get("semantic_quality_rules", [])
+    semantic_rules_by_id = {
+        rule["id"]: rule
+        for rule in semantic_rules
+    }
 
     assert any(
         "Cara kerjanya" in rule and "Cara kerja ini" in rule
@@ -27,6 +33,37 @@ def test_recent_coderabbit_translation_nits_are_encoded_as_style_rules(config_pa
     assert any(
         "('n" in rule and "parenthesized" in rule
         for rule in style_rules["af_ZA"]
+    )
+    assert any(
+        "count trades" in rule and "handelaars" in rule
+        for rule in style_rules["af_ZA"]
+    )
+    assert any(
+        "Comerciantes / Rol" in rule and "Traders / Rol" in rule
+        for rule in style_rules["es"]
+    )
+    assert any(
+        "Commerçants / Rôle" in rule and "Traders / Rôle" in rule
+        for rule in style_rules["fr"]
+    )
+    assert any(
+        "clearnet/open network" in rule and "Địa chỉ mạng công khai" in rule
+        for rule in style_rules["vi"]
+    )
+    assert semantic_review.get("enabled") is True
+    assert semantic_review.get("model") == "gpt-5.4-mini"
+    assert {
+        "trade-history-traders-label",
+        "af-trade-history-counts-trades",
+        "vi-clearnet-clear-network-address",
+    }.issubset(semantic_rules_by_id)
+    assert all(
+        semantic_rules_by_id[rule_id]["source"] == "bisq-mobile#1478 CodeRabbit"
+        for rule_id in {
+            "trade-history-traders-label",
+            "af-trade-history-counts-trades",
+            "vi-clearnet-clear-network-address",
+        }
     )
     assert any(
         "paymentAccounts.details" in rule

--- a/tests/unit/test_semantic_quality.py
+++ b/tests/unit/test_semantic_quality.py
@@ -1,0 +1,216 @@
+from pathlib import Path
+
+from src.semantic_quality import (
+    SemanticRule,
+    TranslationChange,
+    analyze_all_translation_entries,
+    evaluate_retained_source_words,
+    evaluate_semantic_rules,
+    load_semantic_rules,
+)
+from src.translation_quality_gate import (
+    QualityGateConfig,
+    analyze_semantic_qa_changes,
+    analyze_source_identical_changes,
+    build_quality_gate_report,
+)
+
+
+def _write_properties(path: Path, entries: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(f"{key}={value}" for key, value in entries.items()) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_declarative_semantic_rule_blocks_forbidden_target_text(tmp_path):
+    repo_root = tmp_path
+    input_folder = repo_root / "resources"
+    input_folder.mkdir()
+    rules = [
+        SemanticRule(
+            id="trade-history-traders-label",
+            message="Fully localize the traders label.",
+            locales=("es", "fr"),
+            keys=("mobile.tradeHistory.details.tradersAndRole",),
+            forbidden_target_regex=r"\bTraders\b",
+            severity="error",
+        )
+    ]
+    diff_text = """diff --git a/resources/mobile_es.properties b/resources/mobile_es.properties
++++ b/resources/mobile_es.properties
++mobile.tradeHistory.details.tradersAndRole=Traders / Rol
+"""
+
+    semantic_stats = analyze_semantic_qa_changes(
+        diff_text=diff_text,
+        repo_root=str(repo_root),
+        input_folder=str(input_folder),
+        locale_codes=["es"],
+        semantic_rules=rules,
+    )
+    report = build_quality_gate_report(
+        source_stats=analyze_source_identical_changes(
+            diff_text="",
+            repo_root=str(repo_root),
+            input_folder=str(input_folder),
+            locale_codes=["es"],
+            brand_glossary=[],
+        ),
+        semantic_stats=semantic_stats,
+        validation_summary={"files": {}, "pipeline_warnings": []},
+        changed_files=["resources/mobile_es.properties"],
+        input_folder=str(input_folder),
+        config=QualityGateConfig(block_on_semantic_qa_findings=True),
+    )
+
+    assert semantic_stats.errors_count == 1
+    assert semantic_stats.warnings_count == 0
+    assert semantic_stats.examples[0]["rule_id"] == "trade-history-traders-label"
+    assert report["blocking"] is True
+
+
+def test_retained_source_word_findings_are_warning_only_by_default():
+    change = TranslationChange(
+        file="resources/mobile_es.properties",
+        locale_code="es",
+        key="mobile.some.label",
+        source_value="Settlement Details",
+        old_value=None,
+        new_value="Detalles Settlement",
+    )
+
+    findings = evaluate_retained_source_words(
+        changes=[change],
+        brand_glossary=["Lightning"],
+    )
+
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert findings[0].rule_id == "retained-source-word"
+
+
+def test_semantic_warnings_do_not_block_unless_configured(tmp_path):
+    repo_root = tmp_path
+    input_folder = repo_root / "resources"
+    _write_properties(input_folder / "mobile.properties", {"k": "Settlement Details"})
+    diff_text = """diff --git a/resources/mobile_es.properties b/resources/mobile_es.properties
++++ b/resources/mobile_es.properties
++k=Detalles Settlement
+"""
+
+    semantic_stats = analyze_semantic_qa_changes(
+        diff_text=diff_text,
+        repo_root=str(repo_root),
+        input_folder=str(input_folder),
+        locale_codes=["es"],
+        brand_glossary=[],
+    )
+    report = build_quality_gate_report(
+        source_stats=analyze_source_identical_changes(
+            diff_text="",
+            repo_root=str(repo_root),
+            input_folder=str(input_folder),
+            locale_codes=["es"],
+            brand_glossary=[],
+        ),
+        semantic_stats=semantic_stats,
+        validation_summary={"files": {}, "pipeline_warnings": []},
+        changed_files=["resources/mobile_es.properties"],
+        input_folder=str(input_folder),
+        config=QualityGateConfig(
+            block_on_semantic_qa_findings=True,
+            block_on_semantic_qa_warnings=False,
+        ),
+    )
+
+    assert semantic_stats.findings_count == 1
+    assert semantic_stats.warnings_count == 1
+    assert report["blocking"] is False
+
+
+def test_ai_review_error_findings_are_folded_into_quality_gate(tmp_path):
+    report = build_quality_gate_report(
+        source_stats=analyze_source_identical_changes(
+            diff_text="",
+            repo_root=str(tmp_path),
+            input_folder=str(tmp_path),
+            locale_codes=["es"],
+            brand_glossary=[],
+        ),
+        semantic_stats=None,
+        validation_summary={
+            "files": {},
+            "pipeline_warnings": [],
+            "semantic_review_findings": [
+                {
+                    "file": "mobile_es.properties",
+                    "key": "mobile.clear",
+                    "severity": "error",
+                    "reason": "The target uses a delete verb for a clearnet label.",
+                    "value": "Borrar red: {0}",
+                    "source": "ai-review",
+                }
+            ],
+        },
+        changed_files=["resources/mobile_es.properties"],
+        input_folder="resources",
+        config=QualityGateConfig(block_on_semantic_qa_findings=True),
+    )
+
+    assert report["semantic_qa"]["errors_count"] == 1
+    assert report["blocking"] is True
+    assert "Semantic translation QA" in report["blocking_reasons"][0]
+
+
+def test_full_semantic_audit_scans_entries_without_diff(tmp_path):
+    repo_root = tmp_path
+    input_folder = repo_root / "resources"
+    _write_properties(input_folder / "mobile.properties", {"mobile.some.label": "Settlement Details"})
+    _write_properties(input_folder / "mobile_es.properties", {"mobile.some.label": "Detalles Settlement"})
+
+    stats = analyze_all_translation_entries(
+        repo_root=str(repo_root),
+        input_folder=str(input_folder),
+        locale_codes=["es"],
+        brand_glossary=[],
+        semantic_rules=[],
+    )
+
+    assert stats.findings_count == 1
+    assert stats.warnings_count == 1
+    assert stats.examples[0]["file"] == "mobile_es.properties"
+
+
+def test_feedback_rules_load_review_source_metadata():
+    rules = load_semantic_rules(
+        [
+            {
+                "id": "vi-clearnet-clear",
+                "message": "Do not translate clear as delete.",
+                "locales": ["vi"],
+                "keys": ["mobile.tradeHistory.details.networkAddress.clear"],
+                "forbidden_target_regex": r"^Xóa\b",
+                "severity": "error",
+                "source": "bisq-mobile#1478 CodeRabbit",
+            }
+        ]
+    )
+
+    findings = evaluate_semantic_rules(
+        changes=[
+            TranslationChange(
+                file="resources/mobile_vi.properties",
+                locale_code="vi",
+                key="mobile.tradeHistory.details.networkAddress.clear",
+                source_value="Clear network address: {0}",
+                old_value=None,
+                new_value="Xóa địa chỉ mạng: {0}",
+            )
+        ],
+        rules=rules,
+    )
+
+    assert findings[0].rule_id == "vi-clearnet-clear"
+    assert findings[0].source == "bisq-mobile#1478 CodeRabbit"

--- a/tests/unit/test_translation_quality_gate.py
+++ b/tests/unit/test_translation_quality_gate.py
@@ -2,8 +2,10 @@ from pathlib import Path
 
 from src.translation_quality_gate import (
     QualityGateConfig,
+    analyze_semantic_qa_changes,
     analyze_source_identical_changes,
     build_quality_gate_report,
+    load_quality_gate_config,
     load_validation_summary,
     render_quality_gate_markdown,
 )
@@ -87,6 +89,7 @@ def test_quality_gate_blocks_many_unexpected_source_identical_changes(tmp_path):
     )
     report = build_quality_gate_report(
         source_stats=stats,
+        semantic_stats=None,
         validation_summary={"files": {}, "pipeline_warnings": []},
         changed_files=["resources/mobile_es.properties"],
         input_folder=str(input_folder),
@@ -112,6 +115,7 @@ def test_pipeline_warnings_are_blocking_when_configured():
             locale_codes=["es"],
             brand_glossary=[],
         ),
+        semantic_stats=None,
         validation_summary={
             "files": {},
             "pipeline_warnings": [
@@ -137,6 +141,7 @@ def test_pipeline_warnings_are_filtered_to_current_batch():
             locale_codes=["es"],
             brand_glossary=[],
         ),
+        semantic_stats=None,
         validation_summary={
             "files": {},
             "pipeline_warnings": [
@@ -163,6 +168,7 @@ def test_pipeline_warnings_from_other_batches_do_not_block():
             locale_codes=["es"],
             brand_glossary=[],
         ),
+        semantic_stats=None,
         validation_summary={
             "files": {},
             "pipeline_warnings": [
@@ -184,6 +190,87 @@ def test_missing_validation_summary_loads_empty_summary(tmp_path):
     assert summary == {"files": {}, "pipeline_warnings": []}
 
 
+def test_semantic_qa_blocks_recent_coderabbit_translation_nits(tmp_path):
+    repo_root = tmp_path
+    input_folder = repo_root / "resources"
+    input_folder.mkdir()
+    _, _, _, semantic_rules = load_quality_gate_config("config.example.yaml")
+    diff_text = """diff --git a/resources/mobile_af_ZA.properties b/resources/mobile_af_ZA.properties
++++ b/resources/mobile_af_ZA.properties
++mobile.tradeHistory.count.many={0} handelaars
++mobile.tradeHistory.count.filtered={0} van {1} handelaars
+diff --git a/resources/mobile_es.properties b/resources/mobile_es.properties
++++ b/resources/mobile_es.properties
++mobile.tradeHistory.details.tradersAndRole=Traders / Rol
+diff --git a/resources/mobile_fr.properties b/resources/mobile_fr.properties
++++ b/resources/mobile_fr.properties
++mobile.tradeHistory.details.tradersAndRole=Traders / Rôle
+diff --git a/resources/mobile_vi.properties b/resources/mobile_vi.properties
++++ b/resources/mobile_vi.properties
++mobile.tradeHistory.details.networkAddress.clear=Xóa địa chỉ mạng: {0}
+"""
+
+    semantic_stats = analyze_semantic_qa_changes(
+        diff_text=diff_text,
+        repo_root=str(repo_root),
+        input_folder=str(input_folder),
+        locale_codes=["af_ZA", "es", "fr", "vi"],
+        semantic_rules=semantic_rules,
+    )
+    report = build_quality_gate_report(
+        source_stats=analyze_source_identical_changes(
+            diff_text="",
+            repo_root=str(repo_root),
+            input_folder=str(input_folder),
+            locale_codes=["af_ZA", "es", "fr", "vi"],
+            brand_glossary=[],
+        ),
+        semantic_stats=semantic_stats,
+        validation_summary={"files": {}, "pipeline_warnings": []},
+        changed_files=[
+            "resources/mobile_af_ZA.properties",
+            "resources/mobile_es.properties",
+            "resources/mobile_fr.properties",
+            "resources/mobile_vi.properties",
+        ],
+        input_folder=str(input_folder),
+        config=QualityGateConfig(block_on_semantic_qa_findings=True),
+    )
+
+    assert semantic_stats.findings_count == 5
+    assert semantic_stats.errors_count == 5
+    assert report["blocking"] is True
+    assert "Semantic translation QA" in report["blocking_reasons"][0]
+
+
+def test_semantic_qa_reports_retained_source_words_but_ignores_glossary(tmp_path):
+    repo_root = tmp_path
+    input_folder = repo_root / "resources"
+    _write_properties(
+        input_folder / "mobile.properties",
+        {
+            "mobile.some.label": "Settlement Details",
+            "mobile.invoice": "Lightning invoice",
+        },
+    )
+    diff_text = """diff --git a/resources/mobile_es.properties b/resources/mobile_es.properties
++++ b/resources/mobile_es.properties
++mobile.some.label=Detalles Settlement
++mobile.invoice=Factura Lightning
+"""
+
+    semantic_stats = analyze_semantic_qa_changes(
+        diff_text=diff_text,
+        repo_root=str(repo_root),
+        input_folder=str(input_folder),
+        locale_codes=["es"],
+        brand_glossary=["Lightning"],
+    )
+
+    assert semantic_stats.findings_count == 1
+    assert "Settlement" in semantic_stats.examples[0]["reason"]
+
+
 def test_quality_gate_markdown_contains_validation_summary():
     report = {
         "blocking": False,
@@ -195,6 +282,17 @@ def test_quality_gate_markdown_contains_validation_summary():
             "unexpected_source_identical_count": 1,
             "unexpected_source_identical_ratio": 0.125,
             "examples": [],
+        },
+        "semantic_qa": {
+            "findings_count": 1,
+            "examples": [
+                {
+                    "file": "mobile_es.properties",
+                    "key": "mobile.tradeHistory.details.tradersAndRole",
+                    "value": "Traders / Rol",
+                    "reason": "Trade Details traders/role label contains untranslated English term 'Traders'.",
+                }
+            ],
         },
         "validation": {
             "reverted_keys_count": 2,
@@ -210,5 +308,7 @@ def test_quality_gate_markdown_contains_validation_summary():
 
     assert "Translation Validation Summary" in markdown
     assert "Unexpected source-identical changed values" in markdown
+    assert "Semantic QA findings" in markdown
+    assert "Semantic QA Examples" in markdown
     assert "Reverted keys" in markdown
     assert "Control-character findings" in markdown

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -1,0 +1,133 @@
+import json
+import os
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
+
+from src.semantic_quality import TranslationChange
+from src.translation_semantic_reviewer import (
+    _run,
+    append_semantic_review_findings,
+    build_semantic_review_messages,
+    normalize_review_response,
+)
+
+
+def test_semantic_reviewer_prompt_is_json_only_and_context_rich():
+    messages = build_semantic_review_messages(
+        target_language="Spanish",
+        changes=[
+            TranslationChange(
+                file="resources/mobile_es.properties",
+                locale_code="es",
+                key="mobile.tradeHistory.details.networkAddress.clear",
+                source_value="Clear network address: {0}",
+                old_value="Dirección de red clara: {0}",
+                new_value="Borrar dirección de red: {0}",
+            )
+        ],
+        style_rules=["Use formal tone.", "Do not translate clear as delete for clearnet labels."],
+        brand_glossary=["Bisq", "Tor"],
+    )
+
+    combined = "\n".join(message["content"] for message in messages)
+
+    assert "JSON only" in combined
+    assert "source_value" in combined
+    assert "old_target_value" in combined
+    assert "new_target_value" in combined
+    assert "Clear network address: {0}" in combined
+    assert "Borrar dirección de red: {0}" in combined
+    assert "Do not translate clear as delete" in combined
+    assert "Bisq" in combined
+
+
+def test_normalize_review_response_accepts_only_in_scope_findings():
+    response = json.dumps(
+        {
+            "findings": [
+                {
+                    "key": "mobile.clear",
+                    "severity": "error",
+                    "reason": "Delete verb used for clearnet label.",
+                    "suggested_value": "Dirección de red pública: {0}",
+                },
+                {
+                    "key": "outside.scope",
+                    "severity": "error",
+                    "reason": "Should be ignored.",
+                },
+            ]
+        }
+    )
+    changes = [
+        TranslationChange(
+            file="resources/mobile_es.properties",
+            locale_code="es",
+            key="mobile.clear",
+            source_value="Clear network address: {0}",
+            old_value=None,
+            new_value="Borrar dirección de red: {0}",
+        )
+    ]
+
+    findings = normalize_review_response(response, changes)
+
+    assert len(findings) == 1
+    assert findings[0]["file"] == "mobile_es.properties"
+    assert findings[0]["key"] == "mobile.clear"
+    assert findings[0]["severity"] == "error"
+    assert findings[0]["source"] == "ai-review"
+    assert findings[0]["suggested_value"] == "Dirección de red pública: {0}"
+
+
+def test_append_semantic_review_findings_preserves_existing_summary(tmp_path):
+    summary_path = tmp_path / "translation_validation_summary.json"
+    summary_path.write_text(
+        json.dumps({"files": {"mobile_es.properties": {}}, "pipeline_warnings": []}),
+        encoding="utf-8",
+    )
+
+    append_semantic_review_findings(
+        str(summary_path),
+        [
+            {
+                "file": "mobile_es.properties",
+                "key": "mobile.clear",
+                "severity": "warning",
+                "reason": "Suspicious wording.",
+                "source": "ai-review",
+            }
+        ],
+    )
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["files"] == {"mobile_es.properties": {}}
+    assert summary["pipeline_warnings"] == []
+    assert summary["semantic_review_findings"][0]["key"] == "mobile.clear"
+
+
+@pytest.mark.asyncio
+async def test_semantic_reviewer_is_opt_in(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    validation_summary_path = tmp_path / "translation_validation_summary.json"
+    config_path.write_text("dry_run: false\n", encoding="utf-8")
+
+    exit_code = await _run(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--input-folder",
+            str(tmp_path),
+            "--config",
+            str(config_path),
+            "--validation-summary",
+            str(validation_summary_path),
+            "--changed-files",
+            "mobile_es.properties",
+        ]
+    )
+
+    assert exit_code == 0
+    assert not validation_summary_path.exists()

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -37,6 +37,7 @@ def test_semantic_reviewer_prompt_is_json_only_and_context_rich():
     assert "source_value" in combined
     assert "old_target_value" in combined
     assert "new_target_value" in combined
+    assert '"file": "relative/path/to/file.properties"' in combined
     assert "Clear network address: {0}" in combined
     assert "Borrar dirección de red: {0}" in combined
     assert "Do not translate clear as delete" in combined
@@ -48,12 +49,14 @@ def test_normalize_review_response_accepts_only_in_scope_findings():
         {
             "findings": [
                 {
+                    "file": "resources/mobile_es.properties",
                     "key": "mobile.clear",
                     "severity": "error",
                     "reason": "Delete verb used for clearnet label.",
                     "suggested_value": "Dirección de red pública: {0}",
                 },
                 {
+                    "file": "resources/mobile_es.properties",
                     "key": "outside.scope",
                     "severity": "error",
                     "reason": "Should be ignored.",
@@ -75,11 +78,51 @@ def test_normalize_review_response_accepts_only_in_scope_findings():
     findings = normalize_review_response(response, changes)
 
     assert len(findings) == 1
-    assert findings[0]["file"] == "mobile_es.properties"
+    assert findings[0]["file"] == "resources/mobile_es.properties"
     assert findings[0]["key"] == "mobile.clear"
     assert findings[0]["severity"] == "error"
     assert findings[0]["source"] == "ai-review"
     assert findings[0]["suggested_value"] == "Dirección de red pública: {0}"
+
+
+def test_normalize_review_response_matches_duplicate_keys_by_file_and_key():
+    response = json.dumps(
+        {
+            "findings": [
+                {
+                    "file": "resources/settings_es.properties",
+                    "key": "shared.clear",
+                    "severity": "warning",
+                    "reason": "Ambiguous clear wording.",
+                }
+            ]
+        }
+    )
+    changes = [
+        TranslationChange(
+            file="resources/mobile_es.properties",
+            locale_code="es",
+            key="shared.clear",
+            source_value="Clear",
+            old_value=None,
+            new_value="Borrar",
+        ),
+        TranslationChange(
+            file="resources/settings_es.properties",
+            locale_code="es",
+            key="shared.clear",
+            source_value="Clear",
+            old_value=None,
+            new_value="Limpiar",
+        ),
+    ]
+
+    findings = normalize_review_response(response, changes)
+
+    assert len(findings) == 1
+    assert findings[0]["file"] == "resources/settings_es.properties"
+    assert findings[0]["key"] == "shared.clear"
+    assert findings[0]["value"] == "Limpiar"
 
 
 def test_append_semantic_review_findings_preserves_existing_summary(tmp_path):

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -42,9 +42,26 @@ def test_generated_prs_publish_translation_quality_gate_status():
     script = (REPO_ROOT / "update-translations.sh").read_text()
 
     assert "src.translation_quality_gate" in script
+    assert "src.translation_semantic_reviewer" in script
+    assert 'QUALITY_AUDIT_SCOPE="${TRANSLATION_QUALITY_AUDIT_SCOPE:-changed}"' in script
+    assert '--audit-scope "$QUALITY_AUDIT_SCOPE"' in script
     assert "translation-quality-gate" in script
-    assert 'gh api "repos/$UPSTREAM_REPO_NAME/statuses/$commit_sha"' in script
+    assert 'status_repo="${FORK_OWNER}/${FORK_REPO_NAME_SHORT}"' in script
+    assert 'gh api "repos/$status_repo/statuses/$commit_sha"' in script
+    assert 'gh api "repos/$status_repo/commits/$commit_sha/status"' in script
     assert "QUALITY_REPORT_MD" in script
+
+
+def test_fork_repo_name_short_strips_git_suffix_before_status_api():
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    normalize_index = script.index('FORK_REPO_NAME_SHORT=$(echo "$origin_url"')
+    submit_index = script.index('if ! stage_and_submit_batch "$BRANCH_NAME"')
+
+    assert "origin_url=$(git remote get-url origin)" in script
+    assert 's#\\.git$##' in script
+    assert 'status_repo="${FORK_OWNER}/${FORK_REPO_NAME_SHORT}"' in script
+    assert normalize_index < submit_index
 
 
 def test_config_file_is_normalized_before_late_quality_gate_call():

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -49,6 +49,10 @@ def test_generated_prs_publish_translation_quality_gate_status():
     assert 'status_repo="${FORK_OWNER}/${FORK_REPO_NAME_SHORT}"' in script
     assert 'gh api "repos/$status_repo/statuses/$commit_sha"' in script
     assert 'gh api "repos/$status_repo/commits/$commit_sha/status"' in script
+    assert "for verify_attempt in 1 2 3 4 5" in script
+    assert 'sleep "$verify_delay"' in script
+    assert 'verify_delay=$((verify_delay * 2))' in script
+    assert "2>/dev/null || true" in script
     assert "QUALITY_REPORT_MD" in script
 
 

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -584,9 +584,22 @@ This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT
         log "Failed to publish translation-quality-gate commit status." "ERROR"
         return 1
     fi
-    local published_quality_state
-    if ! published_quality_state=$(gh api "repos/$status_repo/commits/$commit_sha/status" \
-        --jq '[(.statuses[] | select(.context == "translation-quality-gate"))][0].state // ""'); then
+    local published_quality_state=""
+    local verify_attempt
+    local verify_delay=2
+    for verify_attempt in 1 2 3 4 5; do
+        published_quality_state=$(gh api "repos/$status_repo/commits/$commit_sha/status" \
+            --jq '[(.statuses[] | select(.context == "translation-quality-gate"))][0].state // ""' \
+            2>/dev/null || true)
+        if [ "$published_quality_state" = "$quality_state" ]; then
+            break
+        fi
+        if [ "$verify_attempt" -lt 5 ]; then
+            sleep "$verify_delay"
+            verify_delay=$((verify_delay * 2))
+        fi
+    done
+    if [ -z "$published_quality_state" ]; then
         log "Failed to verify translation-quality-gate commit status." "ERROR"
         return 1
     fi

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -479,6 +479,24 @@ stage_and_submit_batch() {
     local QUALITY_REPORT_JSON="$report_dir/translation_quality_report-${branch}.json"
     local QUALITY_REPORT_MD="$report_dir/translation_quality_report-${branch}.md"
     local VALIDATION_SUMMARY="$report_dir/translation_validation_summary.json"
+    local QUALITY_AUDIT_SCOPE="${TRANSLATION_QUALITY_AUDIT_SCOPE:-changed}"
+    local SEMANTIC_REVIEW_EXIT=0
+    set +e
+    (
+        cd "$app_root" && \
+        python3 -m src.translation_semantic_reviewer \
+            --repo-root "$TARGET_PROJECT_ROOT" \
+            --input-folder "$ABSOLUTE_INPUT_FOLDER" \
+            --config "$CONFIG_FILE" \
+            --validation-summary "$VALIDATION_SUMMARY" \
+            --changed-files "${BATCH_FILES[@]}"
+    )
+    SEMANTIC_REVIEW_EXIT=$?
+    set -e
+    if [ "$SEMANTIC_REVIEW_EXIT" -ne 0 ]; then
+        log "Semantic AI review failed; continuing with deterministic quality gate only." "WARNING"
+    fi
+
     local QUALITY_GATE_EXIT=0
     set +e
     (
@@ -490,6 +508,7 @@ stage_and_submit_batch() {
             --validation-summary "$VALIDATION_SUMMARY" \
             --output-json "$QUALITY_REPORT_JSON" \
             --output-markdown "$QUALITY_REPORT_MD" \
+            --audit-scope "$QUALITY_AUDIT_SCOPE" \
             --changed-files "${BATCH_FILES[@]}"
     )
     QUALITY_GATE_EXIT=$?
@@ -553,9 +572,11 @@ This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT
 
     local quality_state
     local quality_description
+    local status_repo
     quality_state=$(jq -r '.status_state // "success"' "$QUALITY_REPORT_JSON")
     quality_description=$(jq -r '.status_description // "Translation quality gate passed."' "$QUALITY_REPORT_JSON" | cut -c1-140)
-    if ! gh api "repos/$UPSTREAM_REPO_NAME/statuses/$commit_sha" \
+    status_repo="${FORK_OWNER}/${FORK_REPO_NAME_SHORT}"
+    if ! gh api "repos/$status_repo/statuses/$commit_sha" \
         -f state="$quality_state" \
         -f context="translation-quality-gate" \
         -f description="$quality_description" \
@@ -563,7 +584,17 @@ This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT
         log "Failed to publish translation-quality-gate commit status." "ERROR"
         return 1
     fi
-    log "Published translation-quality-gate status: $quality_state"
+    local published_quality_state
+    if ! published_quality_state=$(gh api "repos/$status_repo/commits/$commit_sha/status" \
+        --jq '[(.statuses[] | select(.context == "translation-quality-gate"))][0].state // ""'); then
+        log "Failed to verify translation-quality-gate commit status." "ERROR"
+        return 1
+    fi
+    if [ "$published_quality_state" != "$quality_state" ]; then
+        log "translation-quality-gate status verification mismatch: expected '$quality_state', got '${published_quality_state:-missing}'." "ERROR"
+        return 1
+    fi
+    log "Published translation-quality-gate status on $status_repo: $quality_state"
 }
 
 # Check specifically for changes in translation files
@@ -584,8 +615,9 @@ if [ -n "$TRANSLATION_CHANGES" ]; then
             log "'origin' remote not found; cannot push PR branch." "ERROR"
             exit 1
         fi
-        FORK_OWNER=$(git remote get-url origin | sed -E 's#.*[:/](.+)/[^/]+(\.git)?$#\1#')
-        FORK_REPO_NAME_SHORT=$(git remote get-url origin | sed -E 's#.*/([^/]+)(\.git)?$#\1#')
+        origin_url=$(git remote get-url origin)
+        FORK_OWNER=$(echo "$origin_url" | sed -E 's#^.*[:/]([^/:]+)/[^/]+$#\1#')
+        FORK_REPO_NAME_SHORT=$(echo "$origin_url" | sed -E 's#^.*[:/]([^/]+)$#\1#; s#\.git$##')
         if [ -z "$FORK_OWNER" ]; then
             log "Error: Could not determine the fork owner from the 'origin' remote URL." "ERROR"
             exit 1


### PR DESCRIPTION
## What changed

- Added a declarative semantic translation quality layer for generated PRs.
- Added deterministic semantic rules for the recent Bisq Mobile PR #1478 review findings.
- Added an optional AI semantic reviewer that emits structured findings into the existing validation summary.
- Kept retained source-word detection as warning-only by default to avoid brittle hard blocks.
- Added changed-vs-all semantic audit scope support for normal runs and scheduled audits.
- Fixed translation-quality-gate commit status publishing for fork PRs by publishing to the fork head repository and stripping `.git` from the normalized repo name.

## Why

Recent automated translation PRs passed the existing mechanical checks while still containing semantic localization mistakes. This adds a layered quality gate so deterministic rules catch known regressions, AI review can surface new semantic issues, and the PR status reliably appears on generated fork PRs.

## Validation

- `bash -n update-translations.sh`
- `pytest tests/unit/test_update_translations_script.py`
- `pytest tests/unit/test_config_quality.py tests/unit/test_translation_semantic_reviewer.py`
- `pytest` -> 167 passed

## Notes

The semantic reviewer is explicitly configured to use `gpt-5.4-mini` for cost control. Heuristic retained-English findings are warnings by default; configured semantic rule errors and AI review errors block the quality gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced semantic QA system with AI-powered semantic review for enhanced translation quality validation
  * Added deterministic semantic quality rules for translation accuracy enforcement
  * Extended language support: French (fr) and Vietnamese (vi)
  * Enhanced style rules for improved localization quality across multiple locales

<!-- end of auto-generated comment: release notes by coderabbit.ai -->