### PR TITLE
Make model provider reusable

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -218,3 +218,19 @@ CVE-2026-39821
 CVE-2026-42502
 CVE-2026-42506
 CVE-2026-27145
+
+# CVE-2026-48702, CVE-2026-39832:
+# New Trivy findings in Go dependencies embedded in CI/CD helper binaries.
+# Affects: gh v2.93.0 (github.com/sigstore/rekor) and tx v1.6.17
+#          (golang.org/x/crypto/ssh/agent).
+# Rationale: These binaries are used only in controlled build/deployment
+#            automation. gh is used for GitHub API/PR/status operations and not
+#            for untrusted Rekor bundle decompression in this workflow. tx talks
+#            to Transifex's API using fixed workflow inputs and does not expose
+#            SSH agent forwarding to untrusted users here. Mitigation depends on
+#            upstream releases or a future toolchain refresh.
+# Checked CI Trivy report: 2026-06-26.
+# Added: 2026-06-26
+# Revisit by: 2026-08-15
+CVE-2026-48702
+CVE-2026-39832

--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ summary afterward, so you always know what a run costs on your key.
 
 ## Features
 
-* **Your provider, your cost** — OpenAI, or any OpenAI-compatible endpoint
-  (Ollama, Groq, Together, …) via `api_base_url` / `OPENAI_BASE_URL`. No markup, no quota.
+* **Your provider, your cost** — AISuite is the default packaged provider
+  abstraction for multi-provider model names, with OpenAI-compatible endpoints
+  (Ollama, Groq, Together, …) supported through `api_base_url` /
+  `OPENAI_BASE_URL`. No markup, no quota.
 * **Two-step quality process** — a fast initial translation followed by a chunked
   holistic AI review for consistency and quality.
 * **Glossary & style rules** — enforce brand terms, required translations, and
@@ -122,10 +124,27 @@ Key settings:
 | `localization_format` | File format metadata. Built-in: `java_properties`; custom mappings can describe future formats. |
 | `project_context` | Product/domain guidance injected into translation prompts. |
 | `translation_source` | `git` (default for new projects) or `transifex`. |
+| `model_provider` | `aisuite` by default; use `openai_compatible` only for the direct OpenAI SDK fallback path. |
 | `model_name`, `review_model_name` | Translate and review models. |
 | `api_base_url` | OpenAI-compatible endpoint, e.g. a local Ollama server. |
 | `supported_locales` | Target languages. |
 | `style_rules`, `brand_technical_glossary` | Per-locale tone and do-not-translate terms. |
+
+AISuite is the default packaged provider. Bare model names such as
+`gpt-4o-mini` are treated as OpenAI models for compatibility, and explicit
+AISuite names such as `openai:gpt-4o-mini` remain supported. The pipeline still
+owns token counting, cost estimates, retry behavior, and completion-token
+compatibility at its provider boundary, so direct OpenAI SDK fallback runs can
+use the same higher-level config shape.
+
+### Public API boundaries
+
+Reusable modules should import from the stable public packages instead of
+internal implementation files:
+
+* `src.core` — format-agnostic pipeline orchestration contracts.
+* `src.providers` — chat-model provider contracts and provider factories.
+* `src.formats` — localization format metadata and loader helpers.
 
 ### Adding new languages
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,7 @@ project_context: "Translate concise UI text for a software product."
 translation_source: "git"
 
 # --- Model / provider ---
+model_provider: "aisuite"           # Default AISuite-backed provider abstraction.
 model_name: "gpt-4o-mini"          # fast initial translation
 review_model_name: "gpt-4o"        # holistic review pass (set equal to model_name to save cost)
 
@@ -35,6 +36,18 @@ review_model_name: "gpt-4o"        # holistic review pass (set equal to model_na
 # translate with zero data egress and no API key (set the model names to a model
 # you have pulled, e.g. "llama3.1"). Env var OPENAI_BASE_URL overrides this.
 # api_base_url: "http://localhost:11434/v1"
+
+# AISuite lets one config address multiple providers with model names like
+# "openai:gpt-4o-mini" or "anthropic:claude-3-5-sonnet". Bare model names are
+# treated as OpenAI models by default. Use model_provider: "openai_compatible"
+# only when you explicitly want the direct OpenAI SDK fallback path.
+# model_provider: "aisuite"
+# model_name: "openai:gpt-4o-mini"
+# review_model_name: "openai:gpt-4o"
+# aisuite:
+#   provider_configs:
+#     # Keep secrets in environment variables or your secret manager, not here.
+#     openai: {}
 
 # --- Glossary (optional but recommended) ---
 # JSON file of per-language term mappings. See glossary.example.json for the format.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -54,6 +54,10 @@ opens a PR you can review and merge.
 
 ## Using your own model / a local endpoint
 
+The action uses the packaged AISuite provider abstraction by default. Bare model
+names are treated as OpenAI models for compatibility; explicit AISuite names
+such as `openai:gpt-4o-mini` can be set in `config.yaml`.
+
 To translate against any OpenAI-compatible endpoint (a self-hosted Ollama, Groq,
 Together, …) set `api-base-url`. When the endpoint needs no key (Ollama) omit
 `openai-api-key` entirely — your strings never leave your infrastructure:

--- a/docs/new-project-deployment.md
+++ b/docs/new-project-deployment.md
@@ -107,6 +107,11 @@ The `TRANSLATOR_PROFILE=my-project` value in `docker/.env` selects
 `profiles/my-project/` for Docker runs. The included Bisq production profile is
 available under `profiles/bisq/` as a complete real-world example.
 
+The default profile uses `model_provider: aisuite`, which is packaged with the
+Docker image. Bare model names are treated as OpenAI models. Set
+`model_provider: openai_compatible` only if you intentionally want the direct
+OpenAI SDK fallback path.
+
 ## Step 4: Build the Docker Image
 
 From the project root, run the build command. This will create a self-contained image with all dependencies.

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -37,6 +37,7 @@ This document outlines the structure and purpose of the files and directories wi
 - **`secrets/`**: (User-managed, gitignored) Stores sensitive files like GPG keys.
 - **`src/`**: Contains the main Python source code for the translation utilities.
   - **`src/pipeline_core.py`**: Format-agnostic run orchestration. It wires injected adapters for change detection, queue processing, reporting, copy-back, and cleanup.
+  - **`src/model_provider.py`**: Provider abstraction for chat completions, token counting, usage tracking, pricing estimates, AISuite dispatch, and the direct OpenAI-compatible fallback.
   - **`src/translate_localization_files.py`**: Java `.properties` runtime adapter and translation implementation. It loads config, provides parser/validator/reporting callables, and invokes `pipeline_core`.
 - **`tests/`**: Contains test files for the project.
 - **`update-translations.sh`**: The main orchestration script, run by the container. It pulls from Transifex, runs the Python script, and manages the Git workflow (branching, committing, creating a PR).
@@ -52,7 +53,9 @@ This document outlines the structure and purpose of the files and directories wi
 
 - **`src/pipeline_core.py`**: Generic Python orchestration for a translation run. It does not know about Java `.properties`, Transifex, GitHub, or OpenAI directly; those behaviors are injected by the runtime entry point.
 
-- **`src/translate_localization_files.py`**: The Java `.properties` runtime adapter. It loads configuration, parses `.properties` files, manages the two-step translation and review process with the OpenAI API, and passes those callables into `pipeline_core`.
+- **`src/model_provider.py`**: AISuite-backed provider boundary. The default backend can dispatch to multiple providers while preserving the pipeline's async interface, usage tracking, token counting, and completion-token compatibility. The direct OpenAI-compatible SDK provider remains available as an explicit fallback.
+
+- **`src/translate_localization_files.py`**: The Java `.properties` runtime adapter. It loads configuration, parses `.properties` files, manages the two-step translation and review process through the configured model provider, and passes those callables into `pipeline_core`.
 
 - **`update-translations.sh`**: The main container orchestration script. It prepares the configured translation source (`git` or `transifex`), runs the Python pipeline, and uses a publisher helper for the Git workflow (branching, committing, creating a PR).
 

--- a/examples/generic-java-properties/README.md
+++ b/examples/generic-java-properties/README.md
@@ -1,0 +1,14 @@
+# Generic Java .properties Example
+
+This generic Java .properties profile is for a project that stores localization
+files as Java `.properties`.
+
+It demonstrates the reusable contract without project-specific terminology:
+
+- `config.yaml` uses the default AISuite-backed provider abstraction.
+- `glossary.json` shows the per-locale glossary shape.
+- `resources/messages.properties` is the source file.
+- `resources/messages_de.properties` is the German target file.
+
+To adapt it, copy the directory into a test project, update `target_project_root`
+and `input_folder`, then run the pipeline with that config.

--- a/examples/generic-java-properties/config.yaml
+++ b/examples/generic-java-properties/config.yaml
@@ -1,0 +1,23 @@
+# Generic Java .properties example profile.
+target_project_root: "."
+input_folder: "resources"
+localization_format: "java_properties"
+project_context: "Translate concise UI text for a software product."
+translation_source: "git"
+
+model_provider: "aisuite"
+model_name: "gpt-4o-mini"
+review_model_name: "gpt-4o"
+
+glossary_file_path: "glossary.json"
+brand_technical_glossary:
+  - GitHub
+
+dry_run: false
+supported_locales:
+  - code: "de"
+    name: "German"
+
+style_rules:
+  de:
+    - "Use clear, concise software UI wording."

--- a/examples/generic-java-properties/glossary.json
+++ b/examples/generic-java-properties/glossary.json
@@ -1,0 +1,6 @@
+{
+  "de": {
+    "account": "Konto",
+    "settings": "Einstellungen"
+  }
+}

--- a/examples/generic-java-properties/resources/messages.properties
+++ b/examples/generic-java-properties/resources/messages.properties
@@ -1,0 +1,3 @@
+app.title=Example app
+settings.save=Save settings
+account.name=Account name

--- a/examples/generic-java-properties/resources/messages_de.properties
+++ b/examples/generic-java-properties/resources/messages_de.properties
@@ -1,0 +1,1 @@
+app.title=Beispiel-App

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,10 @@ aiolimiter==1.2.1 \
     --hash=sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7 \
     --hash=sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9
     # via -r requirements.in
+aisuite==0.1.14 \
+    --hash=sha256:70eedefeae647f4ae4115d8aee04bcd9aa45d7fdef6e01c0a4bf07239f0cb7f4 \
+    --hash=sha256:87fe78af1074b57b2b033c60a1700d52505784a550e9e259f21c3e6d368f38bc
+    # via -r requirements.in
 annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
@@ -155,6 +159,10 @@ distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
     # via openai
+docstring-parser==0.15 \
+    --hash=sha256:48ddc093e8b1865899956fcc03b03e66bb7240c310fac5af81814580c55bf682 \
+    --hash=sha256:d1679b86250d269d06a99670924d6bce45adc00b08069dae8c47d98e89b667a9
+    # via aisuite
 filelock==3.20.3 \
     --hash=sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1 \
     --hash=sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1
@@ -175,11 +183,12 @@ httpcore==1.0.9 \
     --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
     --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
     # via httpx
