### PR TITLE
Add model token compatibility wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ leave your infrastructure:
 ./init.sh --input-folder path/to/your/i18n --api-base-url http://localhost:11434/v1
 ```
 
+Completion-token caps are normalized internally, so newer OpenAI models that
+require `max_completion_tokens` and compatible endpoints that only accept
+`max_tokens` can share the same config shape.
+
 ### Run it locally (no Docker, no CI)
 
 ```bash

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -64,6 +64,10 @@ Together, …) set `api-base-url`. When the endpoint needs no key (Ollama) omit
           api-base-url: http://localhost:11434/v1
 ```
 
+Completion-token caps are normalized internally. Newer OpenAI models that
+require `max_completion_tokens` and compatible endpoints that only accept
+`max_tokens` can use the same action inputs.
+
 ## Inputs
 
 | Input | Default | Purpose |

--- a/src/openai_compat.py
+++ b/src/openai_compat.py
@@ -1,0 +1,126 @@
+"""Compatibility helpers for OpenAI-compatible chat completion clients."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from openai import OpenAIError
+
+CompletionTokenParameter = Literal["max_tokens", "max_completion_tokens"]
+
+logger = logging.getLogger(__name__)
+
+_MAX_COMPLETION_TOKEN_MODEL_PREFIXES = (
+    "gpt-5",
+    "o1",
+    "o3",
+    "o4",
+    "o5",
+)
+
+_UNSUPPORTED_PARAMETER_MARKERS = (
+    "unsupported parameter",
+    "not supported",
+    "not compatible",
+    "unrecognized request argument",
+    "unknown parameter",
+    "unexpected keyword argument",
+    "invalid parameter",
+)
+
+
+def completion_token_parameter_for_model(model: str) -> CompletionTokenParameter:
+    """Return the preferred completion-token cap parameter for ``model``.
+
+    OpenAI reasoning/newer chat models reject ``max_tokens`` and require
+    ``max_completion_tokens``. Other OpenAI-compatible providers may only
+    support the older name, so unknown models keep ``max_tokens`` first and the
+    request helper falls back when the API returns a parameter-compatibility
+    error.
+    """
+    normalized = model.lower()
+    if normalized.startswith(_MAX_COMPLETION_TOKEN_MODEL_PREFIXES):
+        return "max_completion_tokens"
+    return "max_tokens"
+
+
+def _looks_like_unsupported_parameter(exc: Exception, parameter: str) -> bool:
+    message = str(exc).lower()
+    if parameter.lower() not in message:
+        return False
+    return any(marker in message for marker in _UNSUPPORTED_PARAMETER_MARKERS)
+
+
+def _with_completion_token_limit(
+    kwargs: dict[str, Any],
+    parameter: CompletionTokenParameter,
+    limit: int,
+) -> dict[str, Any]:
+    request_kwargs = dict(kwargs)
+    request_kwargs.pop("max_tokens", None)
+    request_kwargs.pop("max_completion_tokens", None)
+    request_kwargs[parameter] = limit
+    return request_kwargs
+
+
+async def create_chat_completion(
+    client: Any,
+    *,
+    model: str,
+    messages: Any,
+    completion_token_limit: int | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Create a chat completion with model-aware token-limit parameters.
+
+    ``completion_token_limit`` is intentionally provider-agnostic. The helper
+    chooses the preferred OpenAI parameter name for known models and retries
+    once with the alternate name if an OpenAI-compatible API rejects it.
+    """
+    if completion_token_limit is None:
+        return await client.chat.completions.create(
+            model=model,
+            messages=messages,
+            **kwargs,
+        )
+
+    first_parameter = completion_token_parameter_for_model(model)
+    fallback_parameter: CompletionTokenParameter = (
+        "max_completion_tokens"
+        if first_parameter == "max_tokens"
+        else "max_tokens"
+    )
+    first_kwargs = _with_completion_token_limit(
+        kwargs,
+        first_parameter,
+        completion_token_limit,
+    )
+
+    try:
+        return await client.chat.completions.create(
+            model=model,
+            messages=messages,
+            **first_kwargs,
+        )
+    except (OpenAIError, TypeError) as exc:
+        if not _looks_like_unsupported_parameter(exc, first_parameter):
+            raise
+
+    logger.debug(
+        "Retrying chat completion for model '%s' with '%s' instead of '%s' "
+        "after parameter compatibility error.",
+        model,
+        fallback_parameter,
+        first_parameter,
+    )
+    fallback_kwargs = _with_completion_token_limit(
+        kwargs,
+        fallback_parameter,
+        completion_token_limit,
+    )
+    return await client.chat.completions.create(
+        model=model,
+        messages=messages,
+        **fallback_kwargs,
+    )

--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -40,6 +40,7 @@ from tqdm.asyncio import tqdm
 
 from src.app_config import load_app_config
 from src.localization_formats import JAVA_PROPERTIES_FORMAT, LocalizationFormat
+from src.openai_compat import create_chat_completion
 from src.properties_parser import parse_properties_file, reassemble_file
 from src.usage_tracker import usage_tracker
 from src.cost_estimator import estimate_run_cost, format_estimate
@@ -1138,7 +1139,8 @@ Provide the translation **of the Value only**, following the instructions above.
         for attempt in range(1, max_retries + 1):  # type: ignore[arg-type]
             try:
                 # Use chat completion API
-                response = await client.chat.completions.create(
+                response = await create_chat_completion(
+                    client,
                     model=MODEL_NAME,
                     messages=[
                         ChatCompletionSystemMessageParam(role="system", content=system_prompt),
@@ -1295,14 +1297,15 @@ async def holistic_review_async(
         base_delay = 5  # Longer delay for a potentially larger task
         for attempt in range(1, max_retries + 1):
             try:
-                response = await client.chat.completions.create(
+                response = await create_chat_completion(
+                    client,
                     model=REVIEW_MODEL_NAME,
                     messages=[
                         ChatCompletionSystemMessageParam(role="system", content=review_system_prompt)
                     ],
                     temperature=0.1,
                     response_format={"type": "json_object"},
-                    max_tokens=8192,  # Increased to handle larger review responses
+                    completion_token_limit=8192,
                     timeout=120.0,
                 )
                 usage_tracker.record_response(REVIEW_MODEL_NAME, response)

--- a/src/translation_semantic_reviewer.py
+++ b/src/translation_semantic_reviewer.py
@@ -14,6 +14,7 @@ import yaml
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam
 
+from src.openai_compat import create_chat_completion
 from src.semantic_quality import (
     TranslationChange,
     iter_translation_changes_from_diff,
@@ -157,7 +158,8 @@ async def review_translation_changes(
         style_rules=style_rules,
         brand_glossary=brand_glossary,
     )
-    response = await client.chat.completions.create(
+    response = await create_chat_completion(
+        client,
         model=model,
         messages=[
             ChatCompletionSystemMessageParam(role="system", content=messages[0]["content"]),
@@ -165,7 +167,7 @@ async def review_translation_changes(
         ],
         temperature=0,
         response_format={"type": "json_object"},
-        max_tokens=4096,
+        completion_token_limit=4096,
         timeout=120.0,
     )
     response_text = response.choices[0].message.content or ""

--- a/tests/unit/test_holistic_review_protection.py
+++ b/tests/unit/test_holistic_review_protection.py
@@ -5,7 +5,15 @@ Tests the ability to protect placeholders during holistic review phase
 to prevent the AI from modifying, removing, or adding placeholders.
 """
 
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
 from src.translate_localization_files import (
+    holistic_review_async,
     protect_placeholders_in_properties,
     restore_placeholders_in_properties
 )
@@ -160,3 +168,51 @@ key2=World {1}"""
         assert "# Comment" in protected
         assert "\n\n" in protected  # Blank line preserved
         assert "__PH_" in protected
+
+
+class _NullAsyncContext:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_holistic_review_uses_compatible_completion_token_limit():
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=json.dumps({"key1": "Hallo {0}"})
+                )
+            )
+        ]
+    )
+    create_completion = AsyncMock(return_value=response)
+
+    with (
+        patch("src.translate_localization_files.DRY_RUN", False),
+        patch("src.translate_localization_files.client", object()),
+        patch("src.translate_localization_files.REVIEW_MODEL_NAME", "gpt-5.4-mini"),
+        patch("src.translate_localization_files.create_chat_completion", create_completion),
+        patch("src.translate_localization_files.usage_tracker.record_response") as record_response,
+    ):
+        result = await holistic_review_async(
+            source_content="key1=Hello {0}",
+            translated_content="key1=Hallo {0}",
+            target_language="German",
+            keys_to_review=["key1"],
+            semaphore=asyncio.Semaphore(1),
+            rate_limiter=_NullAsyncContext(),
+            style_rules_text="",
+        )
+
+    assert result == {"key1": "Hallo {0}"}
+    kwargs = create_completion.await_args.kwargs
+    assert kwargs["model"] == "gpt-5.4-mini"
+    assert kwargs["completion_token_limit"] == 8192
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert "max_tokens" not in kwargs
+    assert "max_completion_tokens" not in kwargs
+    record_response.assert_called_once_with("gpt-5.4-mini", response)

--- a/tests/unit/test_openai_compat.py
+++ b/tests/unit/test_openai_compat.py
@@ -1,0 +1,148 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+from openai import OpenAIError
+
+from src.openai_compat import create_chat_completion
+
+
+def _response(content="{}"):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+class _FakeCompletions:
+    def __init__(self, *outcomes):
+        self.outcomes = list(outcomes) or [_response()]
+        self.calls = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class _FakeClient:
+    def __init__(self, *outcomes):
+        self.chat = SimpleNamespace(completions=_FakeCompletions(*outcomes))
+
+    @property
+    def calls(self):
+        return self.chat.completions.calls
+
+
+@pytest.mark.asyncio
+async def test_newer_openai_models_use_max_completion_tokens():
+    client = _FakeClient()
+
+    await create_chat_completion(
+        client,
+        model="gpt-5.4-mini",
+        messages=[],
+        completion_token_limit=4096,
+        temperature=0,
+    )
+
+    assert client.calls[0]["max_completion_tokens"] == 4096
+    assert "max_tokens" not in client.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_default_models_keep_max_tokens_for_provider_compatibility():
+    client = _FakeClient()
+
+    await create_chat_completion(
+        client,
+        model="gpt-4o",
+        messages=[],
+        completion_token_limit=4096,
+        temperature=0,
+    )
+
+    assert client.calls[0]["max_tokens"] == 4096
+    assert "max_completion_tokens" not in client.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_retries_with_max_completion_tokens_when_max_tokens_is_rejected(caplog):
+    client = _FakeClient(
+        OpenAIError("Unsupported parameter: 'max_tokens'"),
+        _response(),
+    )
+    caplog.set_level(logging.DEBUG, logger="src.openai_compat")
+
+    await create_chat_completion(
+        client,
+        model="custom-provider-model",
+        messages=[],
+        completion_token_limit=2048,
+    )
+
+    assert client.calls[0]["max_tokens"] == 2048
+    assert "max_completion_tokens" not in client.calls[0]
+    assert client.calls[1]["max_completion_tokens"] == 2048
+    assert "max_tokens" not in client.calls[1]
+    assert "Retrying chat completion" in caplog.text
+    assert "max_completion_tokens" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_retries_with_max_tokens_when_max_completion_tokens_is_rejected():
+    client = _FakeClient(
+        OpenAIError("Unsupported parameter: 'max_completion_tokens'"),
+        _response(),
+    )
+
+    await create_chat_completion(
+        client,
+        model="gpt-5.4-mini",
+        messages=[],
+        completion_token_limit=2048,
+    )
+
+    assert client.calls[0]["max_completion_tokens"] == 2048
+    assert "max_tokens" not in client.calls[0]
+    assert client.calls[1]["max_tokens"] == 2048
+    assert "max_completion_tokens" not in client.calls[1]
+
+
+@pytest.mark.asyncio
+async def test_retries_when_local_sdk_rejects_unknown_parameter():
+    client = _FakeClient(
+        TypeError(
+            "AsyncCompletions.create() got an unexpected keyword argument "
+            "'max_completion_tokens'"
+        ),
+        _response(),
+    )
+
+    await create_chat_completion(
+        client,
+        model="gpt-5.4-mini",
+        messages=[],
+        completion_token_limit=2048,
+    )
+
+    assert client.calls[0]["max_completion_tokens"] == 2048
+    assert "max_tokens" not in client.calls[0]
+    assert client.calls[1]["max_tokens"] == 2048
+    assert "max_completion_tokens" not in client.calls[1]
+
+
+@pytest.mark.asyncio
+async def test_omits_completion_token_cap_when_no_limit_is_requested():
+    client = _FakeClient()
+
+    await create_chat_completion(
+        client,
+        model="gpt-5.4-mini",
+        messages=[],
+        temperature=0.3,
+    )
+
+    assert "max_tokens" not in client.calls[0]
+    assert "max_completion_tokens" not in client.calls[0]

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -1,5 +1,7 @@
 import json
 import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -11,6 +13,7 @@ from src.translation_semantic_reviewer import (
     append_semantic_review_findings,
     build_semantic_review_messages,
     normalize_review_response,
+    review_translation_changes,
 )
 
 
@@ -174,3 +177,46 @@ async def test_semantic_reviewer_is_opt_in(tmp_path):
 
     assert exit_code == 0
     assert not validation_summary_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_semantic_reviewer_uses_compatible_completion_token_limit():
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=json.dumps({"findings": []}))
+            )
+        ]
+    )
+    create_completion = AsyncMock(return_value=response)
+    changes = [
+        TranslationChange(
+            file="resources/mobile_es.properties",
+            locale_code="es",
+            key="mobile.clear",
+            source_value="Clear network address: {0}",
+            old_value=None,
+            new_value="Borrar dirección de red: {0}",
+        )
+    ]
+
+    with patch(
+        "src.translation_semantic_reviewer.create_chat_completion",
+        create_completion,
+    ):
+        findings = await review_translation_changes(
+            client=object(),
+            model="gpt-5.4-mini",
+            target_language="Spanish",
+            changes=changes,
+            style_rules=[],
+            brand_glossary=[],
+        )
+
+    assert findings == []
+    kwargs = create_completion.await_args.kwargs
+    assert kwargs["model"] == "gpt-5.4-mini"
+    assert kwargs["completion_token_limit"] == 4096
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert "max_tokens" not in kwargs
+    assert "max_completion_tokens" not in kwargs


### PR DESCRIPTION
## Summary
- add a shared chat-completion compatibility helper for provider-agnostic completion token limits
- route translation, holistic review, and semantic review calls through the helper
- document max_tokens/max_completion_tokens normalization for local endpoints and GitHub Action users

## Tests
- venv/bin/python -m pytest
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader compatibility for chat completions across different model requirements, including support for newer token-cap behavior.
  * Updated translation review and localization flows to use the shared completion handling.

* **Documentation**
  * Clarified setup notes in the README and GitHub Action guide about token-cap normalization for compatible model configurations.

* **Tests**
  * Added coverage for model-specific token-cap handling, fallback behavior, and JSON response usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->