### PR TITLE
Handle OpenAI token limit parameters

### DIFF
--- a/src/openai_compat.py
+++ b/src/openai_compat.py
@@ -1,0 +1,116 @@
+"""Compatibility helpers for OpenAI chat-completion parameter drift."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from openai import BadRequestError
+
+
+_MAX_TOKENS_PARAM = "max_tokens"
+_MAX_COMPLETION_TOKENS_PARAM = "max_completion_tokens"
+_MAX_COMPLETION_TOKEN_MODEL_PREFIXES = (
+    "gpt-5",
+    "o1",
+    "o3",
+    "o4",
+)
+
+
+def _model_without_provider(model: str) -> str:
+    """Return the provider-local model name from either plain or provider:model form."""
+    return str(model).split(":", 1)[-1].strip().lower()
+
+
+def prefers_max_completion_tokens(model: str) -> bool:
+    """Return true for model families that reject legacy max_tokens."""
+    normalized_model = _model_without_provider(model)
+    return normalized_model.startswith(_MAX_COMPLETION_TOKEN_MODEL_PREFIXES)
+
+
+def chat_completion_token_limit_kwargs(model: str, token_limit: Optional[int]) -> Dict[str, int]:
+    """Build the token-limit kwargs for a chat completion request.
+
+    Newer OpenAI reasoning/chat model families reject ``max_tokens`` and require
+    ``max_completion_tokens``. Older OpenAI-compatible providers often still expect
+    ``max_tokens``. The caller can still recover if this guess is wrong by using
+    ``create_chat_completion_with_token_limit``.
+    """
+    if token_limit is None:
+        return {}
+    param = (
+        _MAX_COMPLETION_TOKENS_PARAM
+        if prefers_max_completion_tokens(model)
+        else _MAX_TOKENS_PARAM
+    )
+    return {param: token_limit}
+
+
+def _error_body(error: BadRequestError) -> Dict[str, Any]:
+    body = getattr(error, "body", None)
+    if not isinstance(body, dict):
+        return {}
+    nested_error = body.get("error")
+    if isinstance(nested_error, dict):
+        return nested_error
+    return body
+
+
+def _is_unsupported_param_error(error: BadRequestError, param: str) -> bool:
+    body = _error_body(error)
+    message = str(body.get("message") or error)
+    normalized_message = message.lower()
+    reported_param = body.get("param")
+    code = body.get("code")
+    param_matches = reported_param == param or param in message
+    unsupported = (
+        code == "unsupported_parameter"
+        or "unsupported" in normalized_message
+        or "not supported" in normalized_message
+    )
+    return param_matches and unsupported
+
+
+def _alternate_token_limit_param(param: str) -> str:
+    if param == _MAX_TOKENS_PARAM:
+        return _MAX_COMPLETION_TOKENS_PARAM
+    return _MAX_TOKENS_PARAM
+
+
+async def create_chat_completion_with_token_limit(
+    completions: Any,
+    *,
+    model: str,
+    messages: Any,
+    max_output_tokens: Optional[int] = None,
+    **kwargs: Any,
+) -> Any:
+    """Create a chat completion and retry once with the alternate token limit param.
+
+    This keeps model selection configurable: we use a model-family default for the
+    first request, then handle OpenAI-compatible providers or newly changed model
+    behavior by retrying only the known unsupported-parameter failure.
+    """
+    token_kwargs = chat_completion_token_limit_kwargs(model, max_output_tokens)
+    request_kwargs = {**kwargs, **token_kwargs}
+    try:
+        return await completions.create(
+            model=model,
+            messages=messages,
+            **request_kwargs,
+        )
+    except BadRequestError as error:
+        if not token_kwargs:
+            raise
+        token_param, token_limit = next(iter(token_kwargs.items()))
+        if not _is_unsupported_param_error(error, token_param):
+            raise
+
+        alternate_param = _alternate_token_limit_param(token_param)
+        retry_kwargs = dict(kwargs)
+        retry_kwargs[alternate_param] = token_limit
+        return await completions.create(
+            model=model,
+            messages=messages,
+            **retry_kwargs,
+        )

--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -40,6 +40,7 @@ from tqdm.asyncio import tqdm
 
 from src.app_config import load_app_config
 from src.properties_parser import parse_properties_file, reassemble_file
+from src.openai_compat import create_chat_completion_with_token_limit
 from src.usage_tracker import usage_tracker
 from src.cost_estimator import estimate_run_cost, format_estimate
 from src.locale_utils import is_locale_file
@@ -1303,14 +1304,15 @@ async def holistic_review_async(
         base_delay = 5  # Longer delay for a potentially larger task
         for attempt in range(1, max_retries + 1):
             try:
-                response = await client.chat.completions.create(
+                response = await create_chat_completion_with_token_limit(
+                    client.chat.completions,
                     model=REVIEW_MODEL_NAME,
                     messages=[
                         ChatCompletionSystemMessageParam(role="system", content=review_system_prompt)
                     ],
+                    max_output_tokens=8192,
                     temperature=0.1,
                     response_format={"type": "json_object"},
-                    max_tokens=8192,  # Increased to handle larger review responses
                     timeout=120.0,
                 )
                 usage_tracker.record_response(REVIEW_MODEL_NAME, response)

--- a/src/translation_semantic_reviewer.py
+++ b/src/translation_semantic_reviewer.py
@@ -14,6 +14,7 @@ import yaml
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam
 
+from src.openai_compat import create_chat_completion_with_token_limit
 from src.semantic_quality import (
     TranslationChange,
     iter_translation_changes_from_diff,
@@ -157,15 +158,16 @@ async def review_translation_changes(
         style_rules=style_rules,
         brand_glossary=brand_glossary,
     )
-    response = await client.chat.completions.create(
+    response = await create_chat_completion_with_token_limit(
+        client.chat.completions,
         model=model,
         messages=[
             ChatCompletionSystemMessageParam(role="system", content=messages[0]["content"]),
             ChatCompletionUserMessageParam(role="user", content=messages[1]["content"]),
         ],
+        max_output_tokens=4096,
         temperature=0,
         response_format={"type": "json_object"},
-        max_tokens=4096,
         timeout=120.0,
     )
     response_text = response.choices[0].message.content or ""

--- a/tests/unit/test_openai_compat.py
+++ b/tests/unit/test_openai_compat.py
@@ -1,0 +1,153 @@
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import BadRequestError
+
+from src.openai_compat import (
+    chat_completion_token_limit_kwargs,
+    create_chat_completion_with_token_limit,
+)
+
+
+def _bad_request_for_param(
+    param: str,
+    *,
+    message: str | None = None,
+    code: str = "unsupported_parameter",
+) -> BadRequestError:
+    message = message or f"Unsupported parameter: '{param}' is not supported with this model."
+    request = httpx.Request("POST", "https://api.example.test/v1/chat/completions")
+    response = httpx.Response(400, request=request)
+    return BadRequestError(
+        message,
+        response=response,
+        body={
+            "error": {
+                "message": message,
+                "param": param,
+                "code": code,
+            }
+        },
+    )
+
+
+def test_chat_completion_token_limit_kwargs_uses_model_appropriate_parameter():
+    assert chat_completion_token_limit_kwargs("gpt-5.4-mini", 4096) == {
+        "max_completion_tokens": 4096
+    }
+    assert chat_completion_token_limit_kwargs("openai:o3-mini", 4096) == {
+        "max_completion_tokens": 4096
+    }
+    assert chat_completion_token_limit_kwargs("gpt-4o", 4096) == {"max_tokens": 4096}
+
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_retries_with_alternate_token_limit_parameter():
+    class FakeCompletions:
+        def __init__(self):
+            self.calls = []
+
+        async def create(self, **kwargs):
+            self.calls.append(kwargs)
+            if len(self.calls) == 1:
+                raise _bad_request_for_param("max_tokens")
+            return SimpleNamespace(choices=[])
+
+    completions = FakeCompletions()
+
+    await create_chat_completion_with_token_limit(
+        completions,
+        model="custom-router-model",
+        messages=[{"role": "user", "content": "Return JSON."}],
+        max_output_tokens=123,
+        temperature=0,
+    )
+
+    assert completions.calls[0]["max_tokens"] == 123
+    assert "max_completion_tokens" not in completions.calls[0]
+    assert completions.calls[1]["max_completion_tokens"] == 123
+    assert "max_tokens" not in completions.calls[1]
+    assert completions.calls[1]["temperature"] == 0
+
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_uses_max_completion_tokens_first_for_gpt5():
+    class FakeCompletions:
+        def __init__(self):
+            self.calls = []
+
+        async def create(self, **kwargs):
+            self.calls.append(kwargs)
+            return SimpleNamespace(choices=[])
+
+    completions = FakeCompletions()
+
+    await create_chat_completion_with_token_limit(
+        completions,
+        model="gpt-5.4-mini",
+        messages=[{"role": "user", "content": "Return JSON."}],
+        max_output_tokens=456,
+    )
+
+    assert completions.calls == [
+        {
+            "model": "gpt-5.4-mini",
+            "messages": [{"role": "user", "content": "Return JSON."}],
+            "max_completion_tokens": 456,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_falls_back_to_max_tokens_for_compatible_api():
+    class FakeCompletions:
+        def __init__(self):
+            self.calls = []
+
+        async def create(self, **kwargs):
+            self.calls.append(kwargs)
+            if len(self.calls) == 1:
+                raise _bad_request_for_param("max_completion_tokens")
+            return SimpleNamespace(choices=[])
+
+    completions = FakeCompletions()
+
+    await create_chat_completion_with_token_limit(
+        completions,
+        model="gpt-5.4-mini",
+        messages=[{"role": "user", "content": "Return JSON."}],
+        max_output_tokens=789,
+    )
+
+    assert completions.calls[0]["max_completion_tokens"] == 789
+    assert "max_tokens" not in completions.calls[0]
+    assert completions.calls[1]["max_tokens"] == 789
+    assert "max_completion_tokens" not in completions.calls[1]
+
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_does_not_retry_other_token_limit_errors():
+    class FakeCompletions:
+        def __init__(self):
+            self.calls = []
+
+        async def create(self, **kwargs):
+            self.calls.append(kwargs)
+            raise _bad_request_for_param(
+                "max_tokens",
+                message="Invalid value for max_tokens.",
+                code="invalid_request_error",
+            )
+
+    completions = FakeCompletions()
+
+    with pytest.raises(BadRequestError, match="Invalid value for max_tokens"):
+        await create_chat_completion_with_token_limit(
+            completions,
+            model="custom-router-model",
+            messages=[{"role": "user", "content": "Return JSON."}],
+            max_output_tokens=-1,
+        )
+
+    assert len(completions.calls) == 1


### PR DESCRIPTION
## Summary

- Add an OpenAI chat-completion compatibility helper for capped completion requests.
- Use `max_completion_tokens` first for newer OpenAI model families while preserving `max_tokens` for older/OpenAI-compatible models.
- Retry once with the alternate token-limit parameter only when the API reports that the original parameter is unsupported.
- Route the holistic review and semantic review calls through the helper.

## Root Cause

The production semantic reviewer used `max_tokens` with a newer OpenAI model that rejects that parameter and expects `max_completion_tokens`. The regular translation call does not set a completion-token cap, so it was not part of this failure.

## Validation

- `env OPENAI_API_KEY=test-openai-key ./venv/bin/pytest tests/unit/test_openai_compat.py tests/unit/test_translation_semantic_reviewer.py tests/unit/test_holistic_review_protection.py -q`
- `env OPENAI_API_KEY=test-openai-key ./venv/bin/pytest -q`
