### PR TITLE
Add per-run OpenAI token usage and cost logging

### DIFF
--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -40,6 +40,7 @@ from tqdm.asyncio import tqdm
 
 from src.app_config import load_app_config
 from src.properties_parser import parse_properties_file, reassemble_file
+from src.usage_tracker import usage_tracker
 from src.translation_validator import (
     check_placeholder_parity,
     check_encoding_and_mojibake,
@@ -1160,6 +1161,7 @@ Provide the translation **of the Value only**, following the instructions above.
                     temperature=0.3,
                     timeout=60.0,
                 )
+                usage_tracker.record_response(MODEL_NAME, response)
 
                 msg_content = response.choices[0].message.content
                 if not msg_content:
@@ -1309,6 +1311,7 @@ async def holistic_review_async(
                     max_tokens=8192,  # Increased to handle larger review responses
                     timeout=120.0,
                 )
+                usage_tracker.record_response(REVIEW_MODEL_NAME, response)
                 msg_content = response.choices[0].message.content
                 if not msg_content or not msg_content.strip():
                     logger.error("Holistic review returned empty content.")
@@ -2263,6 +2266,16 @@ async def main():
         skipped_files=skipped_files,
     )
     logger.info(f"Wrote translation validation summary to {validation_summary_path}")
+
+    # Step 6b: Write token usage / cost summary for this run.
+    usage_summary_path = os.path.join(PROJECT_ROOT_DIR, 'logs', 'token_usage_summary.json')
+    try:
+        usage_tracker.write_json(usage_summary_path)
+        for line in usage_tracker.format_summary().splitlines():
+            logger.info(line)
+        logger.info(f"Wrote token usage summary to {usage_summary_path}")
+    except Exception:
+        logger.exception("Failed to write token usage summary")
 
     # Step 7: Copy translated files back to the input folder, overwriting the originals.
     copy_translated_files_back(TRANSLATED_QUEUE_FOLDER, INPUT_FOLDER)

