### PR TITLE
Add JSON format pipeline profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ Key settings:
 | Setting | Purpose |
 |---|---|
 | `target_project_root`, `input_folder` | Where your repo and localization files live. |
-| `localization_format` | Built-in format id: `java_properties` or `json`. |
+| `localization_format` | Built-in format id: `java_properties` or `json` for single-format projects. |
 | `localization_layout` | File layout id: `suffix`, `locale_directory`, or `locale_filename`. |
+| `localization_formats` | Optional list of format/layout profiles for mixed projects. |
 | `project_context` | Product/domain guidance injected into translation prompts. |
 | `translation_source` | `git` (default for new projects) or `transifex`. |
 | `model_provider` | `aisuite` by default; use `openai_compatible` only for the direct OpenAI SDK fallback path. |
@@ -170,7 +171,7 @@ internal implementation files:
 * `src.core` — format-agnostic pipeline orchestration contracts.
 * `src.providers` — chat-model provider contracts and provider factories.
 * `src.formats` — localization format/layout metadata, runtime adapters, adapter
-  registration, and conformance-test helpers.
+  registration, configured format profiles, and conformance-test helpers.
 
 CLI details: **[Localization CLI guide](./docs/localization-cli.md)**.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,8 +27,9 @@ localization_layout:
   source_locale: "en"
 
 # Optional: projects with more than one localization convention can replace the
-# singular settings above with a list. Each profile routes matching files through
-# its own parser/serializer and source-path mapping.
+# singular `localization_format` and `localization_layout` settings above with a
+# list. Each profile routes matching files through its own parser/serializer and
+# source-path mapping.
 # localization_formats:
 #   - id: "java_properties"
 #     layout: "suffix"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,6 +26,17 @@ localization_layout:
   id: "suffix"
   source_locale: "en"
 
+# Optional: projects with more than one localization convention can replace the
+# singular settings above with a list. Each profile routes matching files through
+# its own parser/serializer and source-path mapping.
+# localization_formats:
+#   - id: "java_properties"
+#     layout: "suffix"
+#   - id: "json"
+#     layout:
+#       id: "locale_directory"
+#       source_locale: "en"
+
 # Optional product/domain context injected into translation prompts.
 # Keep this generic for reusable configs; project-specific configs can be more precise.
 project_context: "Translate concise UI text for a software product."

--- a/docs/adding-new-locales.md
+++ b/docs/adding-new-locales.md
@@ -388,6 +388,24 @@ localization_layout:
 
 This maps `locales/de.json` back to `locales/en.json`.
 
+Projects that contain more than one localization convention can configure
+several profiles instead of the singular `localization_format` setting:
+
+```yaml
+localization_formats:
+  - id: "java_properties"
+    layout: "suffix"
+  - id: "json"
+    layout:
+      id: "locale_directory"
+      source_locale: "en"
+```
+
+When a source file changes, the pipeline queues only target files that map back
+through the same profile. A change to `messages.properties` does not enqueue
+`locales/de/messages.json`, and a change to `locales/en/messages.json` does not
+enqueue `messages_de.properties`.
+
 ## Best Practices
 
 ### Style Rules

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -25,6 +25,19 @@ If your JSON files use native locale directories such as
 `localization_layout.id: locale_directory` and
 `localization_layout.source_locale: en` in that config.
 
+If a project contains multiple localization conventions, replace the singular
+`localization_format` setting with profile entries:
+
+```yaml
+localization_formats:
+  - id: "java_properties"
+    layout: "suffix"
+  - id: "json"
+    layout:
+      id: "locale_directory"
+      source_locale: "en"
+```
+
 ## 2. Add the workflow
 
 Create `.github/workflows/translate.yml` in your repo:

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -61,6 +61,46 @@ That keeps orchestration stable while the internals remain modular:
   testing helpers.
 - `src.providers` exposes the model-provider abstraction and capabilities.
 
+## JSON Projects
+
+For JSON locale files, select the JSON adapter and the layout used by your
+repository:
+
+```yaml
+localization_format: "json"
+localization_layout:
+  id: "locale_directory"
+  source_locale: "en"
+```
+
+That maps `locales/de/messages.json` back to
+`locales/en/messages.json`. Suffix files such as `messages_de.json` and locale
+filenames such as `locales/de.json` are supported by changing
+`localization_layout.id` to `suffix` or `locale_filename`.
+
+The JSON adapter translates string leaves. Nested keys and array entries are
+addressed internally with JSON Pointer keys such as `/dialog/title` or
+`/steps/0/label`; non-string values are kept as non-translatable structure.
+
+## Mixed-Format Projects
+
+Projects can configure several format/layout profiles in one run:
+
+```yaml
+localization_formats:
+  - id: "java_properties"
+    layout: "suffix"
+  - id: "json"
+    layout:
+      id: "locale_directory"
+      source_locale: "en"
+```
+
+The runtime resolves each queued file to its matching profile, then uses that
+profile for source-file lookup, parsing, linting, review prompts, validation,
+and serialization. Existing single-format configs using `localization_format`
+and `localization_layout` keep working.
+
 ## Adding A Custom Format
 
 Custom formats register one `LocalizationFileAdapter` at process startup. The

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -40,6 +40,7 @@ This document outlines the structure and purpose of the files and directories wi
   - **`src/model_provider.py`**: Provider abstraction for chat completions, token counting, usage tracking, pricing estimates, AISuite dispatch, and the direct OpenAI-compatible fallback.
   - **`src/localization_adapters.py`**: Runtime parser/serializer/validator adapters for supported localization formats.
   - **`src/localization_layouts.py`**: Source/target path layout helpers for suffix files, locale directories, and locale filenames.
+  - **`src/localization_profiles.py`**: Configured format/layout pairs for projects that use one or more localization conventions.
 - **`src/cli.py`**: Reusable `localize` command entry point for init, validate,
   format discovery, and running the configured pipeline.
 - **`src/translate_localization_files.py`**: Translation runtime. It loads config, selects the localization adapter, manages the two-step translation/review process, and invokes `pipeline_core`.
@@ -61,8 +62,9 @@ This document outlines the structure and purpose of the files and directories wi
 
 - **`src/localization_adapters.py`**: Format adapter implementations for Java `.properties` and JSON. Adapters expose parse, serialize, key synchronization, linting, diff-key extraction, review snippets, and format-specific escaping behind one runtime contract.
 - **`src/localization_layouts.py`**: Layout implementations that map target locale paths back to source locale paths without coupling the runtime to one filename convention.
+- **`src/localization_profiles.py`**: Profile loader for single-format and mixed-format configs. Each queued file resolves to one profile before parsing, validation, prompt construction, and serialization.
 
-- **`src/translate_localization_files.py`**: The translation runtime. It loads configuration, selects the configured localization adapter, manages the two-step translation and review process through the configured model provider, and passes orchestration callables into `pipeline_core`.
+- **`src/translate_localization_files.py`**: The translation runtime. It loads configuration, resolves queued files to configured localization profiles, manages the two-step translation and review process through the configured model provider, and passes orchestration callables into `pipeline_core`.
 - **`src/connectors.py`**: Public source/processor/reporter/publisher connector
   contracts for projects that want to compose the core pipeline without using
   the default shell publisher.

--- a/examples/generic-json/README.md
+++ b/examples/generic-json/README.md
@@ -11,7 +11,9 @@ Files in this example:
 
 The JSON adapter translates string leaves only. Nested string leaves are tracked
 internally with JSON Pointer keys, so object keys containing dots remain
-unambiguous.
+unambiguous. Arrays are supported with numeric JSON Pointer segments such as
+`/steps/0/title`. Non-string values are treated as non-translatable structure
+and synchronized from the source shape.
 
 Try it from the repository root:
 

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -499,6 +499,8 @@ def load_app_config() -> AppConfig:
     try:
         localization_profiles = load_localization_profiles(config)
     except ValueError:
+        if config.get('localization_formats') is not None:
+            raise
         try:
             localization_format = load_localization_format(config.get('localization_format'))
         except ValueError:

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -20,6 +20,7 @@ from src.localization_layouts import (
     LocalizationLayout,
     load_localization_layout,
 )