-httpx==0.28.1 \
-    --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
-    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+httpx==0.27.2 \
+    --hash=sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0 \
+    --hash=sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2
     # via
     #   -r requirements.in
+    #   aisuite
     #   openai
 idna==3.15 \
     --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
@@ -894,6 +903,7 @@ sniffio==1.3.1 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
     # via
     #   anyio
+    #   httpx
     #   openai
 sortedcontainers==2.4.0 \
     --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88 \

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@
 # Run 'pip-compile' to generate requirements.txt
 
 openai
+aisuite==0.1.14
 python-dotenv
 PyYAML
 GitPython

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 aiolimiter==1.2.1
     # via -r requirements.in
+aisuite==0.1.14
+    # via -r requirements.in
 annotated-types==0.7.0
     # via pydantic
 anyio==4.10.0
@@ -25,6 +27,8 @@ charset-normalizer==3.4.2
     # via requests
 distro==1.9.0
     # via openai
+docstring-parser==0.15
+    # via aisuite
 gitdb==4.0.12
     # via gitpython
 gitpython==3.1.50
@@ -33,9 +37,10 @@ h11==0.16.0
     # via httpcore
 httpcore==1.0.9
     # via httpx
-httpx==0.28.1
+httpx==0.27.2
     # via
     #   -r requirements.in
+    #   aisuite
     #   openai
 idna==3.15
     # via
@@ -79,6 +84,7 @@ smmap==5.0.2
 sniffio==1.3.1
     # via
     #   anyio
+    #   httpx
     #   openai
 text-unidecode==1.3
     # via python-slugify

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -8,13 +8,19 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 from dotenv import load_dotenv
-from openai import AsyncOpenAI
 
 from src.logging_config import setup_logger
 from src.localization_formats import (
     JAVA_PROPERTIES_FORMAT,
     LocalizationFormat,
     load_localization_format,
+)
+from src.model_provider import (
+    ChatModelProvider,
+    DEFAULT_MODEL_PROVIDER,
+    ModelProviderConfigurationError,
+    create_model_provider,
+    normalize_model_provider_name,
 )
 from src.semantic_quality import normalize_retained_source_word_allowlist
 
@@ -66,8 +72,12 @@ class AppConfig:
     translation_key_ledger_file_path: str
     preserve_queues_for_debug: bool
 
-    # OpenAI client
-    openai_client: Optional[AsyncOpenAI]
+    # Model provider
+    model_provider: Optional[ChatModelProvider]
+    # Backward-compatible raw client alias for tests and older callers. New code
+    # should use model_provider.
+    openai_client: Optional[Any]
+    model_provider_name: str = DEFAULT_MODEL_PROVIDER
 
     # Generated PR quality gate
     quality_gate: QualityGateConfig = field(default_factory=QualityGateConfig)
@@ -329,11 +339,6 @@ def _as_bool(value: Any, default: bool) -> bool:
     return default
 
 
-# Placeholder key for local/self-hosted OpenAI-compatible servers (e.g. Ollama)
-# that do not require authentication. The SDK requires a non-empty api_key.
-_LOCAL_PROVIDER_PLACEHOLDER_KEY = "not-needed"
-
-
 def _resolve_api_base_url(config: Dict[str, Any]) -> Optional[str]:
     """Resolve the OpenAI-compatible endpoint, env (OPENAI_BASE_URL) over config.
 
@@ -347,12 +352,14 @@ def _resolve_api_base_url(config: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def _create_openai_client(
+def _create_model_provider(
     dry_run: bool,
     logger: logging.Logger,
+    provider_name: str,
     api_base_url: Optional[str] = None,
-) -> Optional[AsyncOpenAI]:
-    """Create an OpenAI(-compatible) client unless running in dry-run mode.
+    aisuite_provider_configs: Optional[Dict[str, Any]] = None,
+) -> Optional[ChatModelProvider]:
+    """Create the configured chat model provider unless running in dry-run mode.
 
     When ``api_base_url`` is set the client targets a custom endpoint (another
     provider or a local Ollama server). Such endpoints often need no key, so a
@@ -360,40 +367,27 @@ def _create_openai_client(
     OpenAI API a missing key remains a hard error.
     """
     if dry_run:
-        logger.info("Running in dry-run mode, OpenAI client will not be initialized")
+        logger.info("Running in dry-run mode, model provider will not be initialized")
         return None
 
-    is_custom_endpoint = bool(api_base_url)
     api_key_from_env = os.environ.get('OPENAI_API_KEY')
 
-    if not api_key_from_env:
-        if is_custom_endpoint:
-            logger.info(
-                "No OPENAI_API_KEY set; using a placeholder key for custom endpoint '%s' "
-                "(typical for local servers such as Ollama).",
-                api_base_url,
-            )
-            api_key_from_env = _LOCAL_PROVIDER_PLACEHOLDER_KEY
-        else:
-            logger.critical("CRITICAL: OPENAI_API_KEY environment variable not found.")
+    try:
+        return create_model_provider(
+            provider_name=provider_name,
+            api_key=api_key_from_env,
+            api_base_url=api_base_url,
+            logger=logger,
+            aisuite_provider_configs=aisuite_provider_configs,
+        )
+    except ModelProviderConfigurationError as exc:
+        logger.critical("CRITICAL: %s", exc)
+        if "OPENAI_API_KEY" in str(exc):
             logger.critical("Please set OPENAI_API_KEY or enable dry_run mode in configuration.")
             logger.critical("For dry-run mode, set 'dry_run: true' in your config file.")
-            sys.exit(1)
-    elif not is_custom_endpoint and not api_key_from_env.startswith('sk-'):
-        # The sk- convention only applies to the official OpenAI API; BYO keys for
-        # other providers (Groq, Together, etc.) use different prefixes.
-        logger.warning("Warning: OPENAI_API_KEY does not start with 'sk-'. This may be invalid.")
-
-    try:
-        client_kwargs: Dict[str, Any] = {"api_key": api_key_from_env}
-        if api_base_url:
-            client_kwargs["base_url"] = api_base_url
-            logger.info("Using OpenAI-compatible endpoint: %s", api_base_url)
-        client = AsyncOpenAI(**client_kwargs)
-        logger.info("OpenAI client initialized successfully")
-        return client
+        sys.exit(1)
     except Exception as e:
-        logger.critical("Failed to initialize OpenAI client: %s", str(e))
+        logger.critical("Failed to initialize model provider: %s", str(e))
         logger.critical("Please check your OPENAI_API_KEY and network connectivity.")
         sys.exit(1)
 
@@ -445,6 +439,11 @@ def load_app_config() -> AppConfig:
     )
     model_name = config.get('model_name', 'gpt-4')
     review_model_name = os.environ.get('REVIEW_MODEL_NAME', config.get('review_model_name', model_name))
