### PR TITLE
Allowlist version loanword for Bisq locales

### DIFF
--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -23,9 +23,12 @@ quality_gate:
   block_on_semantic_qa_warnings: false
   semantic_qa_audit_scope: "changed"
   retained_source_word_allowlist:
+    da: ["version"]
+    de: ["version"]
     es: ["personal"]
-    fr: ["information", "message", "messages"]
+    fr: ["information", "message", "messages", "version"]
     it: ["reporting"]
+    sv: ["version"]
 semantic_review:
   enabled: true
   model: "gpt-5.4-mini"

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -126,6 +126,10 @@ def test_recent_coderabbit_translation_nits_are_encoded_as_style_rules(config_pa
     )
     assert semantic_review.get("enabled") is True
     assert semantic_review.get("model") == "gpt-5.4-mini"
+    assert "version" in retained_allowlist["da"]
+    assert "version" in retained_allowlist["de"]
+    assert {"information", "message", "messages", "version"}.issubset(retained_allowlist["fr"])
+    assert "version" in retained_allowlist["sv"]
     assert {
         "trade-history-traders-label",
         "af-trade-history-counts-trades",


### PR DESCRIPTION
## Summary
- add `version` to the retained-source-word allowlist for Danish, German, French, and Swedish in the Bisq profile
- keep the allowlist scoped to the Bisq profile now that generic config is intentionally minimal
- extend the config-quality regression test for the new allowlist entries

## Why
Draft PR #76 targeted the old config layout and is now conflicted. The underlying CodeRabbit false positive from bisq-network/bisq2#4848 still applies: `version` is a valid loanword/cognate for these locales, while other locales should still be flagged when they retain it untranslated.

## Tests
- venv/bin/python -m pytest tests/unit/test_config_quality.py::test_recent_coderabbit_translation_nits_are_encoded_as_style_rules
- venv/bin/python -m pytest
- git diff --check

Replaces #76.