### PR TITLE
Allowlist 'version' loanword in retained-word QA

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -68,9 +68,12 @@ quality_gate:
   semantic_qa_audit_scope: "changed"
   # Locale-specific retained source words that are valid loan/cognate words.
   retained_source_word_allowlist:
+    da: ["version"]
+    de: ["version"]
     es: ["personal"]
-    fr: ["information", "message", "messages"]
+    fr: ["information", "message", "messages", "version"]
     it: ["reporting"]
+    sv: ["version"]
 
 # Optional independent AI semantic reviewer. It reviews only changed keys and
 # appends structured findings to logs/translation_validation_summary.json.

--- a/docker/config.docker.yaml
+++ b/docker/config.docker.yaml
@@ -17,9 +17,12 @@ quality_gate:
   block_on_semantic_qa_warnings: false
   semantic_qa_audit_scope: "changed"
   retained_source_word_allowlist:
+    da: ["version"]
+    de: ["version"]
     es: ["personal"]
-    fr: ["information", "message", "messages"]
+    fr: ["information", "message", "messages", "version"]
     it: ["reporting"]
+    sv: ["version"]
 semantic_review:
   enabled: true
   model: "gpt-5.4-mini"

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -136,8 +136,11 @@ def test_recent_coderabbit_translation_nits_are_encoded_as_style_rules(config_pa
         }
     )
     assert "personal" in retained_allowlist["es"]
-    assert {"information", "message", "messages"}.issubset(retained_allowlist["fr"])
+    assert {"information", "message", "messages", "version"}.issubset(retained_allowlist["fr"])
     assert "reporting" in retained_allowlist["it"]
+    assert "version" in retained_allowlist["da"]
+    assert "version" in retained_allowlist["de"]
+    assert "version" in retained_allowlist["sv"]
     assert any(
         "paymentAccounts.details" in rule
         and "paymentAccounts.accountCreationDate" in rule


### PR DESCRIPTION
## Problem

`bisq-network/bisq2#4848` adds two new keys, including
`trade.error.minVersionRequired` whose English source is:

> Trading requires Bisq version {0} or later. ... a minimum required version for trading.

The `retained-source-word` semantic heuristic
(`src/semantic_quality.py`) flags any English source word of seven or
more characters that reappears verbatim in a target value. The word
**version** is exactly seven characters and is the standard, native
spelling in several languages, so correct translations were reported
as "untranslated source term(s)".

This surfaced as a CodeRabbit comment on `default_da.properties` (line
70) asking to replace the Danish `version` with `udgave`. That is a
false positive: `version` is standard Danish (and the Swedish, German
and French values in the very same PR use the identical word).

## Root cause

`version` is a cross-language loanword/cognate that the heuristic
cannot distinguish from genuinely untranslated English.

## Change

Add `version` to the locale-scoped `retained_source_word_allowlist`
for `da`, `de`, `fr`, `sv` in both `config.example.yaml` and
`docker/config.docker.yaml`, following the existing precedent
(`es: ["personal"]`, `fr: ["information", ...]`, `it: ["reporting"]`).

The allowlist is intentionally locale-scoped: the warning is preserved
for locales such as Hausa (`ha`) and Yoruba (`yo`), where this PR shows
`version` is genuinely untranslated and should still be flagged.

The config-quality regression test was extended to assert the new
entries.

## Evidence

- bisq-network/bisq2#4848 — `default_da.properties` line 70, CodeRabbit
  inline comment classifying `version` as untranslated English.
- Sibling locales in the same PR: `default_sv.properties` and
  `default_fr.properties` use `version`; `default_de.properties` uses
  `Version`.

## Tests

`OPENAI_API_KEY=<dummy> .venv/bin/pytest -q tests/unit` → 166 passed
(focused: `tests/unit/test_config_quality.py`,
`tests/unit/test_semantic_quality.py` → 11 passed).

Requires `docker compose run --rm translator` build + local run before merge.