+    model_provider_name = normalize_model_provider_name(
+        str(config.get('model_provider', DEFAULT_MODEL_PROVIDER) or DEFAULT_MODEL_PROVIDER)
+    )
+    aisuite_config = config.get('aisuite', {}) or {}
+    aisuite_provider_configs = aisuite_config.get('provider_configs', {}) or {}
     retranslate_identical_source_strings = bool(config.get('retranslate_identical_source_strings', False))
     quality_gate_config = config.get('quality_gate', {}) or {}
     quality_gate = QualityGateConfig(
@@ -490,8 +489,15 @@ def load_app_config() -> AppConfig:
     except ValueError:
         localization_format = JAVA_PROPERTIES_FORMAT
 
-    # Create the client against the endpoint resolved earlier.
-    openai_client = _create_openai_client(dry_run, logger, api_base_url)
+    # Create the provider against the endpoint resolved earlier.
+    model_provider = _create_model_provider(
+        dry_run,
+        logger,
+        model_provider_name,
+        api_base_url,
+        aisuite_provider_configs,
+    )
+    openai_client = getattr(model_provider, "client", None) if model_provider else None
 
     return AppConfig(
         project_root=project_root,
@@ -515,7 +521,9 @@ def load_app_config() -> AppConfig:
         translated_queue_folder=translated_queue_folder,
         translation_key_ledger_file_path=translation_key_ledger_file_path,
         preserve_queues_for_debug=config.get('preserve_queues_for_debug', False),
+        model_provider=model_provider,
         openai_client=openai_client,
+        model_provider_name=model_provider_name,
         quality_gate=quality_gate,
         api_base_url=api_base_url,
         project_context=project_context,

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,19 @@
+"""Public core orchestration API."""
+
+from src.pipeline_core import (
+    ProcessQueueResult,
+    TranslationPipelineOptions,
+    TranslationPipelinePaths,
+    TranslationPipelineResult,
+    TranslationPipelineSteps,
+    run_translation_pipeline,
+)
+
+__all__ = [
+    "ProcessQueueResult",
+    "TranslationPipelineOptions",
+    "TranslationPipelinePaths",
+    "TranslationPipelineResult",
+    "TranslationPipelineSteps",
+    "run_translation_pipeline",
+]

--- a/src/formats/__init__.py
+++ b/src/formats/__init__.py
@@ -1,0 +1,13 @@
+"""Public localization-format metadata API."""
+
+from src.localization_formats import (
+    JAVA_PROPERTIES_FORMAT,
+    LocalizationFormat,
+    load_localization_format,
+)
+
+__all__ = [
+    "JAVA_PROPERTIES_FORMAT",
+    "LocalizationFormat",
+    "load_localization_format",
+]

--- a/src/model_provider.py
+++ b/src/model_provider.py
@@ -1,0 +1,348 @@
+"""Model-provider abstraction for chat completions, usage, tokens, and cost."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+from typing import Any, Dict, Optional, Protocol, Sequence
+
+import tiktoken
+from openai import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AsyncOpenAI,
+    RateLimitError,
+)
+
+from src.cost_estimator import CostEstimate, estimate_run_cost, format_estimate
+from src.openai_compat import create_chat_completion, create_chat_completion_with_fallback
+from src.usage_tracker import DEFAULT_PRICES, UsageTracker
+
+
+_LOCAL_PROVIDER_PLACEHOLDER_KEY = "not-needed"
+DEFAULT_MODEL_PROVIDER = "aisuite"
+DEFAULT_AISUITE_PROVIDER = "openai"
+_MODEL_PROVIDER_ALIASES = {
+    "aisuite": "aisuite",
+    "openai": "openai_compatible",
+    "openai_compatible": "openai_compatible",
+}
+
+
+class ModelProviderConfigurationError(RuntimeError):
+    """Raised when a model provider cannot be configured safely."""
+
+
+class ChatModelProvider(Protocol):
+    """Provider boundary used by the translation pipeline."""
+
+    client: Any
+
+    async def create_chat_completion(
+        self,
+        *,
+        model: str,
+        messages: Any,
+        completion_token_limit: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Create one chat completion and record usage when available."""
+
+    def count_tokens(self, text: str, model_name: str) -> int:
+        """Count tokens for provider/model context budgeting."""
+
+    def estimate_run_cost(
+        self,
+        *,
+        num_keys: int,
+        locale_codes: Sequence[str],
+        translate_model: str,
+        review_model: str,
+        avg_prompt_tokens_per_string: int = 220,
+        avg_completion_tokens_per_string: int = 40,
+    ) -> CostEstimate:
+        """Estimate run cost using provider-specific prices."""
+
+    def format_estimate(self, estimate: CostEstimate) -> str:
+        """Format a provider cost estimate for logging."""
+
+    def record_response(self, model: str, response: Any) -> None:
+        """Record token usage from a provider response."""
+
+    def write_usage_summary(self, path: str) -> None:
+        """Persist the accumulated provider usage summary."""
+
+    def format_usage_summary(self) -> str:
+        """Format the accumulated provider usage summary."""
+
+    def is_retryable_error(self, exc: Exception) -> bool:
+        """Return true when the provider error should follow retry backoff."""
+
+
+def normalize_model_provider_name(provider_name: str) -> str:
+    """Return the canonical provider name for config aliases."""
+    normalized = (provider_name or DEFAULT_MODEL_PROVIDER).strip().lower().replace("-", "_")
+    return _MODEL_PROVIDER_ALIASES.get(normalized, normalized)
+
+
+class OpenAICompatibleProvider:
+    """OpenAI-compatible chat-completion provider.
+
+    This keeps OpenAI SDK details, token-limit parameter compatibility, tiktoken
+    counting, pricing, and usage tracking behind one boundary.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: Any,
+        usage_tracker: Optional[UsageTracker] = None,
+        prices: Optional[Dict[str, Dict[str, float]]] = None,
+    ) -> None:
+        self.client = client
+        self._prices = prices if prices is not None else DEFAULT_PRICES
+        self._usage_tracker = usage_tracker or UsageTracker(prices=self._prices)
+
+    async def create_chat_completion(
+        self,
+        *,
+        model: str,
+        messages: Any,
+        completion_token_limit: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if self.client is None:
+            raise ModelProviderConfigurationError("OpenAI-compatible client is not configured.")
+
+        response = await create_chat_completion(
+            self.client,
+            model=model,
+            messages=messages,
+            completion_token_limit=completion_token_limit,
+            **kwargs,
+        )
+        self.record_response(model, response)
+        return response
+
+    def count_tokens(self, text: str, model_name: str) -> int:
+        """Count tokens with a provider-local fallback chain."""
+        tokenizer_model_name = model_name.split(":", 1)[1] if ":" in model_name else model_name
+        try:
+            encoding = tiktoken.encoding_for_model(tokenizer_model_name)
+        except Exception:
+            try:
+                encoding = tiktoken.get_encoding("gpt2")
+            except Exception:
+                return len(text.split())
+
+        try:
+            return len(encoding.encode(text))
+        except Exception:
+            return len(text.split())
+
+    def estimate_run_cost(
+        self,
+        *,
+        num_keys: int,
+        locale_codes: Sequence[str],
+        translate_model: str,
+        review_model: str,
+        avg_prompt_tokens_per_string: int = 220,
+        avg_completion_tokens_per_string: int = 40,
+    ) -> CostEstimate:
+        return estimate_run_cost(
+            num_keys=num_keys,
+            locale_codes=locale_codes,
+            translate_model=translate_model,
+            review_model=review_model,
+            avg_prompt_tokens_per_string=avg_prompt_tokens_per_string,
+            avg_completion_tokens_per_string=avg_completion_tokens_per_string,
+            prices=self._prices,
+        )
+
+    def format_estimate(self, estimate: CostEstimate) -> str:
+        return format_estimate(estimate)
+
+    def record_response(self, model: str, response: Any) -> None:
+        self._usage_tracker.record_response(model, response)
+
+    def write_usage_summary(self, path: str) -> None:
+        self._usage_tracker.write_json(path)
+
+    def format_usage_summary(self) -> str:
+        return self._usage_tracker.format_summary()
+
+    def is_retryable_error(self, exc: Exception) -> bool:
+        if isinstance(exc, (RateLimitError, APITimeoutError, APIConnectionError)):
+            return True
+        if isinstance(exc, APIStatusError):
+            return getattr(exc, "status_code", 0) >= 500
+        return False
+
+
+class AiSuiteProvider(OpenAICompatibleProvider):
+    """AISuite-backed provider using the same async boundary as the pipeline.
+
+    AISuite exposes a synchronous OpenAI-style client. This adapter runs the
+    blocking call in a worker thread and keeps usage/cost/token APIs identical
+    to the direct OpenAI-compatible provider.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: Any,
+        usage_tracker: Optional[UsageTracker] = None,
+        prices: Optional[Dict[str, Dict[str, float]]] = None,
+        default_provider: str = DEFAULT_AISUITE_PROVIDER,
+    ) -> None:
+        super().__init__(client=client, usage_tracker=usage_tracker, prices=prices)
+        self.default_provider = default_provider
+
+    def _provider_model_name(self, model: str) -> str:
+        if ":" in model:
+            return model
+        return f"{self.default_provider}:{model}"
+
+    async def create_chat_completion(
+        self,
+        *,
+        model: str,
+        messages: Any,
+        completion_token_limit: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if self.client is None:
+            raise ModelProviderConfigurationError("AISuite client is not configured.")
+
+        async def call_aisuite(**request_kwargs: Any) -> Any:
+            return await asyncio.to_thread(
+                self.client.chat.completions.create,
+                **request_kwargs,
+            )
+
+        response = await create_chat_completion_with_fallback(
+            call_aisuite,
+            model=self._provider_model_name(model),
+            messages=messages,
+            completion_token_limit=completion_token_limit,
+            retry_exception_types=(Exception,),
+            **kwargs,
+        )
+        self.record_response(model, response)
+        return response
+
+    def is_retryable_error(self, exc: Exception) -> bool:
+        if super().is_retryable_error(exc):
+            return True
+        exc_module = exc.__class__.__module__
+        exc_name = exc.__class__.__name__
+        return exc_module.startswith("aisuite") or exc_name == "LLMError"
+
+
+def create_openai_compatible_provider(
+    *,
+    api_key: Optional[str],
+    api_base_url: Optional[str],
+    logger: logging.Logger,
+) -> OpenAICompatibleProvider:
+    """Create an OpenAI-compatible provider from resolved credentials."""
+    is_custom_endpoint = bool(api_base_url)
+    resolved_key = api_key
+
+    if not resolved_key:
+        if is_custom_endpoint:
+            logger.info(
+                "No OPENAI_API_KEY set; using a placeholder key for custom endpoint '%s' "
+                "(typical for local servers such as Ollama).",
+                api_base_url,
+            )
+            resolved_key = _LOCAL_PROVIDER_PLACEHOLDER_KEY
+        else:
+            raise ModelProviderConfigurationError(
+                "OPENAI_API_KEY is required when no custom api_base_url is configured."
+            )
+    elif not is_custom_endpoint and not resolved_key.startswith("sk-"):
+        logger.warning("Warning: OPENAI_API_KEY does not start with 'sk-'. This may be invalid.")
+
+    client_kwargs: Dict[str, Any] = {"api_key": resolved_key}
+    if api_base_url:
+        client_kwargs["base_url"] = api_base_url
+        logger.info("Using OpenAI-compatible endpoint: %s", api_base_url)
+
+    client = AsyncOpenAI(**client_kwargs)
+    logger.info("OpenAI-compatible model provider initialized successfully")
+    return OpenAICompatibleProvider(client=client)
+
+
+def create_aisuite_provider(
+    *,
+    provider_configs: Dict[str, Any],
+    logger: logging.Logger,
+    default_provider: str = DEFAULT_AISUITE_PROVIDER,
+) -> AiSuiteProvider:
+    """Create the AISuite-backed provider used by the default runtime path."""
+    try:
+        aisuite = importlib.import_module("aisuite")
+    except ImportError as exc:
+        raise ModelProviderConfigurationError(
+            "AISuite provider selected, but the 'aisuite' package is not installed."
+        ) from exc
+
+    client = aisuite.Client(provider_configs=provider_configs)
+    logger.info("AISuite model provider initialized successfully")
+    return AiSuiteProvider(client=client, default_provider=default_provider)
+
+
+def _openai_provider_config(
+    *,
+    api_key: Optional[str],
+    api_base_url: Optional[str],
+) -> Dict[str, str]:
+    config: Dict[str, str] = {}
+    if api_key:
+        config["api_key"] = api_key
+    elif api_base_url:
+        config["api_key"] = _LOCAL_PROVIDER_PLACEHOLDER_KEY
+    if api_base_url:
+        config["base_url"] = api_base_url
+    return config
+
+
+def create_model_provider(
+    *,
+    provider_name: str,
+    api_key: Optional[str],
+    api_base_url: Optional[str],
+    logger: logging.Logger,
+    aisuite_provider_configs: Optional[Dict[str, Any]] = None,
+) -> ChatModelProvider:
+    """Create the configured model provider backend."""
+    normalized = normalize_model_provider_name(provider_name)
+    if normalized == "openai_compatible":
+        return create_openai_compatible_provider(
+            api_key=api_key,
+            api_base_url=api_base_url,
+            logger=logger,
+        )
+    if normalized == "aisuite":
+        provider_configs: Dict[str, Any] = dict(aisuite_provider_configs or {})
+        openai_config = _openai_provider_config(
+            api_key=api_key,
+            api_base_url=api_base_url,
+        )
+        if openai_config:
+            provider_configs["openai"] = {
+                **provider_configs.get("openai", {}),
+                **openai_config,
+            }
+        return create_aisuite_provider(
+            provider_configs=provider_configs,
+            logger=logger,
+            default_provider=DEFAULT_AISUITE_PROVIDER,
+        )
+    raise ModelProviderConfigurationError(
+        f"Unsupported model_provider '{provider_name}'. Supported values: openai_compatible, aisuite."
+    )

--- a/src/openai_compat.py
+++ b/src/openai_compat.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Literal
+import inspect
+from typing import Any, Callable, Literal, Tuple
 
 from openai import OpenAIError
 
@@ -30,6 +31,12 @@ _UNSUPPORTED_PARAMETER_MARKERS = (
 )
 
 
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
 def completion_token_parameter_for_model(model: str) -> CompletionTokenParameter:
     """Return the preferred completion-token cap parameter for ``model``.
 
@@ -40,6 +47,8 @@ def completion_token_parameter_for_model(model: str) -> CompletionTokenParameter
     error.
     """
     normalized = model.lower()
+    if ":" in normalized:
+        normalized = normalized.split(":", 1)[1]
     if normalized.startswith(_MAX_COMPLETION_TOKEN_MODEL_PREFIXES):
         return "max_completion_tokens"
     return "max_tokens"
@@ -72,6 +81,26 @@ async def create_chat_completion(
     completion_token_limit: int | None = None,
     **kwargs: Any,
 ) -> Any:
+    """Create a chat completion with model-aware token-limit parameters."""
+    return await create_chat_completion_with_fallback(
+        client.chat.completions.create,
+        model=model,
+        messages=messages,
+        completion_token_limit=completion_token_limit,
+        retry_exception_types=(OpenAIError, TypeError),
+        **kwargs,
+    )
+
+
+async def create_chat_completion_with_fallback(
+    create_completion: Callable[..., Any],
+    *,
+    model: str,
+    messages: Any,
+    completion_token_limit: int | None = None,
+    retry_exception_types: Tuple[type[BaseException], ...] = (Exception,),
+    **kwargs: Any,
+) -> Any:
     """Create a chat completion with model-aware token-limit parameters.
 
     ``completion_token_limit`` is intentionally provider-agnostic. The helper
@@ -79,11 +108,7 @@ async def create_chat_completion(
     once with the alternate name if an OpenAI-compatible API rejects it.
     """
     if completion_token_limit is None:
-        return await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            **kwargs,
-        )
+        return await _maybe_await(create_completion(model=model, messages=messages, **kwargs))
 
     first_parameter = completion_token_parameter_for_model(model)
     fallback_parameter: CompletionTokenParameter = (
@@ -98,12 +123,8 @@ async def create_chat_completion(
     )
 
     try:
-        return await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            **first_kwargs,
-        )
-    except (OpenAIError, TypeError) as exc:
+        return await _maybe_await(create_completion(model=model, messages=messages, **first_kwargs))
+    except retry_exception_types as exc:
         if not _looks_like_unsupported_parameter(exc, first_parameter):
             raise
 
@@ -119,8 +140,4 @@ async def create_chat_completion(
         fallback_parameter,
         completion_token_limit,
     )
-    return await client.chat.completions.create(
-        model=model,
-        messages=messages,
-        **fallback_kwargs,
-    )
+    return await _maybe_await(create_completion(model=model, messages=messages, **fallback_kwargs))

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,0 +1,27 @@
+"""Public model-provider API."""
+
+from src.model_provider import (
+    AiSuiteProvider,
+    ChatModelProvider,
+    DEFAULT_AISUITE_PROVIDER,
+    DEFAULT_MODEL_PROVIDER,
+    ModelProviderConfigurationError,
+    OpenAICompatibleProvider,
+    create_aisuite_provider,
+    create_model_provider,
+    create_openai_compatible_provider,
+    normalize_model_provider_name,
+)
+
+__all__ = [
+    "AiSuiteProvider",
+    "ChatModelProvider",
+    "DEFAULT_AISUITE_PROVIDER",
+    "DEFAULT_MODEL_PROVIDER",
+    "ModelProviderConfigurationError",
+    "OpenAICompatibleProvider",
+    "create_aisuite_provider",
+    "create_model_provider",
+    "create_openai_compatible_provider",
+    "normalize_model_provider_name",
+]

--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -23,15 +23,8 @@ if sys.version_info < (3, 11):
 # --- End Version Check ---
 
 import jsonschema
-import tiktoken
 from aiolimiter import AsyncLimiter
-from openai import (
-    APIConnectionError,
-    APIStatusError,
-    RateLimitError,
-    APITimeoutError,
-    OpenAIError
-)
+from openai import OpenAIError
 from openai.types.chat import (
     ChatCompletionSystemMessageParam,
     ChatCompletionUserMessageParam
@@ -40,7 +33,7 @@ from tqdm.asyncio import tqdm
 
 from src.app_config import load_app_config
 from src.localization_formats import JAVA_PROPERTIES_FORMAT, LocalizationFormat
-from src.openai_compat import create_chat_completion
+from src.model_provider import OpenAICompatibleProvider
 from src.pipeline_core import (
     TranslationPipelineOptions,
     TranslationPipelinePaths,
@@ -48,8 +41,6 @@ from src.pipeline_core import (
     run_translation_pipeline,
 )
 from src.properties_parser import parse_properties_file, reassemble_file
-from src.usage_tracker import usage_tracker
-from src.cost_estimator import estimate_run_cost, format_estimate
 from src.translation_prompts import build_translation_system_prompt
 from src.translation_validator import (
     check_placeholder_parity,
@@ -99,7 +90,9 @@ TRANSLATION_QUEUE_FOLDER = config.translation_queue_folder
 TRANSLATED_QUEUE_FOLDER = config.translated_queue_folder
 TRANSLATION_KEY_LEDGER_FILE_PATH = config.translation_key_ledger_file_path
 PRESERVE_QUEUES_FOR_DEBUG = config.preserve_queues_for_debug
+MODEL_PROVIDER = config.model_provider
 client = config.openai_client
+_FALLBACK_PROVIDER = OpenAICompatibleProvider(client=None)
 
 # --- End Config and Globals ---
 
@@ -566,18 +559,8 @@ def count_tokens(text: str, model_name: str = 'gpt-3.5-turbo') -> int:
     with ``tiktoken``. As a last resort, a simple whitespace split is used.
     """
 
-    try:
-        encoding = tiktoken.encoding_for_model(model_name)
-    except Exception:
-        try:
-            encoding = tiktoken.get_encoding("gpt2")
-        except Exception:
-            return len(text.split())
-
-    try:
-        return len(encoding.encode(text))
-    except Exception:
-        return len(text.split())
+    provider = MODEL_PROVIDER or _FALLBACK_PROVIDER
+    return provider.count_tokens(text, model_name)
 
 def build_context(
         existing_translations: Dict[str, str],
@@ -1083,8 +1066,8 @@ async def translate_text_async(
         logger.info(f"[Dry Run] Skipping actual translation for key '{key}'. Returning original text.")
         return index, text
 
-    if client is None:
-        logger.error("OpenAI client is None. Cannot proceed with translation.")
+    if MODEL_PROVIDER is None:
+        logger.error("Model provider is not configured. Cannot proceed with translation.")
         return index, text
 
     async with semaphore, rate_limiter:
@@ -1145,8 +1128,7 @@ Provide the translation **of the Value only**, following the instructions above.
         for attempt in range(1, max_retries + 1):  # type: ignore[arg-type]
             try:
                 # Use chat completion API
-                response = await create_chat_completion(
-                    client,
+                response = await MODEL_PROVIDER.create_chat_completion(
                     model=MODEL_NAME,
                     messages=[
                         ChatCompletionSystemMessageParam(role="system", content=system_prompt),
@@ -1161,7 +1143,6 @@ Provide the translation **of the Value only**, following the instructions above.
                     temperature=0.3,
                     timeout=60.0,
                 )
-                usage_tracker.record_response(MODEL_NAME, response)
 
                 msg_content = response.choices[0].message.content
                 if not msg_content:
@@ -1178,14 +1159,13 @@ Provide the translation **of the Value only**, following the instructions above.
                 logger.debug(f"Translated key '{key}' successfully.")
                 return index, translated_text
 
-            except (RateLimitError, APITimeoutError, APIConnectionError, APIStatusError, OpenAIError) as api_exc:
-                logger.error(f"API error occurred: {api_exc.__class__.__name__} - {api_exc}")
-                should_retry = await _handle_retry(attempt, max_retries, base_delay, key, api_exc)
-                if should_retry:
-                    continue
-                else:
-                    return index, text
             except Exception as general_exc:
+                if MODEL_PROVIDER.is_retryable_error(general_exc):
+                    logger.error(f"API error occurred: {general_exc.__class__.__name__} - {general_exc}")
+                    should_retry = await _handle_retry(attempt, max_retries, base_delay, key, general_exc)
+                    if should_retry:
+                        continue
+                    return index, text
                 logger.error(f"An unexpected error occurred: {general_exc}", exc_info=True)
                 return index, text
 
@@ -1279,8 +1259,8 @@ async def holistic_review_async(
         # Return an empty dictionary to simulate a successful review that made no changes.
         return {}
 
-    if client is None:
-        logger.error("OpenAI client is None. Cannot proceed with holistic review.")
+    if MODEL_PROVIDER is None:
+        logger.error("Model provider is not configured. Cannot proceed with holistic review.")
         return {}
 
     # Protect placeholders in both source and translated content before sending to AI
@@ -1303,8 +1283,7 @@ async def holistic_review_async(
         base_delay = 5  # Longer delay for a potentially larger task
         for attempt in range(1, max_retries + 1):
             try:
-                response = await create_chat_completion(
-                    client,
+                response = await MODEL_PROVIDER.create_chat_completion(
                     model=REVIEW_MODEL_NAME,
                     messages=[
                         ChatCompletionSystemMessageParam(role="system", content=review_system_prompt)
@@ -1314,7 +1293,6 @@ async def holistic_review_async(
                     completion_token_limit=8192,
                     timeout=120.0,
                 )
-                usage_tracker.record_response(REVIEW_MODEL_NAME, response)
                 msg_content = response.choices[0].message.content
                 if not msg_content or not msg_content.strip():
                     logger.error("Holistic review returned empty content.")
@@ -1362,12 +1340,13 @@ async def holistic_review_async(
                 logger.debug(f"Invalid AI response (Schema Error):\n---\n{response_text}\n---")
                 # Fall through to retry logic
 
-            except (RateLimitError, APITimeoutError, APIConnectionError, APIStatusError, OpenAIError) as api_exc:
-                logger.warning(f"API error during holistic review: {api_exc}")
-                should_retry = await _handle_retry(attempt, max_retries, base_delay, "holistic_review", api_exc)
-                if not should_retry:
-                    return None
             except Exception as e:
+                if MODEL_PROVIDER.is_retryable_error(e):
+                    logger.warning(f"API error during holistic review: {e}")
+                    should_retry = await _handle_retry(attempt, max_retries, base_delay, "holistic_review", e)
+                    if not should_retry:
+                        return None
+                    continue
                 logger.error(f"Unexpected error during holistic review: {e}", exc_info=True)
                 return None  # Do not retry on unexpected errors
 
@@ -1876,14 +1855,15 @@ async def process_translation_queue(
             continue
 
         # Pre-run scope/cost preview for this file (ballpark — actuals logged at the end).
-        file_estimate = estimate_run_cost(
+        provider = MODEL_PROVIDER or _FALLBACK_PROVIDER
+        file_estimate = provider.estimate_run_cost(
             num_keys=len(keys_to_translate),
             locale_codes=[language_code],
             translate_model=MODEL_NAME,
             review_model=REVIEW_MODEL_NAME,
         )
         logger.info("Pre-run estimate for '%s':", translation_file)
-        for line in format_estimate(file_estimate).splitlines():
+        for line in provider.format_estimate(file_estimate).splitlines():
             logger.info(line)
 
         # Gather all translation tasks
@@ -2205,8 +2185,9 @@ def remove_file_if_exists(path: str) -> None:
 def write_token_usage_summary(summary_path: str) -> None:
     """Persist and log token usage for the current run."""
     try:
-        usage_tracker.write_json(summary_path)
-        for line in usage_tracker.format_summary().splitlines():
+        provider = MODEL_PROVIDER or _FALLBACK_PROVIDER
+        provider.write_usage_summary(summary_path)
+        for line in provider.format_usage_summary().splitlines():
             logger.info(line)
         logger.info(f"Wrote token usage summary to {summary_path}")
     except Exception:

--- a/src/translation_semantic_reviewer.py
+++ b/src/translation_semantic_reviewer.py
@@ -5,16 +5,22 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
 import jsonschema
 import yaml
-from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam
 
-from src.openai_compat import create_chat_completion
+from src.model_provider import (
+    ChatModelProvider,
+    DEFAULT_MODEL_PROVIDER,
+    ModelProviderConfigurationError,
+    OpenAICompatibleProvider,
+    create_model_provider,
+)
 from src.semantic_quality import (
     TranslationChange,
     iter_translation_changes_from_diff,
@@ -143,23 +149,24 @@ def append_semantic_review_findings(
 
 
 async def review_translation_changes(
-    client: AsyncOpenAI,
+    client: Any,
     model: str,
     target_language: str,
     changes: Sequence[TranslationChange],
     style_rules: Sequence[str],
     brand_glossary: Sequence[str],
+    model_provider: Optional[ChatModelProvider] = None,
 ) -> List[Dict[str, str]]:
     if not changes:
         return []
+    provider = model_provider or OpenAICompatibleProvider(client=client)
     messages = build_semantic_review_messages(
         target_language=target_language,
         changes=changes,
         style_rules=style_rules,
         brand_glossary=brand_glossary,
     )
-    response = await create_chat_completion(
-        client,
+    response = await provider.create_chat_completion(
         model=model,
         messages=[
             ChatCompletionSystemMessageParam(role="system", content=messages[0]["content"]),
@@ -199,10 +206,6 @@ async def _run(argv: Optional[Sequence[str]]) -> int:
         append_semantic_review_findings(args.validation_summary, [])
         return 0
 
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        return 0
-
     locales = [
         locale["code"]
         for locale in config.get("supported_locales", [])
@@ -234,19 +237,34 @@ async def _run(argv: Optional[Sequence[str]]) -> int:
             config.get("review_model_name", config.get("model_name", "gpt-4o")),
         )
     )
-    client = AsyncOpenAI(api_key=api_key)
+    provider_name = str(config.get("model_provider", DEFAULT_MODEL_PROVIDER) or DEFAULT_MODEL_PROVIDER)
+    api_base_url = os.environ.get("OPENAI_BASE_URL") or config.get("api_base_url")
+    aisuite_config = config.get("aisuite", {}) or {}
+    logger = logging.getLogger(__name__)
+    try:
+        provider = create_model_provider(
+            provider_name=provider_name,
+            api_key=os.environ.get("OPENAI_API_KEY"),
+            api_base_url=api_base_url,
+            logger=logger,
+            aisuite_provider_configs=aisuite_config.get("provider_configs", {}) or {},
+        )
+    except ModelProviderConfigurationError as exc:
+        logger.error("Semantic review model provider configuration failed: %s", exc)
+        return 1
     findings: List[Dict[str, str]] = []
 
     for locale_code in sorted({change.locale_code for change in changes if change.locale_code}):
         locale_changes = [change for change in changes if change.locale_code == locale_code]
         findings.extend(
             await review_translation_changes(
-                client=client,
+                client=provider.client,
                 model=model,
                 target_language=language_names.get(locale_code, locale_code),
                 changes=locale_changes,
                 style_rules=style_rules_by_locale.get(locale_code, []),
                 brand_glossary=brand_glossary,
+                model_provider=provider,
             )
         )
 

--- a/src/usage_tracker.py
+++ b/src/usage_tracker.py
@@ -24,6 +24,14 @@ DEFAULT_PRICES: Dict[str, Dict[str, float]] = {
     "gpt-4": {"input": 30.00, "output": 60.00},
     "gpt-4-turbo": {"input": 10.00, "output": 30.00},
 }
+_PRICE_COMPATIBLE_PROVIDER_PREFIXES = frozenset({"openai"})
+
+
+def _price_lookup_model(model: str) -> str:
+    provider, separator, bare_model = model.partition(":")
+    if separator and provider in _PRICE_COMPATIBLE_PROVIDER_PREFIXES:
+        return bare_model
+    return model
 
 
 def cost_for_tokens(
@@ -39,6 +47,8 @@ def cost_for_tokens(
     """
     table = prices if prices is not None else DEFAULT_PRICES
     price = table.get(model)
+    if price is None:
+        price = table.get(_price_lookup_model(model))
     if price is None:
         return None
     return (

--- a/tests/integration/test_quote_escaping.py
+++ b/tests/integration/test_quote_escaping.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
 # Set a dummy API key before importing the main script to prevent SystemExit.
@@ -28,8 +29,7 @@ class TestQuoteEscaping(unittest.IsolatedAsyncioTestCase):
     @patch('src.translate_localization_files.load_glossary')
     @patch('src.translate_localization_files.parse_properties_file')
     @patch('src.translate_localization_files.get_working_tree_changed_keys')
-    @patch('src.translate_localization_files.client.chat.completions.create', new_callable=AsyncMock)
-    async def test_single_quotes_are_escaped(self, mock_create, mock_git_changed_keys, mock_parse_properties, mock_load_glossary, mock_pre_validator, mock_holistic_review, mock_post_validator):
+    async def test_single_quotes_are_escaped(self, mock_git_changed_keys, mock_parse_properties, mock_load_glossary, mock_pre_validator, mock_holistic_review, mock_post_validator):
         from src.translate_localization_files import process_translation_queue, LANGUAGE_CODES, NAME_TO_CODE, REPO_ROOT
 
         # Configure the mocks
@@ -63,9 +63,14 @@ class TestQuoteEscaping(unittest.IsolatedAsyncioTestCase):
 
         # 2. Mock the AI response for the initial translation
         response_text = "Dies ist ein '{0}' Beispiel."
-        mock_create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=response_text))]
-        )
+        provider = MagicMock()
+        provider.create_chat_completion = AsyncMock(return_value=SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=response_text))]
+        ))
+        provider.count_tokens.side_effect = lambda text, model: len(text.split())
+        provider.estimate_run_cost.return_value = MagicMock()
+        provider.format_estimate.return_value = "estimate"
+        provider.is_retryable_error.return_value = False
 
         # 3. Create the dummy files the function needs to find
         source_file_path = os.path.join(self.test_dir, 'app.properties')