+from src.localization_profiles import LocalizationProfile, load_localization_profiles
 from src.model_provider import (
     ChatModelProvider,
     DEFAULT_MODEL_PROVIDER,
@@ -95,6 +96,9 @@ class AppConfig:
     project_context: str = ""
     localization_format: LocalizationFormat = JAVA_PROPERTIES_FORMAT
     localization_layout: LocalizationLayout = SUFFIX_LAYOUT
+    localization_profiles: Tuple[LocalizationProfile, ...] = field(default_factory=lambda: (
+        LocalizationProfile(JAVA_PROPERTIES_FORMAT, SUFFIX_LAYOUT),
+    ))
 
 
 @dataclass(frozen=True)
@@ -172,14 +176,7 @@ def validate_config(
         ))
 
     try:
-        load_localization_format(config.get("localization_format"))
-    except ValueError as exc:
-        issues.append(ConfigIssue("error", str(exc)))
-    try:
-        load_localization_layout(
-            config.get("localization_layout"),
-            source_locale=str(config.get("source_locale") or "en"),
-        )
+        load_localization_profiles(config)
     except ValueError as exc:
         issues.append(ConfigIssue("error", str(exc)))
 
@@ -500,19 +497,25 @@ def load_app_config() -> AppConfig:
 
     project_context = str(config.get('project_context') or '').strip()
     try:
-        localization_format = load_localization_format(config.get('localization_format'))
+        localization_profiles = load_localization_profiles(config)
     except ValueError:
-        localization_format = JAVA_PROPERTIES_FORMAT
-    try:
-        localization_layout = load_localization_layout(
-            config.get('localization_layout'),
-            source_locale=str(config.get('source_locale') or 'en'),
-        )
-    except ValueError:
-        localization_layout = load_localization_layout(
-            None,
-            source_locale=str(config.get('source_locale') or 'en'),
-        )
+        try:
+            localization_format = load_localization_format(config.get('localization_format'))
+        except ValueError:
+            localization_format = JAVA_PROPERTIES_FORMAT
+        try:
+            localization_layout = load_localization_layout(
+                config.get('localization_layout'),
+                source_locale=str(config.get('source_locale') or 'en'),
+            )
+        except ValueError:
+            localization_layout = load_localization_layout(
+                None,
+                source_locale=str(config.get('source_locale') or 'en'),
+            )
+        localization_profiles = (LocalizationProfile(localization_format, localization_layout),)
+    localization_format = localization_profiles[0].localization_format
+    localization_layout = localization_profiles[0].localization_layout
 
     # Create the provider against the endpoint resolved earlier.
     model_provider = _create_model_provider(
@@ -555,4 +558,5 @@ def load_app_config() -> AppConfig:
         project_context=project_context,
         localization_format=localization_format,
         localization_layout=localization_layout,
+        localization_profiles=localization_profiles,
     )

--- a/src/formats/__init__.py
+++ b/src/formats/__init__.py
@@ -25,6 +25,10 @@ from src.localization_layouts import (
     LocalizationLayout,
     load_localization_layout,
 )
