### PR TITLE
Harden AISuite provider routing

### DIFF
--- a/src/app_config.py
+++ b/src/app_config.py
@@ -358,6 +358,7 @@ def _create_model_provider(
     provider_name: str,
     api_base_url: Optional[str] = None,
     aisuite_provider_configs: Optional[Dict[str, Any]] = None,
+    model_names: Tuple[str, ...] = (),
 ) -> Optional[ChatModelProvider]:
     """Create the configured chat model provider unless running in dry-run mode.
 
@@ -379,6 +380,7 @@ def _create_model_provider(
             api_base_url=api_base_url,
             logger=logger,
             aisuite_provider_configs=aisuite_provider_configs,
+            model_names=model_names,
         )
     except ModelProviderConfigurationError as exc:
         logger.critical("CRITICAL: %s", exc)
@@ -496,6 +498,7 @@ def load_app_config() -> AppConfig:
         model_provider_name,
         api_base_url,
         aisuite_provider_configs,
+        (model_name, review_model_name),
     )
     openai_client = getattr(model_provider, "client", None) if model_provider else None
 

--- a/src/model_provider.py
+++ b/src/model_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+from collections.abc import Mapping
 from typing import Any, Dict, Optional, Protocol, Sequence
 
 import tiktoken
@@ -110,8 +111,23 @@ def _aisuite_models_route_to_provider(
     )
 
 
-def _provider_config_has_credentials(provider_config: Dict[str, Any]) -> bool:
+def _provider_config_has_credentials(provider_config: Mapping[str, Any]) -> bool:
     return any(provider_config.get(key) for key in ("api_key", "base_url"))
+
+
+def _aisuite_provider_config(
+    provider_configs: Mapping[str, Any],
+    provider_key: str,
+) -> Dict[str, Any]:
+    if provider_key not in provider_configs:
+        return {}
+
+    provider_config = provider_configs[provider_key]
+    if not isinstance(provider_config, Mapping):
+        raise ModelProviderConfigurationError(
+            f"aisuite.provider_configs.{provider_key} must be a mapping when configured."
+        )
+    return dict(provider_config)
 
 
 def _sanitize_aisuite_request_kwargs(model: str, kwargs: Dict[str, Any], default_provider: str) -> Dict[str, Any]:
@@ -375,22 +391,27 @@ def create_model_provider(
         )
     if normalized == "aisuite":
         provider_configs: Dict[str, Any] = dict(aisuite_provider_configs or {})
+        openai_provider_config = _aisuite_provider_config(
+            provider_configs,
+            DEFAULT_AISUITE_PROVIDER,
+        )
         openai_config = _openai_provider_config(
             api_key=api_key,
             api_base_url=api_base_url,
         )
         if openai_config:
             provider_configs["openai"] = {
-                **provider_configs.get("openai", {}),
+                **openai_provider_config,
                 **openai_config,
             }
+            openai_provider_config = provider_configs["openai"]
         if (
             _aisuite_models_route_to_provider(
                 model_names,
                 provider_key=DEFAULT_AISUITE_PROVIDER,
                 default_provider=DEFAULT_AISUITE_PROVIDER,
             )
-            and not _provider_config_has_credentials(provider_configs.get("openai", {}))
+            and not _provider_config_has_credentials(openai_provider_config)
         ):
             raise ModelProviderConfigurationError(
                 "OPENAI_API_KEY is required when AISuite routes bare or openai: models "

--- a/src/model_provider.py
+++ b/src/model_provider.py
@@ -24,6 +24,9 @@ from src.usage_tracker import DEFAULT_PRICES, UsageTracker
 _LOCAL_PROVIDER_PLACEHOLDER_KEY = "not-needed"
 DEFAULT_MODEL_PROVIDER = "aisuite"
 DEFAULT_AISUITE_PROVIDER = "openai"
+_AISUITE_OPENAI_ONLY_REQUEST_KWARGS = frozenset({
+    "response_format",
+})
 _MODEL_PROVIDER_ALIASES = {
     "aisuite": "aisuite",
     "openai": "openai_compatible",
@@ -85,6 +88,41 @@ def normalize_model_provider_name(provider_name: str) -> str:
     """Return the canonical provider name for config aliases."""
     normalized = (provider_name or DEFAULT_MODEL_PROVIDER).strip().lower().replace("-", "_")
     return _MODEL_PROVIDER_ALIASES.get(normalized, normalized)
+
+
+def _aisuite_provider_key_for_model(model: str, default_provider: str) -> str:
+    if ":" in model:
+        return model.split(":", 1)[0].strip().lower()
+    return default_provider.strip().lower()
+
+
+def _aisuite_models_route_to_provider(
+    model_names: Sequence[str],
+    *,
+    provider_key: str,
+    default_provider: str,
+) -> bool:
+    models_to_check = tuple(model_names) or ("",)
+    provider = provider_key.strip().lower()
+    return any(
+        _aisuite_provider_key_for_model(model_name, default_provider) == provider
+        for model_name in models_to_check
+    )
+
+
+def _provider_config_has_credentials(provider_config: Dict[str, Any]) -> bool:
+    return any(provider_config.get(key) for key in ("api_key", "base_url"))
+
+
+def _sanitize_aisuite_request_kwargs(model: str, kwargs: Dict[str, Any], default_provider: str) -> Dict[str, Any]:
+    provider_key = _aisuite_provider_key_for_model(model, default_provider)
+    if provider_key == "openai":
+        return dict(kwargs)
+    return {
+        key: value
+        for key, value in kwargs.items()
+        if key not in _AISUITE_OPENAI_ONLY_REQUEST_KWARGS
+    }
 
 
 class OpenAICompatibleProvider:
@@ -217,6 +255,13 @@ class AiSuiteProvider(OpenAICompatibleProvider):
         if self.client is None:
             raise ModelProviderConfigurationError("AISuite client is not configured.")
 
+        provider_model_name = self._provider_model_name(model)
+        request_kwargs = _sanitize_aisuite_request_kwargs(
+            provider_model_name,
+            kwargs,
+            self.default_provider,
+        )
+
         async def call_aisuite(**request_kwargs: Any) -> Any:
             return await asyncio.to_thread(
                 self.client.chat.completions.create,
@@ -225,11 +270,11 @@ class AiSuiteProvider(OpenAICompatibleProvider):
 
         response = await create_chat_completion_with_fallback(
             call_aisuite,
-            model=self._provider_model_name(model),
+            model=provider_model_name,
             messages=messages,
             completion_token_limit=completion_token_limit,
             retry_exception_types=(Exception,),
-            **kwargs,
+            **request_kwargs,
         )
         self.record_response(model, response)
         return response
@@ -318,6 +363,7 @@ def create_model_provider(
     api_base_url: Optional[str],
     logger: logging.Logger,
     aisuite_provider_configs: Optional[Dict[str, Any]] = None,
+    model_names: Sequence[str] = (),
 ) -> ChatModelProvider:
     """Create the configured model provider backend."""
     normalized = normalize_model_provider_name(provider_name)
@@ -338,6 +384,18 @@ def create_model_provider(
                 **provider_configs.get("openai", {}),
                 **openai_config,
             }
+        if (
+            _aisuite_models_route_to_provider(
+                model_names,
+                provider_key=DEFAULT_AISUITE_PROVIDER,
+                default_provider=DEFAULT_AISUITE_PROVIDER,
+            )
+            and not _provider_config_has_credentials(provider_configs.get("openai", {}))
+        ):
+            raise ModelProviderConfigurationError(
+                "OPENAI_API_KEY is required when AISuite routes bare or openai: models "
+                "to the default OpenAI API without a custom api_base_url."
+            )
         return create_aisuite_provider(
             provider_configs=provider_configs,
             logger=logger,

--- a/src/translation_semantic_reviewer.py
+++ b/src/translation_semantic_reviewer.py
@@ -248,6 +248,7 @@ async def _run(argv: Optional[Sequence[str]]) -> int:
             api_base_url=api_base_url,
             logger=logger,
             aisuite_provider_configs=aisuite_config.get("provider_configs", {}) or {},
+            model_names=(model,),
         )
     except ModelProviderConfigurationError as exc:
         logger.error("Semantic review model provider configuration failed: %s", exc)

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -540,7 +540,19 @@ class TestProviderAbstraction:
         assert config.model_provider_name == "aisuite"
         _, kwargs = factory.call_args
         assert kwargs["provider_name"] == "aisuite"
+        assert kwargs["model_names"] == ("gpt-4", "gpt-4")
         assert config.model_provider is provider
+
+    def test_default_aisuite_missing_openai_key_exits_for_openai_models(self):
+        with patch("builtins.open", mock_open(read_data=yaml.dump({"dry_run": False}))):
+            with patch("os.path.exists", return_value=True):
+                with patch("os.access", return_value=True):
+                    with patch("src.app_config.load_dotenv"):
+                        with patch("src.logging_config.setup_logger") as mock_logger:
+                            mock_logger.return_value = MagicMock()
+                            with patch.dict(os.environ, {}, clear=True):
+                                with pytest.raises(SystemExit):
+                                    load_app_config()
 
     def test_model_provider_name_is_canonicalized(self):
         provider = MagicMock()
@@ -666,3 +678,4 @@ class TestProviderAbstraction:
         assert kwargs["aisuite_provider_configs"] == {
             "anthropic": {"api_key": "from-env-or-secret"}
         }
+        assert kwargs["model_names"] == ("gpt-4", "gpt-4")

--- a/tests/unit/test_model_provider.py
+++ b/tests/unit/test_model_provider.py
@@ -386,3 +386,38 @@ def test_aisuite_factory_requires_openai_credentials_for_mixed_model_routes():
             aisuite_provider_configs={"anthropic": {"api_key": "secret"}},
             model_names=("anthropic:claude-3-5-sonnet-latest", "openai:gpt-4o"),
         )
+
+
+@pytest.mark.parametrize("openai_config", [None, "invalid", ["api_key", "secret"]])
+def test_aisuite_factory_rejects_invalid_openai_provider_config(openai_config):
+    logger = logging.getLogger("test")
+
+    with pytest.raises(
+        ModelProviderConfigurationError,
+        match="aisuite.provider_configs.openai",
+    ):
+        create_model_provider(
+            provider_name="aisuite",
+            api_key=None,
+            api_base_url=None,
+            logger=logger,
+            aisuite_provider_configs={"openai": openai_config},
+            model_names=("gpt-4o-mini",),
+        )
+
+
+def test_aisuite_factory_rejects_invalid_openai_config_before_endpoint_merge():
+    logger = logging.getLogger("test")
+
+    with pytest.raises(
+        ModelProviderConfigurationError,
+        match="aisuite.provider_configs.openai",
+    ):
+        create_model_provider(
+            provider_name="aisuite",
+            api_key=None,
+            api_base_url="http://localhost:11434/v1",
+            logger=logger,
+            aisuite_provider_configs={"openai": None},
+            model_names=("gpt-4o-mini",),
+        )

--- a/tests/unit/test_model_provider.py
+++ b/tests/unit/test_model_provider.py
@@ -8,6 +8,7 @@ from openai import APIStatusError, OpenAIError
 
 from src.model_provider import (
     AiSuiteProvider,
+    ModelProviderConfigurationError,
     OpenAICompatibleProvider,
     create_model_provider,
     create_aisuite_provider,
@@ -231,6 +232,42 @@ async def test_aisuite_provider_defaults_bare_model_names_to_openai():
     assert client.calls[0]["model"] == "openai:gpt-4o"
 
 
+@pytest.mark.asyncio
+async def test_aisuite_provider_keeps_openai_only_kwargs_for_openai_models():
+    client = _FakeSyncClient(_response())
+    provider = AiSuiteProvider(client=client, default_provider="openai")
+
+    await provider.create_chat_completion(
+        model="gpt-4o",
+        messages=[{"role": "system", "content": "return json"}],
+        response_format={"type": "json_object"},
+        completion_token_limit=128,
+    )
+
+    assert client.calls[0]["model"] == "openai:gpt-4o"
+    assert client.calls[0]["response_format"] == {"type": "json_object"}
+    assert client.calls[0]["max_tokens"] == 128
+
+
+@pytest.mark.asyncio
+async def test_aisuite_provider_strips_openai_only_kwargs_for_non_openai_models():
+    client = _FakeSyncClient(_response())
+    provider = AiSuiteProvider(client=client, default_provider="openai")
+
+    await provider.create_chat_completion(
+        model="anthropic:claude-3-5-sonnet-latest",
+        messages=[{"role": "system", "content": "return json"}],
+        response_format={"type": "json_object"},
+        completion_token_limit=128,
+        temperature=0.1,
+    )
+
+    assert client.calls[0]["model"] == "anthropic:claude-3-5-sonnet-latest"
+    assert "response_format" not in client.calls[0]
+    assert client.calls[0]["temperature"] == 0.1
+    assert client.calls[0]["max_tokens"] == 128
+
+
 def test_aisuite_factory_imports_aisuite_lazily():
     logger = logging.getLogger("test")
     fake_client = object()
@@ -301,3 +338,51 @@ def test_aisuite_factory_adds_openai_placeholder_for_custom_endpoint_without_key
     _, kwargs = create_aisuite.call_args
     assert kwargs["provider_configs"]["openai"]["base_url"] == "http://localhost:11434/v1"
     assert kwargs["provider_configs"]["openai"]["api_key"]
+
+
+def test_aisuite_factory_requires_openai_credentials_for_default_models():
+    logger = logging.getLogger("test")
+
+    with pytest.raises(ModelProviderConfigurationError, match="OPENAI_API_KEY"):
+        create_model_provider(
+            provider_name="aisuite",
+            api_key=None,
+            api_base_url=None,
+            logger=logger,
+            aisuite_provider_configs={},
+            model_names=("gpt-4o-mini", "gpt-4o"),
+        )
+
+
+def test_aisuite_factory_allows_non_openai_models_without_openai_key():
+    logger = logging.getLogger("test")
+    provider_configs = {"anthropic": {"api_key": "secret-from-provider-config"}}
+
+    with patch("src.model_provider.create_aisuite_provider") as create_aisuite:
+        create_aisuite.return_value = object()
+        provider = create_model_provider(
+            provider_name="aisuite",
+            api_key=None,
+            api_base_url=None,
+            logger=logger,
+            aisuite_provider_configs=provider_configs,
+            model_names=("anthropic:claude-3-5-sonnet-latest",),
+        )
+
+    assert provider is create_aisuite.return_value
+    _, kwargs = create_aisuite.call_args
+    assert kwargs["provider_configs"] == provider_configs
+
+
+def test_aisuite_factory_requires_openai_credentials_for_mixed_model_routes():
+    logger = logging.getLogger("test")
+
+    with pytest.raises(ModelProviderConfigurationError, match="OPENAI_API_KEY"):
+        create_model_provider(
+            provider_name="aisuite",
+            api_key=None,
+            api_base_url=None,
+            logger=logger,
+            aisuite_provider_configs={"anthropic": {"api_key": "secret"}},
+            model_names=("anthropic:claude-3-5-sonnet-latest", "openai:gpt-4o"),
+        )

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -291,6 +291,7 @@ async def test_semantic_reviewer_defaults_to_aisuite_provider(tmp_path):
 
     assert exit_code == 0
     assert create_provider.call_args.kwargs["provider_name"] == "aisuite"
+    assert create_provider.call_args.kwargs["model_names"] == ("gpt-4o",)
     assert json.loads(validation_summary_path.read_text(encoding="utf-8"))[
         "semantic_review_findings"
     ] == []


### PR DESCRIPTION
## Summary
- fail fast when AISuite default OpenAI routing lacks credentials or a custom endpoint
- pass configured model names into provider construction so mixed provider setups are validated early
- strip OpenAI-only request kwargs before dispatching non-OpenAI AISuite models

## Validation
- OPENAI_API_KEY=test-openai-key venv/bin/python -m pytest
- venv/bin/ruff check .
- OPENAI_API_KEY=test-openai-key venv/bin/python -m compileall -q src
- git diff --check
- venv/bin/pip check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection for AI-backed features so routed models are handled more reliably.
  * Added clearer validation when required AI credentials are missing, preventing confusing startup/runtime failures.
  * Updated request handling to avoid sending unsupported options to certain AI providers.
* **Tests**
  * Expanded coverage for provider setup, credential checks, and request-option filtering across model routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->