--- a/src/usage_tracker.py
+++ b/src/usage_tracker.py
@@ -1,0 +1,141 @@
+"""Per-run OpenAI token usage and cost tracking.
+
+Accumulates ``prompt``/``completion`` token counts per model across a single
+pipeline run and produces an estimated USD cost using a configurable price
+table. The numbers are written to ``logs/token_usage_summary.json`` and logged
+at the end of a run so real cost-per-run can be compared against estimates.
+
+Prices are USD per 1,000,000 tokens and are editable below. They change over
+time and by model — update ``DEFAULT_PRICES`` (or pass ``prices=`` to the
+constructor) and treat reported cost as an estimate, not a billing figure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+# USD per 1,000,000 tokens. Verify against current OpenAI pricing before relying.
+DEFAULT_PRICES: Dict[str, Dict[str, float]] = {
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "gpt-4": {"input": 30.00, "output": 60.00},
+    "gpt-4-turbo": {"input": 10.00, "output": 30.00},
+}
+
+
+@dataclass
+class _ModelUsage:
+    calls: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+
+class UsageTracker:
+    """Thread-naive accumulator for token usage across a run.
+
+    Safe for asyncio use because :meth:`record` performs no ``await`` and runs
+    to completion on the single event-loop thread.
+    """
+
+    def __init__(self, prices: Optional[Dict[str, Dict[str, float]]] = None) -> None:
+        self._prices = prices if prices is not None else DEFAULT_PRICES
+        self._by_model: Dict[str, _ModelUsage] = {}
+
+    def reset(self) -> None:
+        self._by_model = {}
+
+    def record(self, model: str, prompt_tokens: int, completion_tokens: int) -> None:
+        """Add one API call's token counts for ``model``."""
+        entry = self._by_model.setdefault(model, _ModelUsage())
+        entry.calls += 1
+        entry.prompt_tokens += int(prompt_tokens or 0)
+        entry.completion_tokens += int(completion_tokens or 0)
+
+    def record_response(self, model: str, response: Any) -> None:
+        """Record usage from an OpenAI ChatCompletion response (no-op if absent)."""
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return
+        self.record(
+            model,
+            getattr(usage, "prompt_tokens", 0) or 0,
+            getattr(usage, "completion_tokens", 0) or 0,
+        )
+
+    def _model_cost(self, model: str, prompt_tokens: int, completion_tokens: int) -> Optional[float]:
+        price = self._prices.get(model)
+        if price is None:
+            return None
+        return (
+            prompt_tokens / 1_000_000 * price["input"]
+            + completion_tokens / 1_000_000 * price["output"]
+        )
+
+    def summary(self) -> Dict[str, Any]:
+        """Return a structured summary of usage and estimated cost."""
+        models: Dict[str, Any] = {}
+        total_prompt = total_completion = 0
+        total_cost = 0.0
+        cost_known = True
+        for model, u in sorted(self._by_model.items()):
+            cost = self._model_cost(model, u.prompt_tokens, u.completion_tokens)
+            if cost is None:
+                cost_known = False
+            else:
+                total_cost += cost
+            models[model] = {
+                "calls": u.calls,
+                "prompt_tokens": u.prompt_tokens,
+                "completion_tokens": u.completion_tokens,
+                "total_tokens": u.prompt_tokens + u.completion_tokens,
+                "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+            }
+            total_prompt += u.prompt_tokens
+            total_completion += u.completion_tokens
+        return {
+            "models": models,
+            "totals": {
+                "calls": sum(u.calls for u in self._by_model.values()),
+                "prompt_tokens": total_prompt,
+                "completion_tokens": total_completion,
+                "total_tokens": total_prompt + total_completion,
+                "estimated_cost_usd": round(total_cost, 6),
+                "cost_complete": cost_known,
+            },
+        }
+
+    def format_summary(self) -> str:
+        """Human-readable multi-line summary for logging."""
+        s = self.summary()
+        t = s["totals"]
+        lines = ["===== Token usage this run ====="]
+        if not s["models"]:
+            lines.append("No API calls recorded.")
+            return "\n".join(lines)
+        for model, m in s["models"].items():
+            cost = m["estimated_cost_usd"]
+            cost_str = f"${cost:.4f}" if cost is not None else "n/a (no price set)"
+            lines.append(
+                f"  {model}: {m['calls']} calls, "
+                f"{m['prompt_tokens']:,} in + {m['completion_tokens']:,} out "
+                f"= {m['total_tokens']:,} tokens, est. {cost_str}"
+            )
+        note = "" if t["cost_complete"] else "  (incomplete — some models had no price set)"
+        lines.append(
+            f"  TOTAL: {t['calls']} calls, {t['total_tokens']:,} tokens, "
+            f"est. ${t['estimated_cost_usd']:.4f}{note}"
+        )
+        return "\n".join(lines)
+
+    def write_json(self, path: str) -> None:
+        """Write the summary to ``path`` as JSON (creates parent dirs)."""
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.summary(), f, ensure_ascii=False, indent=2)
+
+
+# Module-level singleton, consistent with the module-global style of the pipeline.
+usage_tracker = UsageTracker()

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -1,0 +1,99 @@
+"""Unit tests for the per-run token usage / cost tracker."""
+
+import json
+from types import SimpleNamespace
+
+from src.usage_tracker import UsageTracker
+
+
+PRICES = {
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+}
+
+
+def test_record_and_totals():
+    t = UsageTracker(prices=PRICES)
+    t.record("gpt-4o-mini", 1000, 500)
+    t.record("gpt-4o-mini", 1000, 500)
+    s = t.summary()
+    assert s["models"]["gpt-4o-mini"]["calls"] == 2
+    assert s["models"]["gpt-4o-mini"]["prompt_tokens"] == 2000
+    assert s["models"]["gpt-4o-mini"]["completion_tokens"] == 1000
+    assert s["totals"]["total_tokens"] == 3000
+
+
+def test_cost_calculation():
+    t = UsageTracker(prices=PRICES)
+    # 1,000,000 input + 1,000,000 output on gpt-4o = $2.50 + $10.00 = $12.50
+    t.record("gpt-4o", 1_000_000, 1_000_000)
+    s = t.summary()
+    assert s["models"]["gpt-4o"]["estimated_cost_usd"] == 12.5
+    assert s["totals"]["estimated_cost_usd"] == 12.5
+    assert s["totals"]["cost_complete"] is True
+
+
+def test_multiple_models_aggregate():
+    t = UsageTracker(prices=PRICES)
+    t.record("gpt-4o-mini", 1_000_000, 0)   # $0.15
+    t.record("gpt-4o", 1_000_000, 0)         # $2.50
+    s = t.summary()
+    assert s["totals"]["calls"] == 2
+    assert round(s["totals"]["estimated_cost_usd"], 4) == 2.65
+
+
+def test_unknown_model_tracks_tokens_but_no_cost():
+    t = UsageTracker(prices=PRICES)
+    t.record("some-future-model", 1000, 1000)
+    s = t.summary()
+    assert s["models"]["some-future-model"]["total_tokens"] == 2000
+    assert s["models"]["some-future-model"]["estimated_cost_usd"] is None
+    assert s["totals"]["cost_complete"] is False
+
+
+def test_record_response_reads_usage():
+    t = UsageTracker(prices=PRICES)
+    resp = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=120, completion_tokens=30))
+    t.record_response("gpt-4o-mini", resp)
+    s = t.summary()
+    assert s["models"]["gpt-4o-mini"]["prompt_tokens"] == 120
+    assert s["models"]["gpt-4o-mini"]["completion_tokens"] == 30
+
+
+def test_record_response_handles_missing_usage():
+    t = UsageTracker(prices=PRICES)
+    t.record_response("gpt-4o-mini", SimpleNamespace(usage=None))
+    t.record_response("gpt-4o-mini", SimpleNamespace())  # no usage attr at all
+    assert t.summary()["totals"]["total_tokens"] == 0
+
+
+def test_reset():
+    t = UsageTracker(prices=PRICES)
+    t.record("gpt-4o", 100, 100)
+    t.reset()
+    assert t.summary()["totals"]["total_tokens"] == 0
+    assert t.summary()["models"] == {}
+
+
+def test_format_summary_contains_figures():
+    t = UsageTracker(prices=PRICES)
+    t.record("gpt-4o", 1_000_000, 1_000_000)
+    out = t.format_summary()
+    assert "gpt-4o" in out
+    assert "TOTAL" in out
+    assert "12.5" in out
+
+
+def test_format_summary_empty():
+    t = UsageTracker(prices=PRICES)
+    assert "No API calls" in t.format_summary()
+
+
+def test_write_json(tmp_path):
+    t = UsageTracker(prices=PRICES)
+    t.record("gpt-4o-mini", 500, 250)
+    path = tmp_path / "nested" / "usage.json"
+    t.write_json(str(path))
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["totals"]["total_tokens"] == 750
+    assert data["models"]["gpt-4o-mini"]["calls"] == 1


