### PR TITLE
Fix Bisq production profile input folder

### DIFF
--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -1,6 +1,6 @@
 target_project_root: '/target_repo'
 # Mounted Git repository root
-input_folder: '/target_repo/i18n/localize/main/resources' # Path relative to target_project_root
+input_folder: '/target_repo/i18n/src/main/resources' # Path relative to target_project_root
 glossary_file_path: 'glossary.json' # Mounted directly to /app/glossary.json
 localization_format: "java_properties"
 project_context: >

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -96,6 +96,7 @@ def test_bisq_profile_packages_config_and_glossary_assets():
     glossary = yaml.safe_load(BISQ_PROFILE_GLOSSARY.read_text(encoding="utf-8"))
 
     assert config["localization_format"] == "java_properties"
+    assert config["input_folder"] == "/target_repo/i18n/src/main/resources"
     assert "Bisq" in config["project_context"]
     assert "semantic_quality_rules" in config
     assert config["glossary_file_path"] == "glossary.json"


### PR DESCRIPTION
## Summary
- restore the Bisq profile input folder to the target repo's real i18n/src/main/resources path
- add a config-quality regression assertion for the production profile path

## Why
The production smoke run after PR #88 failed before translation because the package namespace rename accidentally changed the Bisq target-project path from src to localize.

## Tests
- OPENAI_API_KEY=sk-test-key venv/bin/ruff check .
- OPENAI_API_KEY=sk-test-key venv/bin/pytest tests/unit/test_config_quality.py -q
- OPENAI_API_KEY=sk-test-key venv/bin/pytest -q
- git diff --check