+from src.localization_profiles import (
+    LocalizationProfile,
+    load_localization_profiles,
+)
 
 __all__ = [
     "JSON_ADAPTER",
@@ -36,12 +40,14 @@ __all__ = [
     "LocalizationFileAdapter",
     "LocalizationFormat",
     "LocalizationLayout",
+    "LocalizationProfile",
     "SUFFIX_LAYOUT",
     "get_localization_adapter",
     "list_localization_adapters",
     "list_localization_formats",
     "load_localization_format",
     "load_localization_layout",
+    "load_localization_profiles",
     "register_localization_adapter",
     "register_localization_format",
     "unregister_localization_adapter",

--- a/src/localization_adapters.py
+++ b/src/localization_adapters.py
@@ -268,6 +268,10 @@ def _json_document_from_parsed_lines(parsed_lines: ParsedLines) -> Dict:
     raise ValueError("JSON parsed document metadata is missing.")
 
 
+def _dump_json_payload(payload: Dict) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
+
 def _synchronize_json_node(source_node: object, target_node: object) -> JsonNode:
     """Return a target JSON node ordered/shaped like source with translations kept."""
     if isinstance(source_node, dict):
@@ -299,7 +303,7 @@ def reassemble_json_file(parsed_lines: ParsedLines) -> str:
             continue
         path = tuple(line.get("json_path") or _json_key_to_path(str(line["key"])))
         _set_json_path(payload, path, str(line.get("value", "")))
-    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    return _dump_json_payload(payload)
 
 
 def synchronize_json_keys(target_file_path: str, source_file_path: str) -> Tuple[Set[str], Set[str]]:
@@ -311,15 +315,16 @@ def synchronize_json_keys(target_file_path: str, source_file_path: str) -> Tuple
     missing_keys = source_keys - target_keys
     extra_keys = target_keys - source_keys
 
-    if not missing_keys and not extra_keys:
-        return missing_keys, extra_keys
-
     source_payload = _json_document_from_parsed_lines(source_parsed_lines)
     target_payload = _json_document_from_parsed_lines(target_parsed_lines)
-    target_payload = _synchronize_json_node(source_payload, target_payload)
+    synchronized_payload = _synchronize_json_node(source_payload, target_payload)
+    synchronized_content = _dump_json_payload(synchronized_payload)
+
+    if not missing_keys and not extra_keys and synchronized_content == _dump_json_payload(target_payload):
+        return missing_keys, extra_keys
 
     with open(target_file_path, "w", encoding="utf-8") as file:
-        file.write(json.dumps(target_payload, ensure_ascii=False, indent=2) + "\n")
+        file.write(synchronized_content)
 
     return missing_keys, extra_keys
 

--- a/src/localization_adapters.py
+++ b/src/localization_adapters.py
@@ -258,41 +258,6 @@ def _set_json_path(
     _assign_json_child(current, path[-1], value)
 
 
-def _delete_json_path(root: Dict, path: Sequence[str]) -> None:
-    current = root
-    parents: List[Tuple[JsonContainer, str]] = []
-    for segment in path[:-1]:
-        child = _get_json_child(current, segment)
-        if not isinstance(child, (dict, list)):
-            return
-        parents.append((current, segment))
-        current = child
-    if isinstance(current, dict):
-        current.pop(path[-1], None)
-    elif isinstance(current, list):
-        index = _json_list_index(path[-1])
-        if index is not None and index < len(current):
-            current.pop(index)
-
-    for parent, segment in reversed(parents):
-        child = _get_json_child(parent, segment)
-        if not isinstance(child, (dict, list)) or child:
-            continue
-        if isinstance(parent, dict):
-            parent.pop(segment, None)
-        elif isinstance(parent, list):
-            index = _json_list_index(segment)
-            if index is not None and index < len(parent):
-                parent.pop(index)
-
-
-def _json_delete_sort_key(path: Sequence[str]) -> Tuple[int, Tuple[Tuple[int, object], ...]]:
-    return (
-        -len(path),
-        tuple((0, -int(segment)) if segment.isdigit() else (1, segment) for segment in path),
-    )
-
-
 def _json_document_from_parsed_lines(parsed_lines: ParsedLines) -> Dict:
     for line in parsed_lines:
         if line.get("type") == "document":
@@ -301,6 +266,30 @@ def _json_document_from_parsed_lines(parsed_lines: ParsedLines) -> Dict:
                 return copy.deepcopy(content)
             raise ValueError("JSON parsed document metadata is invalid.")
     raise ValueError("JSON parsed document metadata is missing.")
+
+
+def _synchronize_json_node(source_node: object, target_node: object) -> JsonNode:
+    """Return a target JSON node ordered/shaped like source with translations kept."""
+    if isinstance(source_node, dict):
+        result: Dict[str, JsonNode] = {}
+        target_dict = target_node if isinstance(target_node, dict) else {}
+        for key, source_child in source_node.items():
+            target_child = target_dict.get(key)
+            result[key] = _synchronize_json_node(source_child, target_child)
+        return result
+
+    if isinstance(source_node, list):
+        result_list: List[JsonNode] = []
+        target_list = target_node if isinstance(target_node, list) else []
+        for index, source_child in enumerate(source_node):
+            target_child = target_list[index] if index < len(target_list) else None
+            result_list.append(_synchronize_json_node(source_child, target_child))
+        return result_list
+
+    if isinstance(source_node, str):
+        return target_node if isinstance(target_node, str) else source_node
+
+    return copy.deepcopy(source_node)
 
 
 def reassemble_json_file(parsed_lines: ParsedLines) -> str:
@@ -325,28 +314,9 @@ def synchronize_json_keys(target_file_path: str, source_file_path: str) -> Tuple
     if not missing_keys and not extra_keys:
         return missing_keys, extra_keys
 
-    source_paths = {
-        line["key"]: tuple(line["json_path"])
-        for line in source_parsed_lines
-        if line.get("type") == "entry"
-    }
-    target_paths = {
-        line["key"]: tuple(line["json_path"])
-        for line in target_parsed_lines
-        if line.get("type") == "entry"
-    }
     source_payload = _json_document_from_parsed_lines(source_parsed_lines)
     target_payload = _json_document_from_parsed_lines(target_parsed_lines)
-
-    for key in sorted(extra_keys, key=lambda key: _json_delete_sort_key(target_paths[key])):
-        _delete_json_path(target_payload, target_paths[key])
-
-    for line in source_parsed_lines:
-        if line.get("type") != "entry":
-            continue
-        key = line["key"]
-        if key in missing_keys:
-            _set_json_path(target_payload, source_paths[key], source_translations[key], source_payload)
+    target_payload = _synchronize_json_node(source_payload, target_payload)
 
     with open(target_file_path, "w", encoding="utf-8") as file:
         file.write(json.dumps(target_payload, ensure_ascii=False, indent=2) + "\n")

--- a/src/localization_profiles.py
+++ b/src/localization_profiles.py
@@ -1,0 +1,104 @@
+"""Configured localization format/layout profiles.
+
+Formats describe file contents; layouts describe where locale files live. A
+project can use more than one pair, e.g. Java properties with suffix filenames
+and JSON files in locale directories.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Tuple
+
+from src.localization_formats import LocalizationFormat, load_localization_format
+from src.localization_layouts import LocalizationLayout, load_localization_layout
+
+
+@dataclass(frozen=True)
+class LocalizationProfile:
+    """One configured localization format and path layout pair."""
+
+    localization_format: LocalizationFormat
+    localization_layout: LocalizationLayout
+
+
+def _profile_format_raw(raw_profile: Any) -> Any:
+    if isinstance(raw_profile, str):
+        return raw_profile
+    if isinstance(raw_profile, Mapping):
+        if any(
+            key in raw_profile
+            for key in ("display_name", "file_extension", "code_fence", "locale_suffix_regex")
+        ):
+            return raw_profile
+        return (
+            raw_profile.get("format")
+            or raw_profile.get("localization_format")
+            or raw_profile.get("id")
+        )
+    return raw_profile
+
+
+def _profile_layout_raw(raw_profile: Any, fallback_layout: Any) -> Any:
+    if isinstance(raw_profile, Mapping):
+        return raw_profile.get("layout") or raw_profile.get("localization_layout") or fallback_layout
+    return fallback_layout
+
+
+def _profile_source_locale(raw_profile: Any, fallback_source_locale: str) -> str:
+    if isinstance(raw_profile, Mapping):
+        return str(raw_profile.get("source_locale") or fallback_source_locale)
+    return fallback_source_locale
+
+
+def _load_profile(
+    raw_profile: Any,
+    *,
+    fallback_layout: Any,
+    fallback_source_locale: str,
+) -> LocalizationProfile:
+    localization_format = load_localization_format(_profile_format_raw(raw_profile))
+    localization_layout = load_localization_layout(
+        _profile_layout_raw(raw_profile, fallback_layout),
+        source_locale=_profile_source_locale(raw_profile, fallback_source_locale),
+    )
+    return LocalizationProfile(
+        localization_format=localization_format,
+        localization_layout=localization_layout,
+    )
+
+
+def load_localization_profiles(config: Mapping[str, Any]) -> Tuple[LocalizationProfile, ...]:
+    """Load one or more localization format/layout profiles from config.
+
+    Backward compatibility:
+    - ``localization_format`` + ``localization_layout`` still define a single
+      profile.
+
+    Multi-format projects can use:
+    ``localization_formats: [{id: json, layout: locale_directory}, ...]``.
+    """
+    fallback_source_locale = str(config.get("source_locale") or "en")
+    fallback_layout = config.get("localization_layout")
+    raw_profiles = config.get("localization_formats")
+
+    if raw_profiles is None:
+        return (
+            _load_profile(
+                config.get("localization_format"),
+                fallback_layout=fallback_layout,
+                fallback_source_locale=fallback_source_locale,
+            ),
+        )
+
+    if not isinstance(raw_profiles, list) or not raw_profiles:
+        raise ValueError("localization_formats must contain at least one profile.")
+
+    return tuple(
+        _load_profile(
+            raw_profile,
+            fallback_layout=fallback_layout,
+            fallback_source_locale=fallback_source_locale,
+        )
+        for raw_profile in raw_profiles
+    )

--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -1303,7 +1303,7 @@ def _iter_localization_profiles(
     if not profiles:
         return (default_profile,)
     if default_profile not in profiles:
-        return (default_profile, *profiles)
+        return (*profiles, default_profile)
     return profiles
 
 

--- a/src/translate_localization_files.py
+++ b/src/translate_localization_files.py
@@ -37,6 +37,7 @@ from src.localization_adapters import (
 )
 from src.localization_formats import LocalizationFormat
 from src.localization_layouts import LocalizationLayout
+from src.localization_profiles import LocalizationProfile
 from src.model_provider import OpenAICompatibleProvider
 from src.placeholder_rules import (
     extract_placeholder_tokens,
@@ -94,6 +95,7 @@ BRAND_GLOSSARY = config.brand_glossary
 PROJECT_CONTEXT = config.project_context
 LOCALIZATION_FORMAT = config.localization_format
 LOCALIZATION_LAYOUT = config.localization_layout
+LOCALIZATION_PROFILES = config.localization_profiles
 TRANSLATION_QUEUE_FOLDER = config.translation_queue_folder
 TRANSLATED_QUEUE_FOLDER = config.translated_queue_folder
 TRANSLATION_KEY_LEDGER_FILE_PATH = config.translation_key_ledger_file_path
@@ -412,7 +414,11 @@ def filter_git_changed_keys_by_source(
     return filtered
 
 
-def get_working_tree_changed_keys(target_file_path: str, repo_root: str) -> Set[str]:
+def get_working_tree_changed_keys(
+        target_file_path: str,
+        repo_root: str,
+        localization_format: Optional[LocalizationFormat] = None,
+) -> Set[str]:
     """
     Return keys that were added/updated for ``target_file_path`` in git working tree.
 
@@ -438,7 +444,7 @@ def get_working_tree_changed_keys(target_file_path: str, repo_root: str) -> Set[
             )
             return set()
 
-        adapter = get_localization_adapter(LOCALIZATION_FORMAT)
+        adapter = get_localization_adapter(localization_format or LOCALIZATION_FORMAT)
         changed_keys: Set[str] = set()
         for line in result.stdout.splitlines():
             if not line.startswith('+') or line.startswith('+++'):
@@ -648,7 +654,11 @@ async def _handle_retry(attempt: int, max_retries: int, base_delay: float, key: 
         logger.error(f"Translation failed for key '{key}' after {max_retries} attempts.")
         return False
 
-def run_pre_translation_validation(target_file_path: str, source_file_path: str) -> Tuple[List[str], Set[str]]:
+def run_pre_translation_validation(
+        target_file_path: str,
+        source_file_path: str,
+        localization_format: Optional[LocalizationFormat] = None,
+) -> Tuple[List[str], Set[str]]:
     """
     Runs validation and preparation checks on a target localization file.
     - Synchronizes keys with the source file (adds missing, removes extra).
@@ -666,7 +676,7 @@ def run_pre_translation_validation(target_file_path: str, source_file_path: str)
     errors: List[str] = []
     newly_added_keys: Set[str] = set()
     filename = os.path.basename(target_file_path)
-    adapter = get_localization_adapter(LOCALIZATION_FORMAT)
+    adapter = get_localization_adapter(localization_format or LOCALIZATION_FORMAT)
     logger.info(f"Running pre-translation validation for '{filename}'...")
 
     # 1. Synchronize keys (add missing, remove extra)
@@ -712,7 +722,8 @@ def run_pre_translation_validation(target_file_path: str, source_file_path: str)
 def run_post_translation_validation(
         final_content: str,
         source_translations: Dict[str, str],
-        filename: str
+        filename: str,
+        localization_format: Optional[LocalizationFormat] = None,
 ) -> bool:
     """
     Runs a series of validation checks on the final translated file content.
@@ -729,13 +740,14 @@ def run_post_translation_validation(
     logger.info(f"Running post-translation validation for '{filename}'...")
 
     temp_file_path = None
-    adapter = get_localization_adapter(LOCALIZATION_FORMAT)
+    effective_format = localization_format or LOCALIZATION_FORMAT
+    adapter = get_localization_adapter(effective_format)
     try:
         # Create a temporary file with delete=False to control its lifecycle.
         with tempfile.NamedTemporaryFile(
                 mode='w',
                 delete=False,
-                suffix=LOCALIZATION_FORMAT.file_extension,
+                suffix=effective_format.file_extension,
                 encoding='utf-8'
         ) as temp_f:
             temp_file_path = temp_f.name
@@ -907,7 +919,8 @@ async def translate_text_async(
         glossary: Dict[str, Dict[str, str]],
         semaphore: asyncio.Semaphore,
         rate_limiter: AsyncLimiter,
-        index: int
+        index: int,
+        localization_format: Optional[LocalizationFormat] = None,
 ) -> Tuple[int, str]:
     """
     Asynchronously translate a single text with context.
@@ -965,7 +978,7 @@ async def translate_text_async(
             target_language=target_language,
             style_rules_text=style_rules_text,
             project_context=PROJECT_CONTEXT,
-            localization_format=LOCALIZATION_FORMAT,
+            localization_format=localization_format or LOCALIZATION_FORMAT,
         )
 
         brand_glossary_text = '\n'.join(f"- {term}" for term in dict.fromkeys(BRAND_GLOSSARY))
@@ -1101,7 +1114,8 @@ async def holistic_review_async(
         keys_to_review: List[str],
         semaphore: asyncio.Semaphore,
         rate_limiter: AsyncLimiter,
-        style_rules_text: str
+        style_rules_text: str,
+        localization_format: Optional[LocalizationFormat] = None,
 ) -> Optional[Dict[str, str]]:
     """
     Performs a holistic review of an entire translated file and returns corrections
@@ -1141,7 +1155,7 @@ async def holistic_review_async(
             source_content=protected_source,
             translated_content=protected_translated,
             style_rules_text=style_rules_text,
-            localization_format=LOCALIZATION_FORMAT,
+            localization_format=localization_format or LOCALIZATION_FORMAT,
         )
         max_retries = 3
         base_delay = 5  # Longer delay for a potentially larger task
@@ -1276,6 +1290,64 @@ def integrate_translations(
 
     return parsed_lines
 
+
+def _default_localization_profile() -> LocalizationProfile:
+    return LocalizationProfile(LOCALIZATION_FORMAT, LOCALIZATION_LAYOUT)
+
+
+def _iter_localization_profiles(
+        localization_profiles: Optional[Tuple[LocalizationProfile, ...]] = None,
+) -> Tuple[LocalizationProfile, ...]:
+    profiles = tuple(localization_profiles or LOCALIZATION_PROFILES or ())
+    default_profile = _default_localization_profile()
+    if not profiles:
+        return (default_profile,)
+    if default_profile not in profiles:
+        return (default_profile, *profiles)
+    return profiles
+
+
+def find_target_localization_profile(
+        relative_path: str,
+        supported_codes: Optional[List[str]] = None,
+        localization_profiles: Optional[Tuple[LocalizationProfile, ...]] = None,
+) -> Optional[LocalizationProfile]:
+    """Return the configured profile that treats ``relative_path`` as a target file."""
+    codes = supported_codes or list(LANGUAGE_CODES.keys())
+    for profile in _iter_localization_profiles(localization_profiles):
+        if profile.localization_layout.is_target_file(
+                relative_path,
+                codes,
+                profile.localization_format,
+        ):
+            return profile
+    return None
+
+
+def find_source_localization_profile(
+        relative_path: str,
+        supported_codes: Optional[List[str]] = None,
+        localization_profiles: Optional[Tuple[LocalizationProfile, ...]] = None,
+) -> Optional[LocalizationProfile]:
+    """Return the configured profile that treats ``relative_path`` as a source file."""
+    codes = supported_codes or list(LANGUAGE_CODES.keys())
+    for profile in _iter_localization_profiles(localization_profiles):
+        if profile.localization_layout.is_source_file(
+                relative_path,
+                codes,
+                profile.localization_format,
+        ):
+            return profile
+    return None
+
+
+def _profile_for_target_or_default(
+        relative_path: str,
+        supported_codes: Optional[List[str]] = None,
+) -> LocalizationProfile:
+    return find_target_localization_profile(relative_path, supported_codes) or _default_localization_profile()
+
+
 def extract_language_from_filename(filename: str, supported_codes: List[str]) -> Optional[str]:
     """
     Extract the language code from a filename by checking against a list of supported codes.
@@ -1287,7 +1359,12 @@ def extract_language_from_filename(filename: str, supported_codes: List[str]) ->
     Returns:
         Optional[str]: The language code if found, else None.
     """
-    return LOCALIZATION_LAYOUT.extract_locale(filename, supported_codes, LOCALIZATION_FORMAT)
+    profile = _profile_for_target_or_default(filename, supported_codes)
+    return profile.localization_layout.extract_locale(
+        filename,
+        supported_codes,
+        profile.localization_format,
+    )
 
 def get_source_filename(translation_file: str, supported_codes: List[str]) -> str:
     """
@@ -1314,7 +1391,12 @@ def get_source_filename(translation_file: str, supported_codes: List[str]) -> st
         >>> get_source_filename('app.properties', ['es', 'de'])
         'app.properties'
     """
-    return LOCALIZATION_LAYOUT.source_path_for_target(translation_file, supported_codes, LOCALIZATION_FORMAT)
+    profile = _profile_for_target_or_default(translation_file, supported_codes)
+    return profile.localization_layout.source_path_for_target(
+        translation_file,
+        supported_codes,
+        profile.localization_format,
+    )
 
 
 def is_target_localization_file(
@@ -1324,6 +1406,8 @@ def is_target_localization_file(
         localization_layout: Optional[LocalizationLayout] = None,
 ) -> bool:
     """Return true when ``relative_path`` is a configured target locale file."""
+    if localization_format is None and localization_layout is None:
+        return find_target_localization_profile(relative_path, supported_codes) is not None
     return (localization_layout or LOCALIZATION_LAYOUT).is_target_file(
         relative_path,
         supported_codes or list(LANGUAGE_CODES.keys()),
@@ -1338,6 +1422,8 @@ def is_source_localization_file(
         localization_layout: Optional[LocalizationLayout] = None,
 ) -> bool:
     """Return true when ``relative_path`` is a configured source locale file."""
+    if localization_format is None and localization_layout is None:
+        return find_source_localization_profile(relative_path, supported_codes) is not None
     return (localization_layout or LOCALIZATION_LAYOUT).is_source_file(
         relative_path,
         supported_codes or list(LANGUAGE_CODES.keys()),
@@ -1448,14 +1534,29 @@ def get_changed_translation_files(
 
     def is_discoverable_target_file(relative_path: str) -> bool:
         """Return true for target files that should be queued for locale extraction."""
-        if is_target_localization_file(relative_path):
-            return True
-        if LOCALIZATION_LAYOUT.id == "suffix":
-            return (
-                LOCALIZATION_FORMAT.is_supported_file(relative_path)
-                and LOCALIZATION_FORMAT.is_locale_file(os.path.basename(relative_path))
-            )
-        return False
+        return find_discoverable_target_profile(relative_path) is not None
+
+    def find_discoverable_target_profile(relative_path: str) -> Optional[LocalizationProfile]:
+        """Return the profile for a target file, including unsupported suffix locales."""
+        target_profile = find_target_localization_profile(relative_path)
+        if target_profile:
+            return target_profile
+        for profile in _iter_localization_profiles():
+            if profile.localization_layout.id != "suffix":
+                continue
+            if (
+                    profile.localization_format.is_supported_file(relative_path)
+                    and profile.localization_format.is_locale_file(os.path.basename(relative_path))
+            ):
+                return profile
+        return None
+
+    def supports_configured_format(relative_path: str) -> bool:
+        """Return true if any configured profile owns this file extension."""
+        return any(
+            profile.localization_format.is_supported_file(relative_path)
+            for profile in _iter_localization_profiles()
+        )
 
     def apply_filter_glob(files: List[str]) -> List[str]:
         """Apply optional TRANSLATION_FILTER_GLOB filtering to discovered files."""
@@ -1546,13 +1647,13 @@ def get_changed_translation_files(
             entries = _entries_from_status_output(result.stdout)
 
         changed_translation_files: Set[str] = set()
-        changed_source_files: Set[str] = set()
+        changed_source_files: Set[Tuple[LocalizationProfile, str]] = set()
         # Accepted change statuses for both formats; deletions (D) are intentionally excluded.
         accepted_status = {'M', 'A', 'AM', 'MM', 'RM', 'R', 'C', '??'}
         for cleaned_status, filepath in entries:
             if cleaned_status not in accepted_status:
                 continue
-            if not LOCALIZATION_FORMAT.is_supported_file(filepath):
+            if not supports_configured_format(filepath):
                 continue
             # Extract the filename relative to input_folder
             rel_path = os.path.relpath(filepath, rel_input_folder)
@@ -1563,15 +1664,24 @@ def get_changed_translation_files(
             # hyphenated locale codes like zh-Hans, zh-Hant.
             if is_discoverable_target_file(rel_path):
                 changed_translation_files.add(rel_path)
-            elif is_source_localization_file(rel_path):
-                changed_source_files.add(rel_path)
+            else:
+                source_profile = find_source_localization_profile(rel_path)
+                if source_profile:
+                    changed_source_files.add((source_profile, rel_path))
 
         # Resilience to delayed Transifex propagation:
         # if source files changed, also enqueue all related locale files even if unchanged in git status.
         if changed_source_files:
             for translation_rel_path in discover_translation_files():
-                source_rel_path = get_source_filename(translation_rel_path, list(LANGUAGE_CODES.keys()))
-                if source_rel_path.replace('\\', '/') in changed_source_files:
+                target_profile = find_target_localization_profile(translation_rel_path)
+                if not target_profile:
+                    continue
+                source_rel_path = target_profile.localization_layout.source_path_for_target(
+                    translation_rel_path,
+                    list(LANGUAGE_CODES.keys()),
+                    target_profile.localization_format,
+                )
+                if (target_profile, source_rel_path.replace('\\', '/')) in changed_source_files:
                     changed_translation_files.add(translation_rel_path)
 
         return apply_filter_glob(sorted(changed_translation_files))
@@ -1639,14 +1749,18 @@ async def process_translation_queue(
         - A dictionary of skipped files, mapping filename to a list of error strings.
         - Total number of keys translated across all files.
     """
-    adapter = get_localization_adapter(LOCALIZATION_FORMAT)
-
-    localization_files = []
-    for root, _, files in os.walk(translation_queue_folder):
+    localization_files: List[Tuple[str, LocalizationProfile]] = []
+    for root, dirs, files in os.walk(translation_queue_folder):
+        dirs.sort()
         for name in files:
+            if name.startswith("."):
+                continue
             relative_path = os.path.relpath(os.path.join(root, name), translation_queue_folder)
-            if is_target_localization_file(relative_path):
-                localization_files.append(relative_path)
+            relative_path = relative_path.replace('\\', '/')
+            profile = find_target_localization_profile(relative_path)
+            if profile:
+                localization_files.append((relative_path, profile))
+    localization_files.sort(key=lambda item: item[0])
 
     # Load the glossary from the JSON file
     glossary = load_glossary(glossary_file_path)
@@ -1666,9 +1780,16 @@ async def process_translation_queue(
     total_keys_translated = 0
     skipped_files: Dict[str, List[str]] = {}
 
-    for translation_file in localization_files:
+    for translation_file, localization_profile in localization_files:
+        localization_format = localization_profile.localization_format
+        localization_layout = localization_profile.localization_layout
+        adapter = get_localization_adapter(localization_format)
         # Extract the language code from the filename
-        language_code = extract_language_from_filename(translation_file, list(LANGUAGE_CODES.keys()))
+        language_code = localization_layout.extract_locale(
+            translation_file,
+            list(LANGUAGE_CODES.keys()),
+            localization_format,
+        )
         if not language_code:
             logger.warning(f"Skipping file {translation_file}: unable to extract language code.")
             continue
@@ -1680,7 +1801,11 @@ async def process_translation_queue(
 
         # Define full paths
         translation_file_path = os.path.join(translation_queue_folder, translation_file)
-        source_file_name = get_source_filename(translation_file, list(LANGUAGE_CODES.keys()))
+        source_file_name = localization_layout.source_path_for_target(
+            translation_file,
+            list(LANGUAGE_CODES.keys()),
+            localization_format,
+        )
         source_file_path = os.path.join(INPUT_FOLDER, source_file_name)
 
         if not os.path.exists(source_file_path):
@@ -1690,7 +1815,11 @@ async def process_translation_queue(
         logger.info(f"Processing file '{translation_file}' for language '{target_language}'...")
 
         # --- Pre-flight Validator ---
-        validation_errors, newly_added_keys = run_pre_translation_validation(translation_file_path, source_file_path)
+        validation_errors, newly_added_keys = run_pre_translation_validation(
+            translation_file_path,
+            source_file_path,
+            localization_format,
+        )
         if validation_errors:
             logger.error(f"Skipping translation for '{translation_file}' due to pre-translation validation errors.")
             for error in validation_errors:
@@ -1717,7 +1846,11 @@ async def process_translation_queue(
         # Extract texts to translate
         file_ledger_entries = key_ledger.get(translation_file, {})
         original_input_file_path = os.path.join(INPUT_FOLDER, translation_file)
-        git_changed_keys = get_working_tree_changed_keys(original_input_file_path, REPO_ROOT)
+        git_changed_keys = get_working_tree_changed_keys(
+            original_input_file_path,
+            REPO_ROOT,
+            localization_format,
+        )
         # Only re-translate git-dirty keys if their English source actually changed.
         # This prevents an infinite cycle where Transifex community translations
         # are overwritten by AI, then Transifex re-serves the community version.
@@ -1772,7 +1905,8 @@ async def process_translation_queue(
                 glossary,
                 semaphore,
                 rate_limiter,  # Pass the rate limiter
-                idx
+                idx,
+                localization_format,
             )
             for idx, (text, key) in enumerate(zip(texts_to_translate, keys_to_translate))
         ]
@@ -1801,7 +1935,7 @@ async def process_translation_queue(
             indices,
             keys_to_translate,
             source_translations,
-            LOCALIZATION_FORMAT,
+            localization_format,
         )
         draft_content = adapter.reassemble_file(draft_lines)
 
@@ -1820,7 +1954,7 @@ async def process_translation_queue(
         with tempfile.NamedTemporaryFile(
                 mode='w',
                 delete=False,
-                suffix=LOCALIZATION_FORMAT.file_extension,
+                suffix=localization_format.file_extension,
                 encoding='utf-8'
         ) as temp_f:
             temp_f.write(draft_content)
@@ -1839,7 +1973,8 @@ async def process_translation_queue(
                 keys_to_review=key_chunk,
                 semaphore=semaphore,
                 rate_limiter=rate_limiter,
-                style_rules_text=style_rules_text_for_review
+                style_rules_text=style_rules_text_for_review,
+                localization_format=localization_format,
             ) for key_chunk in key_chunks]
         )
 
@@ -2011,12 +2146,24 @@ def generate_translation_summary(
     locales: set[str] = set()
 
     for filename in processed_files:
-        code = extract_language_from_filename(filename, sorted_codes)
+        profile = find_target_localization_profile(filename, sorted_codes)
+        if not profile:
+            continue
+        code = profile.localization_layout.extract_locale(
+            filename,
+            sorted_codes,
+            profile.localization_format,
+        )
         if code:
             locales.add(code)
-            source_basename = os.path.basename(get_source_filename(filename, sorted_codes))
-            if source_basename.endswith(LOCALIZATION_FORMAT.file_extension):
-                module = source_basename[:-len(LOCALIZATION_FORMAT.file_extension)]
+            source_filename = profile.localization_layout.source_path_for_target(
+                filename,
+                sorted_codes,
+                profile.localization_format,
+            )
+            source_basename = os.path.basename(source_filename)
+            if source_basename.endswith(profile.localization_format.file_extension):
+                module = source_basename[:-len(profile.localization_format.file_extension)]
             else:
                 module = os.path.splitext(source_basename)[0]
             if module and module != os.path.basename(filename):

--- a/tests/integration/test_quote_escaping.py
+++ b/tests/integration/test_quote_escaping.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 # Set a dummy API key before importing the main script to prevent SystemExit.
 os.environ['OPENAI_API_KEY'] = 'DUMMY_KEY_FOR_TESTING'
 
+from src.localization_formats import JAVA_PROPERTIES_FORMAT
 from src.properties_parser import reassemble_file
 
 
@@ -78,7 +79,8 @@ class TestQuoteEscaping(unittest.IsolatedAsyncioTestCase):
         provider.create_chat_completion.assert_awaited()
         mock_git_changed_keys.assert_called_once_with(
             os.path.join(self.test_dir, 'app_de.properties'),
-            REPO_ROOT
+            REPO_ROOT,
+            JAVA_PROPERTIES_FORMAT,
         )
 
         output_file_path = os.path.join(self.translated_dir, 'app_de.properties')

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -11,8 +11,9 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from types import SimpleNamespace
 import pytest
 import src.translate_localization_files
-from src.localization_formats import JSON_FORMAT
+from src.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
 from src.localization_layouts import LocalizationLayout
+from src.localization_profiles import LocalizationProfile
 
 # All fixtures are now defined in conftest.py and are auto-discovered by pytest.
 
@@ -34,6 +35,54 @@ async def test_main_flow_no_changes(mock_move, mock_copy_back, mock_process, moc
     mock_process.assert_not_called()
     mock_copy_back.assert_not_called()
     mock_move.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_main_translates_json_from_detection_to_copyback(integration_test_environment):
+    env = integration_test_environment
+    source_file_path = os.path.join(env['input_folder'], 'app.json')
+    target_file_path = os.path.join(env['input_folder'], 'app_de.json')
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        json.dump({"hello": "Hello", "nested": {"title": "Title {0}"}}, f, ensure_ascii=False, indent=2)
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        json.dump({"hello": "Hallo"}, f, ensure_ascii=False, indent=2)
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(side_effect=[
+        SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="Titel {0}"))]),
+        SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
+            content=json.dumps({"/nested/title": "Titel {0}"})
+        ))]),
+    ])
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
+
+    profiles = (
+        LocalizationProfile(JSON_FORMAT, LocalizationLayout(id="suffix", source_locale="en")),
+    )
+    with patch('src.translate_localization_files.get_changed_translation_files',
+               return_value=['app_de.json']), \
+         patch('src.translate_localization_files.LOCALIZATION_FORMAT', JSON_FORMAT), \
+         patch('src.translate_localization_files.LOCALIZATION_PROFILES', profiles), \
+         patch('src.translate_localization_files.LANGUAGE_CODES', {'de': 'German'}), \
+         patch('src.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('src.translate_localization_files.PRESERVE_QUEUES_FOR_DEBUG', True), \
+         patch('src.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH',
+               os.path.join(env['input_folder'], 'ledger.json')), \
+         patch('src.translate_localization_files.get_working_tree_changed_keys', return_value=set()):
+        await src.translate_localization_files.main()
+
+    with open(target_file_path, 'r', encoding='utf-8') as f:
+        final_payload = json.load(f)
+
+    assert final_payload == {
+        "hello": "Hallo",
+        "nested": {"title": "Titel {0}"},
+    }
+
 
 @pytest.mark.asyncio
 async def test_process_translation_queue_end_to_end(integration_test_environment):
@@ -166,6 +215,7 @@ async def test_process_translation_queue_translates_json_locale_file(integration
         "nested": {
             "title": "Titel {0}",
         },
+        "count": 3,
     }
 
 
@@ -227,4 +277,86 @@ async def test_process_translation_queue_translates_json_locale_directory_layout
         "steps": [
             {"title": "Details prüfen"},
         ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_translation_queue_routes_mixed_format_profiles(integration_test_environment):
+    env = integration_test_environment
+    properties_source_path = os.path.join(env['input_folder'], 'app.properties')
+    properties_target_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
+    json_source_path = os.path.join(env['input_folder'], 'locales', 'en', 'common.json')
+    json_target_path = os.path.join(env['translation_queue_folder'], 'locales', 'de', 'common.json')
+    os.makedirs(os.path.dirname(json_source_path), exist_ok=True)
+    os.makedirs(os.path.dirname(json_target_path), exist_ok=True)
+
+    with open(properties_source_path, 'w', encoding='utf-8') as f:
+        f.write('headline=Headline\ncta=Continue with {0}\n')
+    with open(properties_target_path, 'w', encoding='utf-8') as f:
+        f.write('headline=Ueberschrift\n')
+    with open(json_source_path, 'w', encoding='utf-8') as f:
+        json.dump({
+            "nested": {"title": "JSON title {0}"},
+            "metadata": {"version": 1},
+        }, f, ensure_ascii=False, indent=2)
+    with open(json_target_path, 'w', encoding='utf-8') as f:
+        json.dump({"metadata": {"version": 1}}, f, ensure_ascii=False, indent=2)
+
+    async def fake_completion(**kwargs):
+        if kwargs.get("response_format"):
+            system_content = kwargs["messages"][0]["content"]
+            if "/nested/title" in system_content:
+                return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
+                    content=json.dumps({"/nested/title": "JSON-Titel {0}"})
+                ))])
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
+                content=json.dumps({"cta": "Weiter mit {0}"})
+            ))])
+
+        user_content = kwargs["messages"][1]["content"]
+        if "Key: /nested/title" in user_content:
+            content = "JSON-Titel {0}"
+        else:
+            content = "Weiter mit {0}"
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(side_effect=fake_completion)
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
+
+    profiles = (
+        LocalizationProfile(
+            JAVA_PROPERTIES_FORMAT,
+            LocalizationLayout(id="suffix", source_locale="en"),
+        ),
+        LocalizationProfile(
+            JSON_FORMAT,
+            LocalizationLayout(id="locale_directory", source_locale="en"),
+        ),
+    )
+    with patch('src.translate_localization_files.LOCALIZATION_PROFILES', profiles), \
+         patch('src.translate_localization_files.LANGUAGE_CODES', {'de': 'German'}), \
+         patch('src.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('src.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH',
+               os.path.join(env['input_folder'], 'ledger.json')), \
+         patch('src.translate_localization_files.get_working_tree_changed_keys', return_value=set()):
+        await src.translate_localization_files.process_translation_queue(
+            translation_queue_folder=env['translation_queue_folder'],
+            translated_queue_folder=env['translated_queue_folder'],
+            glossary_file_path=env['mock_glossary_path_resolved']
+        )
+
+    with open(os.path.join(env['translated_queue_folder'], 'app_de.properties'), 'r', encoding='utf-8') as f:
+        properties_content = f.read()
+    with open(os.path.join(env['translated_queue_folder'], 'locales', 'de', 'common.json'), 'r', encoding='utf-8') as f:
+        json_payload = json.load(f)
+
+    assert "headline=Ueberschrift" in properties_content
+    assert "cta=Weiter mit {0}" in properties_content
+    assert json_payload == {
+        "nested": {"title": "JSON-Titel {0}"},
+        "metadata": {"version": 1},
     }

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -226,6 +226,22 @@ class TestLoadAppConfig:
 
         assert config.localization_format == JAVA_PROPERTIES_FORMAT
 
+    def test_load_config_with_invalid_multi_profile_raises(self):
+        mock_config = {
+            "dry_run": True,
+            "localization_formats": [
+                {"id": "unknown_format", "layout": "suffix"},
+            ],
+        }
+
+        with patch("src.app_config._load_yaml_config", return_value=mock_config):
+            with patch("os.path.exists", return_value=False):
+                with patch("src.logging_config.setup_logger") as mock_logger:
+                    mock_logger.return_value = MagicMock()
+                    with patch.dict(os.environ, {}, clear=True):
+                        with pytest.raises(ValueError, match="Unsupported localization_format"):
+                            load_app_config()
+
     def test_load_config_with_invalid_layout_preserves_source_locale(self):
         mock_config = {
             "dry_run": True,

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 
 from src.app_config import AppConfig, load_app_config, validate_config
-from src.localization_formats import JAVA_PROPERTIES_FORMAT
+from src.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
 from src.localization_layouts import SUFFIX_LAYOUT
 
 
@@ -51,6 +51,7 @@ class TestAppConfig:
         assert config.project_context == "A desktop trading app."
         assert config.localization_format == JAVA_PROPERTIES_FORMAT
         assert config.localization_layout == SUFFIX_LAYOUT
+        assert config.localization_profiles[0].localization_format == JAVA_PROPERTIES_FORMAT
 
 
 class TestLoadAppConfig:
@@ -182,6 +183,33 @@ class TestLoadAppConfig:
         assert config.localization_format.file_extension == ".json"
         assert config.localization_layout.id == "locale_directory"
         assert config.localization_layout.source_locale == "en"
+        assert config.localization_profiles[0].localization_format.id == "custom_json"
+
+    def test_load_config_reads_multiple_localization_profiles(self):
+        mock_config = {
+            "dry_run": True,
+            "localization_formats": [
+                {"id": "java_properties", "layout": "suffix"},
+                {
+                    "id": "json",
+                    "layout": {"id": "locale_directory", "source_locale": "en"},
+                },
+            ],
+        }
+
+        with patch("src.app_config._load_yaml_config", return_value=mock_config):
+            with patch("os.path.exists", return_value=False):
+                with patch("src.logging_config.setup_logger") as mock_logger:
+                    mock_logger.return_value = MagicMock()
+                    with patch.dict(os.environ, {}, clear=True):
+                        config = load_app_config()
+
+        assert [profile.localization_format for profile in config.localization_profiles] == [
+            JAVA_PROPERTIES_FORMAT,
+            JSON_FORMAT,
+        ]
+        assert config.localization_format == JAVA_PROPERTIES_FORMAT
+        assert config.localization_profiles[1].localization_layout.id == "locale_directory"
 
     def test_load_config_with_invalid_format_falls_back_to_java_properties(self):
         mock_config = {

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -45,6 +45,32 @@ def test_cli_validate_reports_valid_config(tmp_path, capsys):
     assert "Configuration OK" in captured.out
 
 
+def test_cli_validate_accepts_mixed_format_profiles(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    i18n = repo / "i18n"
+    i18n.mkdir(parents=True)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({
+            "target_project_root": str(repo),
+            "input_folder": str(i18n),
+            "localization_formats": [
+                {"id": "java_properties", "layout": "suffix"},
+                {"id": "json", "layout": {"id": "locale_directory", "source_locale": "en"}},
+            ],
+            "dry_run": True,
+            "supported_locales": [{"code": "de", "name": "German"}],
+        }),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["validate", "--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Configuration OK" in captured.out
+
+
 def test_cli_validate_returns_nonzero_for_config_errors(tmp_path, capsys):
     config_path = tmp_path / "config.yaml"
     config_path.write_text("target_project_root: /missing\ninput_folder: /missing/i18n\n", encoding="utf-8")

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -987,6 +987,33 @@ class TestFileDetectionLogic(unittest.TestCase):
             "messages_de.properties",
         ])
 
+    def test_explicit_profiles_take_precedence_over_implicit_default(self):
+        """Compatibility default must not shadow explicitly configured profiles."""
+        from src.localization_formats import JSON_FORMAT
+        from src.localization_layouts import LocalizationLayout
+        from src.localization_profiles import LocalizationProfile
+        from src.translate_localization_files import get_source_filename
+
+        explicit_profiles = (
+            LocalizationProfile(
+                JSON_FORMAT,
+                LocalizationLayout(id="locale_directory", source_locale="en"),
+            ),
+        )
+        with patch(
+                "src.translate_localization_files.LOCALIZATION_PROFILES",
+                explicit_profiles,
+        ), patch(
+                "src.translate_localization_files.LOCALIZATION_FORMAT",
+                JSON_FORMAT,
+        ), patch(
+                "src.translate_localization_files.LOCALIZATION_LAYOUT",
+                LocalizationLayout(id="suffix", source_locale="en"),
+        ):
+            source_path = get_source_filename("locales/de/messages_fr.json", ["de", "fr"])
+
+        self.assertEqual(source_path, "locales/en/messages_fr.json")
+
 
 class TestFilterGitChangedKeys(unittest.TestCase):
     """Tests for filter_git_changed_keys_by_source, which prevents the

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -898,6 +898,95 @@ class TestFileDetectionLogic(unittest.TestCase):
 
         self.assertEqual(files, ["de/common.json", "fr/common.json"])
 
+    @patch('subprocess.run')
+    def test_get_changed_files_supports_mixed_format_profiles(self, mock_subprocess_run):
+        """Projects can discover changed locale files across configured format profiles."""
+        from src.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
+        from src.localization_layouts import LocalizationLayout
+        from src.localization_profiles import LocalizationProfile
+        from src.translate_localization_files import get_changed_translation_files
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = temp_dir
+            input_folder = os.path.join(temp_dir, "i18n")
+            for rel_path in [
+                "messages.properties",
+                "messages_de.properties",
+                "locales/en/common.json",
+                "locales/de/common.json",
+                "notes.txt",
+            ]:
+                path = os.path.join(input_folder, rel_path)
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "w", encoding="utf-8") as temp_file:
+                    temp_file.write("k=v\n")
+
+            git_output = (
+                " M i18n/messages_de.properties\n"
+                " M i18n/locales/de/common.json\n"
+                " M i18n/notes.txt\n"
+            )
+            mock_subprocess_run.return_value = MagicMock(stdout=git_output, stderr="", check_returncode=MagicMock())
+
+            profiles = (
+                LocalizationProfile(
+                    JAVA_PROPERTIES_FORMAT,
+                    LocalizationLayout(id="suffix", source_locale="en"),
+                ),
+                LocalizationProfile(
+                    JSON_FORMAT,
+                    LocalizationLayout(id="locale_directory", source_locale="en"),
+                ),
+            )
+            with patch("src.translate_localization_files.LOCALIZATION_PROFILES", profiles):
+                files = get_changed_translation_files(input_folder, repo_root)
+
+        self.assertEqual(files, ["locales/de/common.json", "messages_de.properties"])
+
+    @patch('subprocess.run')
+    def test_process_all_files_supports_mixed_format_profiles(self, mock_subprocess_run):
+        """Full scans should include target files from every configured format profile."""
+        from src.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
+        from src.localization_layouts import LocalizationLayout
+        from src.localization_profiles import LocalizationProfile
+        from src.translate_localization_files import get_changed_translation_files
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = temp_dir
+            input_folder = os.path.join(temp_dir, "i18n")
+            for rel_path in [
+                "messages.properties",
+                "messages_de.properties",
+                "locales/en/common.json",
+                "locales/de/common.json",
+                "locales/fr/common.json",
+                "archive/messages_es.properties",
+            ]:
+                path = os.path.join(input_folder, rel_path)
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "w", encoding="utf-8") as temp_file:
+                    temp_file.write("k=v\n")
+
+            profiles = (
+                LocalizationProfile(
+                    JAVA_PROPERTIES_FORMAT,
+                    LocalizationLayout(id="suffix", source_locale="en"),
+                ),
+                LocalizationProfile(
+                    JSON_FORMAT,
+                    LocalizationLayout(id="locale_directory", source_locale="en"),
+                ),
+            )
+            with patch("src.translate_localization_files.LOCALIZATION_PROFILES", profiles):
+                files = get_changed_translation_files(input_folder, repo_root, process_all_files=True)
+
+        mock_subprocess_run.assert_not_called()
+        self.assertEqual(files, [
+            "locales/de/common.json",
+            "locales/fr/common.json",
+            "messages_de.properties",
+        ])
+
 
 class TestFilterGitChangedKeys(unittest.TestCase):
     """Tests for filter_git_changed_keys_by_source, which prevents the

--- a/tests/unit/test_json_localization_adapter.py
+++ b/tests/unit/test_json_localization_adapter.py
@@ -196,6 +196,75 @@ def test_json_adapter_synchronizes_target_to_source_key_order(tmp_path):
     ]
 
 
+def test_json_adapter_synchronizes_non_string_metadata_without_string_key_changes(tmp_path):
+    source_path = tmp_path / "messages.json"
+    target_path = tmp_path / "messages_de.json"
+    write_json(
+        source_path,
+        {
+            "hello": "Hello",
+            "metadata": {
+                "version": 2,
+                "flags": [2, True],
+            },
+        },
+    )
+    write_json(
+        target_path,
+        {
+            "hello": "Hallo",
+            "metadata": {
+                "version": 1,
+                "flags": [1, False],
+            },
+        },
+    )
+
+    adapter = get_localization_adapter(JSON_FORMAT)
+    missing_keys, extra_keys = adapter.synchronize_keys(str(target_path), str(source_path))
+
+    assert missing_keys == set()
+    assert extra_keys == set()
+    assert json.loads(target_path.read_text(encoding="utf-8")) == {
+        "hello": "Hallo",
+        "metadata": {
+            "version": 2,
+            "flags": [2, True],
+        },
+    }
+
+
+def test_json_adapter_synchronizes_order_without_string_key_changes(tmp_path):
+    source_path = tmp_path / "messages.json"
+    target_path = tmp_path / "messages_de.json"
+    write_json(
+        source_path,
+        {
+            "alpha": "Alpha",
+            "bravo": "Bravo",
+        },
+    )
+    write_json(
+        target_path,
+        {
+            "bravo": "Bravo DE",
+            "alpha": "Alpha DE",
+        },
+    )
+
+    adapter = get_localization_adapter(JSON_FORMAT)
+    missing_keys, extra_keys = adapter.synchronize_keys(str(target_path), str(source_path))
+
+    assert missing_keys == set()
+    assert extra_keys == set()
+    assert target_path.read_text(encoding="utf-8").splitlines() == [
+        "{",
+        '  "alpha": "Alpha DE",',
+        '  "bravo": "Bravo DE"',
+        "}",
+    ]
+
+
 def test_json_adapter_synchronizes_array_string_keys(tmp_path):
     source_path = tmp_path / "messages.json"
     target_path = tmp_path / "messages_de.json"

--- a/tests/unit/test_json_localization_adapter.py
+++ b/tests/unit/test_json_localization_adapter.py
@@ -153,8 +153,47 @@ def test_json_adapter_synchronizes_source_and_target_string_keys(tmp_path):
         "hello": "Hallo",
         "nested": {
             "title": "Title",
+            "non_string": 1,
         },
     }
+
+
+def test_json_adapter_synchronizes_target_to_source_key_order(tmp_path):
+    source_path = tmp_path / "messages.json"
+    target_path = tmp_path / "messages_de.json"
+    write_json(
+        source_path,
+        {
+            "alpha": "Alpha",
+            "bravo": "Bravo",
+            "nested": {
+                "title": "Title",
+            },
+        },
+    )
+    write_json(
+        target_path,
+        {
+            "bravo": "Bravo DE",
+            "legacy": "Remove me",
+            "alpha": "Alpha DE",
+        },
+    )
+
+    adapter = get_localization_adapter(JSON_FORMAT)
+    missing_keys, extra_keys = adapter.synchronize_keys(str(target_path), str(source_path))
+
+    assert missing_keys == {"/nested/title"}
+    assert extra_keys == {"/legacy"}
+    assert target_path.read_text(encoding="utf-8").splitlines() == [
+        "{",
+        '  "alpha": "Alpha DE",',
+        '  "bravo": "Bravo DE",',
+        '  "nested": {',
+        '    "title": "Title"',
+        "  }",
+        "}",
+    ]
 
 
 def test_json_adapter_synchronizes_array_string_keys(tmp_path):

--- a/tests/unit/test_localization_profiles.py
+++ b/tests/unit/test_localization_profiles.py
@@ -1,0 +1,71 @@
+"""Tests for configured localization format/layout profiles."""
+
+import pytest
+
+from src.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
+from src.localization_layouts import LocalizationLayout, SUFFIX_LAYOUT
+from src.localization_profiles import LocalizationProfile, load_localization_profiles
+
+
+def test_load_localization_profiles_defaults_to_legacy_single_format():
+    profiles = load_localization_profiles({})
+
+    assert profiles == (
+        LocalizationProfile(
+            localization_format=JAVA_PROPERTIES_FORMAT,
+            localization_layout=SUFFIX_LAYOUT,
+        ),
+    )
+
+
+def test_load_localization_profiles_preserves_singular_config_shape():
+    profiles = load_localization_profiles({
+        "localization_format": "json",
+        "localization_layout": {"id": "locale_directory", "source_locale": "en"},
+    })
+
+    assert profiles == (
+        LocalizationProfile(
+            localization_format=JSON_FORMAT,
+            localization_layout=LocalizationLayout(id="locale_directory", source_locale="en"),
+        ),
+    )
+
+
+def test_load_localization_profiles_preserves_custom_format_mapping():
+    profiles = load_localization_profiles({
+        "localization_format": {
+            "id": "custom_json",
+            "display_name": "Custom JSON",
+            "file_extension": ".json",
+            "code_fence": "json",
+            "locale_suffix_regex": r"_([a-z]{2})\.json$",
+        },
+        "localization_layout": {"id": "suffix", "source_locale": "en"},
+    })
+
+    assert profiles[0].localization_format.id == "custom_json"
+    assert profiles[0].localization_format.file_extension == ".json"
+    assert profiles[0].localization_layout.id == "suffix"
+
+
+def test_load_localization_profiles_accepts_multiple_format_profiles():
+    profiles = load_localization_profiles({
+        "localization_formats": [
+            {"id": "java_properties", "layout": "suffix"},
+            {
+                "id": "json",
+                "layout": {"id": "locale_directory", "source_locale": "en"},
+            },
+        ],
+    })
+
+    assert profiles == (
+        LocalizationProfile(JAVA_PROPERTIES_FORMAT, LocalizationLayout(id="suffix", source_locale="en")),
+        LocalizationProfile(JSON_FORMAT, LocalizationLayout(id="locale_directory", source_locale="en")),
+    )
+
+
+def test_load_localization_profiles_rejects_empty_multi_format_config():
+    with pytest.raises(ValueError, match="localization_formats must contain at least one profile"):
+        load_localization_profiles({"localization_formats": []})

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -42,9 +42,11 @@ def test_format_public_api_exports_localization_format_metadata():
         SUFFIX_LAYOUT,
         LocalizationFormat,
         LocalizationLayout,
+        LocalizationProfile,
         get_localization_adapter,
         load_localization_format,
         load_localization_layout,
+        load_localization_profiles,
     )
 
     assert JAVA_PROPERTIES_FORMAT.id == "java_properties"
@@ -53,6 +55,8 @@ def test_format_public_api_exports_localization_format_metadata():
     assert LOCALE_DIRECTORY_LAYOUT.id == "locale_directory"
     assert LocalizationFormat.__name__ == "LocalizationFormat"
     assert LocalizationLayout.__name__ == "LocalizationLayout"
+    assert LocalizationProfile.__name__ == "LocalizationProfile"
     assert load_localization_format("java_properties") == JAVA_PROPERTIES_FORMAT
     assert load_localization_layout("suffix") == SUFFIX_LAYOUT
+    assert load_localization_profiles({"localization_format": "json"})[0].localization_format == JSON_FORMAT
     assert get_localization_adapter(JSON_FORMAT).localization_format == JSON_FORMAT


### PR DESCRIPTION
## Summary
- add configured localization format/layout profiles so mixed projects can route Java properties and JSON files through one pipeline run
- route discovery, source lookup, parsing, linting, review prompts, validation, serialization, and summaries through each file's resolved profile
- harden JSON synchronization for source ordering, arrays, nested JSON Pointer keys, missing/extra keys, and non-string metadata preservation
- document single JSON and mixed-format usage for CLI, GitHub Action, examples, and setup docs

## Validation
- OPENAI_API_KEY=sk-test-key venv/bin/ruff check .
- OPENAI_API_KEY=sk-test-key venv/bin/pytest -q
- git diff --check
- OPENAI_API_KEY=sk-test-key venv/bin/python -m src.cli validate --config examples/generic-json/config.yaml
- OPENAI_API_KEY=sk-test-key venv/bin/python -m src.cli formats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple localization format profiles in a single project.
  * Expanded configuration examples and docs for mixed JSON and properties locale setups.

* **Bug Fixes**
  * Improved JSON locale synchronization to better preserve existing translations while matching source structure.
  * Updated file detection and processing so locale changes map to the correct format profile.

* **Documentation**
  * Clarified configuration, CLI, GitHub Action, and repository structure guidance for mixed-format localization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->