### PR DESCRIPTION
## Summary
Adds visibility into the real OpenAI cost of each pipeline run, so cost-per-string and margin can be measured against estimates instead of guessed.

## What changed
- **`src/usage_tracker.py`** (new): a `UsageTracker` that accumulates prompt/completion tokens per model across a run and estimates USD cost from an editable price table (`DEFAULT_PRICES`). Module-level singleton, asyncio-safe (no `await` in `record`).
- **`src/translate_localization_files.py`**: records usage after the translation call (`gpt-4o-mini`) and the holistic-review call (review model), and writes a per-run summary to `logs/token_usage_summary.json` plus the run log at the end of `main()`.
- **`tests/unit/test_usage_tracker.py`** (new): 10 unit tests covering totals, cost math, multi-model aggregation, unknown-model handling, `record_response` with/without `usage`, reset, formatting, and JSON output.

## Behaviour notes
- Prices are USD per 1M tokens and are easy to update; reported cost is an **estimate**, not a billing figure.
- Degrades gracefully: an unknown model is still token-counted with cost flagged incomplete; a missing `usage` field is a no-op (never breaks a run).
- Summary writing is wrapped in try/except so it can never fail a translation run.

## Testing
- `ruff check .` — clean
- `pytest` (full suite) — 181 passed
- Docker image builds successfully (`docker compose build`); the new module imports inside the image.