@@ -79,7 +84,8 @@ class TestQuoteEscaping(unittest.IsolatedAsyncioTestCase):
         # 4. Run the process, patching globals that are still read directly
         with patch.dict(LANGUAGE_CODES, {"de": "German"}), \
              patch.dict(NAME_TO_CODE, {"german": "de"}), \
-             patch('src.translate_localization_files.INPUT_FOLDER', self.test_dir):
+             patch('src.translate_localization_files.INPUT_FOLDER', self.test_dir), \
+             patch('src.translate_localization_files.MODEL_PROVIDER', provider):
             await process_translation_queue(
                 translation_queue_folder=self.queue_dir,
                 translated_queue_folder=self.translated_dir,
@@ -90,7 +96,7 @@ class TestQuoteEscaping(unittest.IsolatedAsyncioTestCase):
         mock_pre_validator.assert_called()
         mock_holistic_review.assert_awaited()
         # The AI should be called for the initial translation
-        mock_create.assert_awaited()
+        provider.create_chat_completion.assert_awaited()
         # parse_properties_file should be called three times:
         # 1. For the target file
         # 2. For the source file

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -6,7 +6,8 @@ external dependencies and file system operations, and also includes unit-like te
 for specific helper functions within the script.
 """
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock
+from types import SimpleNamespace
 import pytest
 import src.translate_localization_files
 
@@ -44,12 +45,16 @@ async def test_process_translation_queue_end_to_end(integration_test_environment
     with open(target_file_path, 'w', encoding='utf-8') as f:
         f.write(target_content)
 
-    async def mock_create(*args, **kwargs):
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=MagicMock(content="Wert zwei"))]
-        return mock_response
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Wert zwei"))]
+    ))
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
 
-    with patch('src.translate_localization_files.client.chat.completions.create', new=mock_create):
+    with patch('src.translate_localization_files.MODEL_PROVIDER', provider):
         await src.translate_localization_files.process_translation_queue(
             translation_queue_folder=env['translation_queue_folder'],
             translated_queue_folder=env['translated_queue_folder'],
@@ -78,13 +83,17 @@ async def test_handles_already_escaped_quotes_correctly(integration_test_environ
     with open(target_de_path, 'w', encoding='utf-8') as f:
         f.write(target_content)
 
-    async def mock_create(*args, **kwargs):
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=MagicMock(content="URL ist '{0}'"))]
-        return mock_response
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="URL ist '{0}'"))]
+    ))
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
 
     with patch('src.translate_localization_files.lint_properties_file', return_value=[]), \
-         patch('src.translate_localization_files.client.chat.completions.create', new=mock_create):
+         patch('src.translate_localization_files.MODEL_PROVIDER', provider):
         await src.translate_localization_files.process_translation_queue(
             translation_queue_folder=env['translation_queue_folder'],
             translated_queue_folder=env['translated_queue_folder'],

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -38,6 +38,7 @@ class TestAppConfig:
             translated_queue_folder="/tmp/translated",
             translation_key_ledger_file_path="/tmp/ledger.json",
             preserve_queues_for_debug=False,
+            model_provider=None,
             openai_client=None
         )
 
@@ -270,14 +271,14 @@ class TestLoadAppConfig:
 
     def test_openai_client_creation_with_api_key(self):
         """Test that OpenAI client is created when API key is present."""
-        mock_config = {"dry_run": False}
+        mock_config = {"dry_run": False, "model_provider": "openai_compatible"}
 
         with patch("builtins.open", mock_open(read_data=yaml.dump(mock_config))):
             with patch("os.path.exists", return_value=True):
                 with patch("os.access", return_value=True):
                     with patch("src.logging_config.setup_logger") as mock_logger:
                         mock_logger.return_value = MagicMock()
-                        with patch("src.app_config.AsyncOpenAI") as mock_openai:
+                        with patch("src.model_provider.AsyncOpenAI") as mock_openai:
                             mock_client = MagicMock()
                             mock_openai.return_value = mock_client
                             with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test-key"}):
@@ -302,15 +303,17 @@ class TestLoadAppConfig:
 
     def test_missing_openai_key_exits_in_production_mode(self):
         """Test that missing OpenAI API key causes system exit in production mode."""
-        mock_config = {"dry_run": False}
+        mock_config = {"dry_run": False, "model_provider": "openai_compatible"}
 
         with patch("builtins.open", mock_open(read_data=yaml.dump(mock_config))):
             with patch("os.path.exists", return_value=True):
-                with patch("src.logging_config.setup_logger") as mock_logger:
-                    mock_logger.return_value = MagicMock()
-                    with patch.dict(os.environ, {}, clear=True):
-                        with pytest.raises(SystemExit):
-                            load_app_config()
+                with patch("os.access", return_value=True):
+                    with patch("src.app_config.load_dotenv"):
+                        with patch("src.logging_config.setup_logger") as mock_logger:
+                            mock_logger.return_value = MagicMock()
+                            with patch.dict(os.environ, {}, clear=True):
+                                with pytest.raises(SystemExit):
+                                    load_app_config()
 
     def test_style_rules_preprocessing(self):
         """Test that style rules are properly preprocessed."""
@@ -514,24 +517,57 @@ class TestProviderAbstraction:
                 with patch("os.access", return_value=True):
                     with patch("src.logging_config.setup_logger") as mock_logger:
                         mock_logger.return_value = MagicMock()
-                        with patch("src.app_config.AsyncOpenAI") as mock_openai:
+                        with patch("src.model_provider.AsyncOpenAI") as mock_openai:
                             mock_openai.return_value = MagicMock()
                             with patch.dict(os.environ, env, clear=True):
                                 config = load_app_config()
         return config, mock_openai
 
-    def test_default_openai_path_unchanged(self):
-        """With no base_url, the client is built with api_key only (backwards compatible)."""
-        config, mock_openai = self._load(
-            {"dry_run": False}, {"OPENAI_API_KEY": "sk-test-key"}
-        )
-        mock_openai.assert_called_once_with(api_key="sk-test-key")
-        assert config.api_base_url is None
+    def test_aisuite_is_default_provider(self):
+        """AISuite is the default abstraction layer for chat model dispatch."""
+        provider = MagicMock()
+        provider.client = object()
+
+        with patch("builtins.open", mock_open(read_data=yaml.dump({"dry_run": False}))):
+            with patch("os.path.exists", return_value=True):
+                with patch("os.access", return_value=True):
+                    with patch("src.logging_config.setup_logger") as mock_logger:
+                        mock_logger.return_value = MagicMock()
+                        with patch("src.app_config.create_model_provider", return_value=provider) as factory:
+                            with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test-key"}, clear=True):
+                                config = load_app_config()
+
+        assert config.model_provider_name == "aisuite"
+        _, kwargs = factory.call_args
+        assert kwargs["provider_name"] == "aisuite"
+        assert config.model_provider is provider
+
+    def test_model_provider_name_is_canonicalized(self):
+        provider = MagicMock()
+        provider.client = object()
+
+        with patch("builtins.open", mock_open(read_data=yaml.dump(
+            {"dry_run": False, "model_provider": "openai"}
+        ))):
+            with patch("os.path.exists", return_value=True):
+                with patch("os.access", return_value=True):
+                    with patch("src.logging_config.setup_logger") as mock_logger:
+                        mock_logger.return_value = MagicMock()
+                        with patch("src.app_config.create_model_provider", return_value=provider) as factory:
+                            with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test-key"}, clear=True):
+                                config = load_app_config()
+
+        assert config.model_provider_name == "openai_compatible"
+        assert factory.call_args.kwargs["provider_name"] == "openai_compatible"
 
     def test_base_url_from_config_passed_to_client(self):
         """api_base_url in config is passed to the OpenAI-compatible client."""
         config, mock_openai = self._load(
-            {"dry_run": False, "api_base_url": "http://localhost:11434/v1"},
+            {
+                "dry_run": False,
+                "model_provider": "openai_compatible",
+                "api_base_url": "http://localhost:11434/v1",
+            },
             {"OPENAI_API_KEY": "sk-test-key"},
         )
         assert config.api_base_url == "http://localhost:11434/v1"
@@ -542,7 +578,11 @@ class TestProviderAbstraction:
     def test_base_url_env_overrides_config(self):
         """OPENAI_BASE_URL env var wins over the config value."""
         config, mock_openai = self._load(
-            {"dry_run": False, "api_base_url": "http://config-host/v1"},
+            {
+                "dry_run": False,
+                "model_provider": "openai_compatible",
+                "api_base_url": "http://config-host/v1",
+            },
             {"OPENAI_API_KEY": "sk-test-key", "OPENAI_BASE_URL": "http://env-host/v1"},
         )
         assert config.api_base_url == "http://env-host/v1"
@@ -552,7 +592,11 @@ class TestProviderAbstraction:
     def test_local_provider_without_key_uses_placeholder(self):
         """A custom endpoint (e.g. Ollama) needs no real key; we must not exit."""
         config, mock_openai = self._load(
-            {"dry_run": False, "api_base_url": "http://localhost:11434/v1"},
+            {
+                "dry_run": False,
+                "model_provider": "openai_compatible",
+                "api_base_url": "http://localhost:11434/v1",
+            },
             {},  # no OPENAI_API_KEY
         )
         _, kwargs = mock_openai.call_args
@@ -562,7 +606,9 @@ class TestProviderAbstraction:
 
     def test_missing_key_without_base_url_still_exits(self):
         """Without a custom endpoint, a missing key is still a hard error."""
-        with patch("builtins.open", mock_open(read_data=yaml.dump({"dry_run": False}))):
+        with patch("builtins.open", mock_open(read_data=yaml.dump(
+            {"dry_run": False, "model_provider": "openai_compatible"}
+        ))):
             with patch("os.path.exists", return_value=True):
                 with patch("os.access", return_value=True):
                     with patch("src.logging_config.setup_logger") as mock_logger:
@@ -575,13 +621,48 @@ class TestProviderAbstraction:
         """A BYO key on a custom endpoint may not start with sk-; accept it without warning."""
         captured = MagicMock()
         with patch("builtins.open", mock_open(read_data=yaml.dump(
-            {"dry_run": False, "api_base_url": "https://api.groq.com/openai/v1"}
+            {
+                "dry_run": False,
+                "model_provider": "openai_compatible",
+                "api_base_url": "https://api.groq.com/openai/v1",
+            }
         ))):
             with patch("os.path.exists", return_value=True):
                 with patch("os.access", return_value=True):
                     with patch("src.logging_config.setup_logger", return_value=captured):
-                        with patch("src.app_config.AsyncOpenAI", return_value=MagicMock()):
+                        with patch("src.model_provider.AsyncOpenAI", return_value=MagicMock()):
                             with patch.dict(os.environ, {"OPENAI_API_KEY": "gsk_abc123"}, clear=True):
                                 load_app_config()
         warnings = [str(c) for c in captured.warning.call_args_list]
         assert not any("sk-" in w for w in warnings)
+
+    def test_aisuite_backend_is_configurable(self):
+        provider = MagicMock()
+        provider.client = object()
+        mock_config = {
+            "dry_run": False,
+            "model_provider": "aisuite",
+            "aisuite": {
+                "provider_configs": {
+                    "anthropic": {"api_key": "from-env-or-secret"}
+                }
+            },
+        }
+
+        with patch("builtins.open", mock_open(read_data=yaml.dump(mock_config))):
+            with patch("os.path.exists", return_value=True):
+                with patch("os.access", return_value=True):
+                    with patch("src.logging_config.setup_logger") as mock_logger:
+                        mock_logger.return_value = MagicMock()
+                        with patch("src.app_config.create_model_provider", return_value=provider) as factory:
+                            with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True):
+                                config = load_app_config()
+
+        assert config.model_provider_name == "aisuite"
+        assert config.model_provider is provider
+        assert config.openai_client is provider.client
+        _, kwargs = factory.call_args
+        assert kwargs["provider_name"] == "aisuite"
+        assert kwargs["aisuite_provider_configs"] == {
+            "anthropic": {"api_key": "from-env-or-secret"}
+        }

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -1,5 +1,6 @@
 """Regression tests for production translation prompt guidance."""
 from pathlib import Path
+import re
 
 import pytest
 import yaml
@@ -8,11 +9,13 @@ import yaml
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 BISQ_PROFILE_CONFIG = PROJECT_ROOT / "profiles" / "bisq" / "config.yaml"
 BISQ_PROFILE_GLOSSARY = PROJECT_ROOT / "profiles" / "bisq" / "glossary.json"
+GENERIC_EXAMPLE_DIR = PROJECT_ROOT / "examples" / "generic-java-properties"
 
 
 def test_example_config_is_a_minimal_generic_starter():
     """config.example.yaml must stay small, generic, and git-source by default."""
     config = yaml.safe_load((PROJECT_ROOT / "config.example.yaml").read_text(encoding="utf-8"))
+    assert config["model_provider"] == "aisuite"
     assert config["translation_source"] == "git"
     assert "target_project_root" in config and "input_folder" in config
     assert isinstance(config.get("supported_locales"), list) and config["supported_locales"]
@@ -21,12 +24,67 @@ def test_example_config_is_a_minimal_generic_starter():
     assert {loc["code"] for loc in config["supported_locales"]} <= {"de", "es", "fr"}
 
 
+def test_aisuite_is_packaged_as_primary_provider():
+    requirements_in = (PROJECT_ROOT / "requirements.in").read_text(encoding="utf-8")
+    requirements_txt = (PROJECT_ROOT / "requirements.txt").read_text(encoding="utf-8")
+
+    in_match = re.search(r"^aisuite==([^\s]+)$", requirements_in, flags=re.MULTILINE)
+    txt_match = re.search(r"^aisuite==([^\s]+)$", requirements_txt, flags=re.MULTILINE)
+    assert in_match is not None
+    assert txt_match is not None
+    assert txt_match.group(1) == in_match.group(1)
+
+
+def test_public_docs_describe_aisuite_as_default_provider():
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    structure_doc = (PROJECT_ROOT / "docs" / "repository-structure.md").read_text(encoding="utf-8")
+    example_config = (PROJECT_ROOT / "config.example.yaml").read_text(encoding="utf-8")
+
+    combined_docs = "\n".join([readme, structure_doc, example_config]).lower()
+    assert "aisuite" in combined_docs
+    assert "default" in combined_docs
+    assert "openai_compatible" in combined_docs
+    assert "fallback" in combined_docs
+    assert "`src.core`" in readme
+    assert "`src.providers`" in readme
+    assert "`src.formats`" in readme
+    assert "optional AISuite" not in readme
+    assert "AISuite is optional" not in readme
+
+
 def test_example_glossary_is_valid_and_small():
     glossary = yaml.safe_load((PROJECT_ROOT / "glossary.example.json").read_text(encoding="utf-8"))
     assert isinstance(glossary, dict) and glossary
     # keyed by language code -> {term: translation}
     for lang, terms in glossary.items():
         assert isinstance(terms, dict)
+
+
+def test_neutral_example_project_is_packaged():
+    config_path = GENERIC_EXAMPLE_DIR / "config.yaml"
+    glossary_path = GENERIC_EXAMPLE_DIR / "glossary.json"
+    readme_path = GENERIC_EXAMPLE_DIR / "README.md"
+    resources = GENERIC_EXAMPLE_DIR / "resources"
+
+    assert config_path.exists()
+    assert glossary_path.exists()
+    assert readme_path.exists()
+    assert (resources / "messages.properties").exists()
+    assert (resources / "messages_de.properties").exists()
+
+    config_text = config_path.read_text(encoding="utf-8")
+    assert "Bisq" not in config_text
+    config = yaml.safe_load(config_text)
+    assert config["model_provider"] == "aisuite"
+    assert config["translation_source"] == "git"
+    assert config["localization_format"] == "java_properties"
+    target_text = (resources / "messages_de.properties").read_text(encoding="utf-8")
+    assert "settings.save" not in target_text
+    assert "account.name" not in target_text
+
+    readme_text = readme_path.read_text(encoding="utf-8")
+    assert "Bisq" not in readme_text
+    assert "generic Java .properties" in readme_text
 
 
 def test_bisq_profile_packages_config_and_glossary_assets():
@@ -65,6 +123,7 @@ def test_deployment_guide_documents_relative_input_folder_semantics():
 
     assert "# - input_folder: i18n/src/main/resources" in guide
     assert "input_folder is resolved relative to target_project_root" in guide
+    assert "model_provider: aisuite" in guide
     assert "The paths must be absolute paths inside the container." not in guide
 
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -36,12 +36,13 @@ class TestHelperFunctions(unittest.TestCase):
 
     def test_count_tokens_fallback(self):
         # Force encoding_for_model to raise to trigger fallback
-        with patch('src.translate_localization_files.tiktoken.encoding_for_model', side_effect=Exception()):
+        with patch('src.translate_localization_files.MODEL_PROVIDER', None):
             # Also patch get_encoding to provide predictable encode
-            fake_enc = MagicMock()
-            fake_enc.encode.side_effect = lambda s: list(s.split())
-            with patch('src.translate_localization_files.tiktoken.get_encoding', return_value=fake_enc):
-                count = count_tokens('one two three')
+            with patch('src.model_provider.tiktoken.encoding_for_model', side_effect=Exception()):
+                fake_enc = MagicMock()
+                fake_enc.encode.side_effect = lambda s: list(s.split())
+                with patch('src.model_provider.tiktoken.get_encoding', return_value=fake_enc):
+                    count = count_tokens('one two three')
         self.assertEqual(count, 3)
 
 

--- a/tests/unit/test_holistic_review_protection.py
+++ b/tests/unit/test_holistic_review_protection.py
@@ -8,7 +8,7 @@ to prevent the AI from modifying, removing, or adding placeholders.
 import asyncio
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -189,14 +189,14 @@ async def test_holistic_review_uses_compatible_completion_token_limit():
             )
         ]
     )
-    create_completion = AsyncMock(return_value=response)
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=response)
+    provider.is_retryable_error.return_value = False
 
     with (
         patch("src.translate_localization_files.DRY_RUN", False),
-        patch("src.translate_localization_files.client", object()),
         patch("src.translate_localization_files.REVIEW_MODEL_NAME", "gpt-5.4-mini"),
-        patch("src.translate_localization_files.create_chat_completion", create_completion),
-        patch("src.translate_localization_files.usage_tracker.record_response") as record_response,
+        patch("src.translate_localization_files.MODEL_PROVIDER", provider),
     ):
         result = await holistic_review_async(
             source_content="key1=Hello {0}",
@@ -209,10 +209,9 @@ async def test_holistic_review_uses_compatible_completion_token_limit():
         )
 
     assert result == {"key1": "Hallo {0}"}
-    kwargs = create_completion.await_args.kwargs
+    kwargs = provider.create_chat_completion.await_args.kwargs
     assert kwargs["model"] == "gpt-5.4-mini"
     assert kwargs["completion_token_limit"] == 8192
     assert kwargs["response_format"] == {"type": "json_object"}
     assert "max_tokens" not in kwargs
     assert "max_completion_tokens" not in kwargs
-    record_response.assert_called_once_with("gpt-5.4-mini", response)

--- a/tests/unit/test_model_provider.py
+++ b/tests/unit/test_model_provider.py
@@ -1,0 +1,303 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from openai import APIStatusError, OpenAIError
+
+from src.model_provider import (
+    AiSuiteProvider,
+    OpenAICompatibleProvider,
+    create_model_provider,
+    create_aisuite_provider,
+    create_openai_compatible_provider,
+    normalize_model_provider_name,
+)
+from src.usage_tracker import UsageTracker
+
+
+def _response(content="{}", prompt_tokens=11, completion_tokens=7):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+        ),
+    )
+
+
+def _api_status_error(status_code):
+    response = httpx.Response(
+        status_code,
+        request=httpx.Request("POST", "https://api.example.test/chat"),
+    )
+    return APIStatusError("request failed", response=response, body={})
+
+
+@pytest.mark.asyncio
+async def test_provider_delegates_chat_completion_and_records_usage():
+    tracker = UsageTracker(prices={"custom-model": {"input": 1.0, "output": 2.0}})
+    provider = OpenAICompatibleProvider(client=object(), usage_tracker=tracker)
+    response = _response(prompt_tokens=123, completion_tokens=45)
+
+    with patch(
+        "src.model_provider.create_chat_completion",
+        AsyncMock(return_value=response),
+    ) as create_completion:
+        result = await provider.create_chat_completion(
+            model="custom-model",
+            messages=[{"role": "user", "content": "translate"}],
+            completion_token_limit=512,
+            temperature=0.1,
+        )
+
+    assert result is response
+    create_completion.assert_awaited_once_with(
+        provider.client,
+        model="custom-model",
+        messages=[{"role": "user", "content": "translate"}],
+        completion_token_limit=512,
+        temperature=0.1,
+    )
+    summary = tracker.summary()
+    assert summary["models"]["custom-model"]["prompt_tokens"] == 123
+    assert summary["models"]["custom-model"]["completion_tokens"] == 45
+
+
+def test_provider_count_tokens_uses_tiktoken_fallback():
+    provider = OpenAICompatibleProvider(client=None)
+    fake_encoding = MagicMock()
+    fake_encoding.encode.side_effect = lambda text: text.split()
+
+    with (
+        patch("src.model_provider.tiktoken.encoding_for_model", side_effect=Exception),
+        patch("src.model_provider.tiktoken.get_encoding", return_value=fake_encoding),
+    ):
+        assert provider.count_tokens("one two three", "unknown-model") == 3
+
+
+def test_provider_count_tokens_strips_provider_prefix_for_tiktoken():
+    provider = OpenAICompatibleProvider(client=None)
+    fake_encoding = MagicMock()
+    fake_encoding.encode.return_value = [1, 2, 3]
+
+    with patch(
+        "src.model_provider.tiktoken.encoding_for_model",
+        return_value=fake_encoding,
+    ) as encoding_for_model:
+        assert provider.count_tokens("one two three", "openai:gpt-4o") == 3
+
+    encoding_for_model.assert_called_once_with("gpt-4o")
+
+
+def test_provider_cost_estimate_uses_provider_price_table():
+    provider = OpenAICompatibleProvider(
+        client=None,
+        prices={"local-model": {"input": 0.0, "output": 0.0}},
+    )
+
+    estimate = provider.estimate_run_cost(
+        num_keys=10,
+        locale_codes=["de", "es"],
+        translate_model="local-model",
+        review_model="local-model",
+    )
+
+    assert estimate.cost_complete is True
+    assert estimate.estimated_cost_usd == 0.0
+
+
+def test_provider_cost_estimate_handles_aisuite_openai_model_prefixes():
+    provider = OpenAICompatibleProvider(client=None)
+
+    estimate = provider.estimate_run_cost(
+        num_keys=10,
+        locale_codes=["de"],
+        translate_model="openai:gpt-4o-mini",
+        review_model="openai:gpt-4o",
+    )
+
+    assert estimate.cost_complete is True
+    assert estimate.estimated_cost_usd is not None
+
+
+def test_provider_usage_summary_is_written_by_provider(tmp_path):
+    provider = OpenAICompatibleProvider(client=None)
+    provider.record_response("gpt-4o-mini", _response(prompt_tokens=9, completion_tokens=3))
+
+    path = tmp_path / "usage" / "summary.json"
+    provider.write_usage_summary(str(path))
+
+    assert path.exists()
+    assert "gpt-4o-mini" in provider.format_usage_summary()
+
+
+def test_factory_builds_default_openai_client():
+    logger = logging.getLogger("test")
+
+    with patch("src.model_provider.AsyncOpenAI", return_value=object()) as openai:
+        provider = create_openai_compatible_provider(
+            api_key="sk-test",
+            api_base_url=None,
+            logger=logger,
+        )
+
+    openai.assert_called_once_with(api_key="sk-test")
+    assert isinstance(provider, OpenAICompatibleProvider)
+
+
+def test_factory_builds_custom_endpoint_with_placeholder_key():
+    logger = logging.getLogger("test")
+
+    with patch("src.model_provider.AsyncOpenAI", return_value=object()) as openai:
+        provider = create_openai_compatible_provider(
+            api_key=None,
+            api_base_url="http://localhost:11434/v1",
+            logger=logger,
+        )
+
+    _, kwargs = openai.call_args
+    assert kwargs["api_key"]
+    assert kwargs["base_url"] == "http://localhost:11434/v1"
+    assert isinstance(provider, OpenAICompatibleProvider)
+
+
+def test_normalize_model_provider_name_canonicalizes_aliases():
+    assert normalize_model_provider_name("") == "aisuite"
+    assert normalize_model_provider_name("openai") == "openai_compatible"
+    assert normalize_model_provider_name("openai-compatible") == "openai_compatible"
+    assert normalize_model_provider_name("AISUITE") == "aisuite"
+
+
+def test_openai_provider_retries_only_transient_errors():
+    provider = OpenAICompatibleProvider(client=None)
+
+    assert provider.is_retryable_error(_api_status_error(500)) is True
+    assert provider.is_retryable_error(_api_status_error(503)) is True
+    assert provider.is_retryable_error(_api_status_error(400)) is False
+    assert provider.is_retryable_error(_api_status_error(401)) is False
+    assert provider.is_retryable_error(OpenAIError("permanent")) is False
+
+
+class _FakeSyncCompletions:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.response
+
+
+class _FakeSyncClient:
+    def __init__(self, response):
+        self.chat = SimpleNamespace(completions=_FakeSyncCompletions(response))
+
+    @property
+    def calls(self):
+        return self.chat.completions.calls
+
+
+@pytest.mark.asyncio
+async def test_aisuite_provider_uses_sync_client_behind_async_boundary():
+    tracker = UsageTracker(prices={"gpt-4o": {"input": 1.0, "output": 2.0}})
+    client = _FakeSyncClient(_response(prompt_tokens=3, completion_tokens=2))
+    provider = AiSuiteProvider(client=client, usage_tracker=tracker)
+
+    result = await provider.create_chat_completion(
+        model="openai:gpt-4o",
+        messages=[{"role": "user", "content": "translate"}],
+        completion_token_limit=128,
+        temperature=0,
+    )
+
+    assert result.usage.prompt_tokens == 3
+    assert client.calls[0]["model"] == "openai:gpt-4o"
+    assert client.calls[0]["max_tokens"] == 128
+    assert tracker.summary()["models"]["openai:gpt-4o"]["total_tokens"] == 5
+
+
+@pytest.mark.asyncio
+async def test_aisuite_provider_defaults_bare_model_names_to_openai():
+    client = _FakeSyncClient(_response())
+    provider = AiSuiteProvider(client=client, default_provider="openai")
+
+    await provider.create_chat_completion(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "translate"}],
+    )
+
+    assert client.calls[0]["model"] == "openai:gpt-4o"
+
+
+def test_aisuite_factory_imports_aisuite_lazily():
+    logger = logging.getLogger("test")
+    fake_client = object()
+
+    with patch("src.model_provider.importlib.import_module") as import_module:
+        import_module.return_value = SimpleNamespace(
+            Client=MagicMock(return_value=fake_client)
+        )
+        provider = create_aisuite_provider(
+            provider_configs={"openai": {"api_key": "sk-test"}},
+            logger=logger,
+        )
+
+    import_module.assert_called_once_with("aisuite")
+    import_module.return_value.Client.assert_called_once_with(
+        provider_configs={"openai": {"api_key": "sk-test"}}
+    )
+    assert isinstance(provider, AiSuiteProvider)
+    assert provider.client is fake_client
+
+
+def test_provider_factory_can_select_aisuite_backend():
+    logger = logging.getLogger("test")
+
+    with patch("src.model_provider.create_aisuite_provider") as create_aisuite:
+        create_aisuite.return_value = object()
+        provider = create_model_provider(
+            provider_name="aisuite",
+            api_key="sk-test",
+            api_base_url=None,
+            logger=logger,
+            aisuite_provider_configs={},
+        )
+
+    assert provider is create_aisuite.return_value
+    create_aisuite.assert_called_once()
+
+
+def test_provider_factory_defaults_to_aisuite_backend():
+    logger = logging.getLogger("test")
+
+    with patch("src.model_provider.create_aisuite_provider") as create_aisuite:
+        create_aisuite.return_value = object()
+        provider = create_model_provider(
+            provider_name="",
+            api_key="sk-test",
+            api_base_url=None,
+            logger=logger,
+            aisuite_provider_configs={},
+        )
+
+    assert provider is create_aisuite.return_value
+
+
+def test_aisuite_factory_adds_openai_placeholder_for_custom_endpoint_without_key():
+    logger = logging.getLogger("test")
+
+    with patch("src.model_provider.create_aisuite_provider") as create_aisuite:
+        create_aisuite.return_value = object()
+        create_model_provider(
+            provider_name="aisuite",
+            api_key=None,
+            api_base_url="http://localhost:11434/v1",
+            logger=logger,
+            aisuite_provider_configs={},
+        )
+
+    _, kwargs = create_aisuite.call_args
+    assert kwargs["provider_configs"]["openai"]["base_url"] == "http://localhost:11434/v1"
+    assert kwargs["provider_configs"]["openai"]["api_key"]

--- a/tests/unit/test_openai_compat.py
+++ b/tests/unit/test_openai_compat.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 from openai import OpenAIError
 
-from src.openai_compat import create_chat_completion
+from src.openai_compat import create_chat_completion, create_chat_completion_with_fallback
 
 
 def _response(content="{}"):
@@ -146,3 +146,24 @@ async def test_omits_completion_token_cap_when_no_limit_is_requested():
 
     assert "max_tokens" not in client.calls[0]
     assert "max_completion_tokens" not in client.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_callable_helper_accepts_sync_completion_callable():
+    calls = []
+    response = _response()
+
+    def create(**kwargs):
+        calls.append(kwargs)
+        return response
+
+    result = await create_chat_completion_with_fallback(
+        create,
+        model="gpt-4o",
+        messages=[],
+        completion_token_limit=128,
+    )
+
+    assert result is response
+    assert len(calls) == 1
+    assert calls[0]["max_tokens"] == 128

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -1,0 +1,42 @@
+def test_core_public_api_exports_pipeline_contract():
+    from src.core import (
+        TranslationPipelineOptions,
+        TranslationPipelinePaths,
+        TranslationPipelineResult,
+        TranslationPipelineSteps,
+        run_translation_pipeline,
+    )
+
+    assert callable(run_translation_pipeline)
+    assert TranslationPipelinePaths.__name__ == "TranslationPipelinePaths"
+    assert TranslationPipelineOptions.__name__ == "TranslationPipelineOptions"
+    assert TranslationPipelineSteps.__name__ == "TranslationPipelineSteps"
+    assert TranslationPipelineResult.__name__ == "TranslationPipelineResult"
+
+
+def test_provider_public_api_exports_default_backends():
+    from src.providers import (
+        AiSuiteProvider,
+        DEFAULT_AISUITE_PROVIDER,
+        DEFAULT_MODEL_PROVIDER,
+        ChatModelProvider,
+        OpenAICompatibleProvider,
+        create_model_provider,
+        normalize_model_provider_name,
+    )
+
+    assert AiSuiteProvider.__name__ == "AiSuiteProvider"
+    assert OpenAICompatibleProvider.__name__ == "OpenAICompatibleProvider"
+    assert ChatModelProvider.__name__ == "ChatModelProvider"
+    assert DEFAULT_MODEL_PROVIDER == "aisuite"
+    assert DEFAULT_AISUITE_PROVIDER == "openai"
+    assert callable(create_model_provider)
+    assert normalize_model_provider_name("openai") == "openai_compatible"
+
+
+def test_format_public_api_exports_localization_format_metadata():
+    from src.formats import JAVA_PROPERTIES_FORMAT, LocalizationFormat, load_localization_format
+
+    assert JAVA_PROPERTIES_FORMAT.id == "java_properties"
+    assert LocalizationFormat.__name__ == "LocalizationFormat"
+    assert load_localization_format("java_properties") == JAVA_PROPERTIES_FORMAT

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -1,13 +1,14 @@
 import json
 import os
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
 
 from src.semantic_quality import TranslationChange
+from src.model_provider import ModelProviderConfigurationError
 from src.translation_semantic_reviewer import (
     _run,
     append_semantic_review_findings,
@@ -188,7 +189,8 @@ async def test_semantic_reviewer_uses_compatible_completion_token_limit():
             )
         ]
     )
-    create_completion = AsyncMock(return_value=response)
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=response)
     changes = [
         TranslationChange(
             file="resources/mobile_es.properties",
@@ -200,23 +202,157 @@ async def test_semantic_reviewer_uses_compatible_completion_token_limit():
         )
     ]
 
-    with patch(
-        "src.translation_semantic_reviewer.create_chat_completion",
-        create_completion,
-    ):
-        findings = await review_translation_changes(
-            client=object(),
-            model="gpt-5.4-mini",
-            target_language="Spanish",
-            changes=changes,
-            style_rules=[],
-            brand_glossary=[],
-        )
+    findings = await review_translation_changes(
+        client=object(),
+        model="gpt-5.4-mini",
+        target_language="Spanish",
+        changes=changes,
+        style_rules=[],
+        brand_glossary=[],
+        model_provider=provider,
+    )
 
     assert findings == []
-    kwargs = create_completion.await_args.kwargs
+    kwargs = provider.create_chat_completion.await_args.kwargs
     assert kwargs["model"] == "gpt-5.4-mini"
     assert kwargs["completion_token_limit"] == 4096
     assert kwargs["response_format"] == {"type": "json_object"}
     assert "max_tokens" not in kwargs
     assert "max_completion_tokens" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_semantic_reviewer_defaults_to_aisuite_provider(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    validation_summary_path = tmp_path / "translation_validation_summary.json"
+    config_path.write_text(
+        "\n".join(
+            [
+                "dry_run: false",
+                "semantic_review:",
+                "  enabled: true",
+                "  model: gpt-4o",
+                "supported_locales:",
+                "  - code: de",
+                "    name: German",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    provider = MagicMock()
+    provider.client = object()
+    provider.create_chat_completion = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=json.dumps({"findings": []}))
+                )
+            ]
+        )
+    )
+
+    with (
+        patch(
+            "src.translation_semantic_reviewer.get_staged_diff",
+            return_value="fake diff",
+        ),
+        patch(
+            "src.translation_semantic_reviewer.iter_translation_changes_from_diff",
+            return_value=[
+                TranslationChange(
+                    file="resources/messages_de.properties",
+                    locale_code="de",
+                    key="hello",
+                    source_value="Hello",
+                    old_value=None,
+                    new_value="Hallo",
+                )
+            ],
+        ),
+        patch(
+            "src.translation_semantic_reviewer.create_model_provider",
+            return_value=provider,
+        ) as create_provider,
+    ):
+        exit_code = await _run(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--input-folder",
+                "resources",
+                "--config",
+                str(config_path),
+                "--validation-summary",
+                str(validation_summary_path),
+                "--changed-files",
+                "resources/messages_de.properties",
+            ]
+        )
+
+    assert exit_code == 0
+    assert create_provider.call_args.kwargs["provider_name"] == "aisuite"
+    assert json.loads(validation_summary_path.read_text(encoding="utf-8"))[
+        "semantic_review_findings"
+    ] == []
+
+
+@pytest.mark.asyncio
+async def test_semantic_reviewer_fails_when_provider_configuration_is_invalid(tmp_path, caplog):
+    config_path = tmp_path / "config.yaml"
+    validation_summary_path = tmp_path / "translation_validation_summary.json"
+    config_path.write_text(
+        "\n".join(
+            [
+                "dry_run: false",
+                "semantic_review:",
+                "  enabled: true",
+                "  model: gpt-4o",
+                "supported_locales:",
+                "  - code: de",
+                "    name: German",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with (
+        patch(
+            "src.translation_semantic_reviewer.get_staged_diff",
+            return_value="fake diff",
+        ),
+        patch(
+            "src.translation_semantic_reviewer.iter_translation_changes_from_diff",
+            return_value=[
+                TranslationChange(
+                    file="resources/messages_de.properties",
+                    locale_code="de",
+                    key="hello",
+                    source_value="Hello",
+                    old_value=None,
+                    new_value="Hallo",
+                )
+            ],
+        ),
+        patch(
+            "src.translation_semantic_reviewer.create_model_provider",
+            side_effect=ModelProviderConfigurationError("missing key"),
+        ),
+    ):
+        exit_code = await _run(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--input-folder",
+                "resources",
+                "--config",
+                str(config_path),
+                "--validation-summary",
+                str(validation_summary_path),
+                "--changed-files",
+                "resources/messages_de.properties",
+            ]
+        )
+
+    assert exit_code == 1
+    assert "Semantic review model provider configuration failed" in caplog.text
+    assert not validation_summary_path.exists()

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -51,6 +51,22 @@ def test_unknown_model_tracks_tokens_but_no_cost():
     assert s["totals"]["cost_complete"] is False
 
 
+def test_provider_prefixed_openai_model_uses_bare_model_price():
+    t = UsageTracker(prices=PRICES)
+    t.record("openai:gpt-4o", 1_000_000, 1_000_000)
+    s = t.summary()
+    assert s["models"]["openai:gpt-4o"]["estimated_cost_usd"] == 12.5
+    assert s["totals"]["cost_complete"] is True
+
+
+def test_unknown_provider_prefixed_model_does_not_use_bare_model_price():
+    t = UsageTracker(prices=PRICES)
+    t.record("azure:gpt-4o", 1_000_000, 1_000_000)
+    s = t.summary()
+    assert s["models"]["azure:gpt-4o"]["estimated_cost_usd"] is None
+    assert s["totals"]["cost_complete"] is False
+
+
 def test_record_response_reads_usage():
     t = UsageTracker(prices=PRICES)
     resp = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=120, completion_tokens=30))


### PR DESCRIPTION
## Summary
- make AISuite the packaged default model provider while keeping openai_compatible as an explicit fallback
- expose stable src.core, src.providers, and src.formats public import boundaries
- add a neutral generic Java properties example and update user-facing docs
- cover provider defaults, public APIs, semantic review provider use, docs, and examples with tests

## Verification
- OPENAI_API_KEY=test-openai-key venv/bin/python -m pytest
- bash -n update-translations.sh
- OPENAI_API_KEY=test-openai-key venv/bin/python -m compileall -q src
- git diff --check
- venv/bin/pip check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new default model-provider setup with broader support for OpenAI-compatible and AISuite-backed endpoints.
  * Introduced a generic Java `.properties` example project with ready-to-use translation and glossary files.

* **Bug Fixes**
  * Improved handling of provider-prefixed model names so pricing, token counts, and completion settings resolve correctly.

* **Documentation**
  * Updated setup, deployment, and GitHub Action docs to clarify default provider behavior and supported configuration options.
  * Expanded repository structure guidance and public API surface notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->