### PR TITLE
Add self-service platform foundations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to Localize Pipeline are documented here.
+
+This project follows semantic versioning once tagged releases begin. Until a
+stable `1.0.0`, minor releases may still refine public APIs with migration notes.
+
+## [0.1.0] - 2026-06-28
+
+### Added
+
+- `localize` CLI with `init`, `check`, `validate`, `run`, `formats`, and
+  `bootstrap-pr` commands.
+- Self-service onboarding branch generation for downstream repositories.
+- Built-in Java `.properties` and JSON localization adapters.
+- Mixed-format profile support through `localization_formats`.
+- AISuite-backed model-provider abstraction with OpenAI-compatible fallback.
+- Exact-match translation memory with conflict-safe reuse.
+- GitHub Action and Docker Compose cron deployment paths.
+- Public `localize.core`, `localize.formats`, and `localize.providers` packages.

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ localize init --input-folder path/to/i18n
 For JSON:
 
 ```bash
-./init.sh --input-folder path/to/i18n --localization-format json
+localize init --input-folder path/to/i18n --localization-format json
 ```
 
 For JSON stored as `locales/en/messages.json` and
 `locales/de/messages.json`:
 
 ```bash
-./init.sh \
+localize init \
   --input-folder locales \
   --localization-format json \
   --localization-layout locale_directory
@@ -63,7 +63,7 @@ For JSON stored as `locales/en/messages.json` and
 For a mixed project:
 
 ```bash
-./init.sh \
+localize init \
   --input-folder path/to/i18n \
   --localization-profile java_properties:suffix \
   --localization-profile json:locale_directory
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/translate-java-property-files@main
+      - uses: bisq-network/translate-java-property-files@v0.1.0
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -177,6 +177,7 @@ localize check --config config.yaml
 localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
 ```
 
 Custom adapter modules can be loaded before any command:
@@ -189,6 +190,23 @@ Installed packages can also expose the `localize.format_adapters` entry point
 group, or users can set `LOCALIZE_PLUGIN_MODULES=module_a,module_b`.
 
 Full guide: [docs/localization-cli.md](docs/localization-cli.md).
+
+## Bootstrap A Project PR
+
+To onboard another repository without hand-copying files, run:
+
+```bash
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
+```
+
+The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
+commits:
+
+- `config.yaml` generated from detected localization files
+- `glossary.json` copied from the generic example
+- `.github/workflows/translate.yml` in safe `dry-run: true` mode
+
+Add `--push --open-pr` when the target repo has `origin` and `gh` configured.
 
 ## Public Python API
 
@@ -203,6 +221,35 @@ Use these packages for reusable code:
 
 Avoid importing implementation modules directly unless you are contributing to
 this repository.
+
+## Translation Memory
+
+The runtime maintains an exact-match translation memory at
+`logs/translation_memory.json` by default. Successful, validation-safe
+translations are recorded by normalized source text, target locale, and format.
+Future runs reuse matching entries before calling the model. If the same source
+segment later receives competing approved targets for the same locale and
+format, the entry is marked as a conflict and no longer reused.
+
+Config knobs:
+
+```yaml
+translation_memory_enabled: true
+translation_memory_file_path: "logs/translation_memory.json"
+```
+
+Use a shared path if several projects should reuse one approved memory store.
+
+## Releases
+
+Pin a tagged release for production workflows once tags are available:
+
+```yaml
+- uses: bisq-network/translate-java-property-files@v0.1.0
+```
+
+Use `@main` only when you intentionally want the latest unreleased changes.
+Release notes live in [CHANGELOG.md](CHANGELOG.md).
 
 ## Docker Server Deployment
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ branding:
 
 inputs:
   config-file:
-    description: "Path to the translation config in your repo (see config.example.yaml or run ./init.sh)."
+    description: "Path to the translation config in your repo (see config.example.yaml or run localize init)."
     required: false
     default: "config.yaml"
   openai-api-key:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,7 +4,7 @@
 # per-locale style rules, learned semantic quality rules, and a large glossary,
 # see profiles/bisq/config.yaml (the Bisq production profile).
 #
-# Tip: run `./init.sh --input-folder path/to/i18n` to scaffold this automatically
+# Tip: run `localize init --input-folder path/to/i18n` to scaffold this automatically
 # by detecting the locales from your existing localization files.
 
 # --- Paths (required) ---
@@ -84,6 +84,10 @@ brand_technical_glossary:
 
 # If true, the script logs actions without calling the API or writing files.
 dry_run: false
+
+# Reuse exact approved translations across runs before calling the model.
+translation_memory_enabled: true
+translation_memory_file_path: "logs/translation_memory.json"
 
 # --- Target locales ---
 # One entry per language you translate into (the source language is excluded).

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -155,8 +155,9 @@ The PR step commits only when localization files changed. User-provided action
 inputs are passed through environment variables, not interpolated directly into
 shell scripts.
 
-Pin a tagged release for production workflows. Use `@main` only when you
-intentionally want unreleased changes.
+Pin a tagged release for production workflows. A workflow reference such as
+`bisq-network/translate-java-property-files@main` follows unreleased changes;
+use it only when that is intentional.
 
 ## Custom Formats
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/translate-java-property-files@main
+      - uses: bisq-network/translate-java-property-files@v0.1.0
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -88,7 +88,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/translate-java-property-files@main
+      - uses: bisq-network/translate-java-property-files@v0.1.0
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/translate-java-property-files@main
+      - uses: bisq-network/translate-java-property-files@v0.1.0
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}
@@ -154,6 +154,9 @@ python -m localize.cli run --config "$TRANSLATOR_CONFIG_FILE"
 The PR step commits only when localization files changed. User-provided action
 inputs are passed through environment variables, not interpolated directly into
 shell scripts.
+
+Pin a tagged release for production workflows. Use `@main` only when you
+intentionally want unreleased changes.
 
 ## Custom Formats
 

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -28,7 +28,7 @@ localize check --config config.yaml
 localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
-localize bootstrap-pr --target-project-root path/to/repo
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
 ```
 
 | Command | What it does |

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -28,6 +28,7 @@ localize check --config config.yaml
 localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
+localize bootstrap-pr --target-project-root path/to/repo
 ```
 
 | Command | What it does |
@@ -37,6 +38,7 @@ localize run --config config.yaml
 | `check` | Runs self-service preflight checks for config, paths, formats, endpoint, and required credentials. |
 | `validate` | Checks config shape, paths, locales, formats, layouts, and endpoint settings. |
 | `run` | Executes the translation pipeline. Use `--dry-run` to force a preview without editing config. |
+| `bootstrap-pr` | Creates an onboarding branch with generated config, glossary, and GitHub workflow files. |
 
 The module form is equivalent:
 
@@ -89,6 +91,27 @@ localize init \
 Generated configs default to `dry_run: true` so first runs can validate
 discovery, queueing, and reports without model calls. Set `dry_run: false` when
 you are ready to let the pipeline write translations.
+
+## Bootstrap Pull Requests
+
+Use `bootstrap-pr` when onboarding another repository:
+
+```bash
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
+```
+
+The command refuses dirty worktrees, creates `localize/onboarding`, writes
+`config.yaml`, `glossary.json`, and `.github/workflows/translate.yml`, then
+commits them locally. The generated workflow starts with `dry-run: true`.
+
+Add network actions explicitly:
+
+```bash
+localize bootstrap-pr --target-project-root path/to/repo --push --open-pr
+```
+
+`--open-pr` uses the GitHub CLI and expects `gh` plus an `origin` remote to be
+configured in the target repository.
 
 ## Mixed-Format Config
 

--- a/docs/new-project-deployment.md
+++ b/docs/new-project-deployment.md
@@ -87,6 +87,11 @@ localization_formats:
 The included `profiles/bisq/` directory is a full production example with style
 rules, semantic QA rules, and a project glossary.
 
+Translation memory is enabled by default and stored under
+`logs/translation_memory.json`. Keep that default for isolated deployments, or
+set `translation_memory_file_path` to a shared persistent path when multiple
+profiles should reuse approved translations.
+
 ## 3. Configure Secrets
 
 Create `docker/.env` from the example:

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -11,6 +11,7 @@ This project has three supported surfaces:
 | Path | Purpose |
 | --- | --- |
 | `README.md` | Product overview and quickstart. |
+| `CHANGELOG.md` | Release notes and version history. |
 | `pyproject.toml` | Python package metadata for `localize-pipeline` and the `localize` console script. |
 | `config.example.yaml` | Minimal generic config starter. |
 | `glossary.example.json` | Minimal glossary example. |
@@ -25,7 +26,8 @@ This project has three supported surfaces:
 
 | Path | Purpose |
 | --- | --- |
-| `localize/cli.py` | `localize formats/init/validate/run`. |
+| `localize/cli.py` | `localize formats/init/check/validate/run/bootstrap-pr`. |
+| `localize/bootstrap_pr.py` | Self-service onboarding branch and PR generation. |
 | `localize/init_config.py` | Config scaffolding and locale detection. |
 | `localize/pipeline_core.py` | Format-agnostic orchestration with injected steps. |
 | `localize/connectors.py` | Public source/processor/reporter/publisher protocols plus reusable filesystem/reporter/processor connectors. |
@@ -37,6 +39,7 @@ This project has three supported surfaces:
 | `localize/plugins.py` | Plugin loading through entry points, env modules, and `--plugin`. |
 | `localize/providers/` | Public provider API. |
 | `localize/model_provider.py` | AISuite and direct OpenAI-compatible provider implementations. |
+| `localize/translation_memory.py` | Exact-match translation memory store and conflict handling. |
 | `localize/translate_localization_files.py` | Runtime translation pipeline. |
 | `localize/translation_quality_gate.py` | Deterministic PR quality gate. |
 | `localize/translation_semantic_reviewer.py` | AI semantic review sidecar. |

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Compatibility wrapper: prefer `localize init` for new docs and automation.
 # Docker-free quickstart: scaffold a minimal config.yaml by auto-detecting
 # target locales from your localization files.
 #

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,1 +1,3 @@
-# Public package for the reusable localization pipeline.
+"""Public package for the reusable localization pipeline."""
+
+__version__ = "0.1.0"

--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -77,6 +77,8 @@ class AppConfig:
     translation_queue_folder: str
     translated_queue_folder: str
     translation_key_ledger_file_path: str
+    translation_memory_file_path: str
+    translation_memory_enabled: bool
     preserve_queues_for_debug: bool
 
     # Model provider
@@ -562,6 +564,13 @@ def load_app_config() -> AppConfig:
     )
     if not os.path.isabs(translation_key_ledger_file_path):
         translation_key_ledger_file_path = os.path.join(project_root, translation_key_ledger_file_path)
+    translation_memory_file_path = config.get(
+        'translation_memory_file_path',
+        os.path.join(project_root, 'logs', 'translation_memory.json')
+    )
+    if not os.path.isabs(translation_memory_file_path):
+        translation_memory_file_path = os.path.join(project_root, translation_memory_file_path)
+    translation_memory_enabled = _as_bool(config.get('translation_memory_enabled', True), default=True)
 
     project_context = str(config.get('project_context') or '').strip()
     try:
@@ -619,6 +628,8 @@ def load_app_config() -> AppConfig:
         translation_queue_folder=translation_queue_folder,
         translated_queue_folder=translated_queue_folder,
         translation_key_ledger_file_path=translation_key_ledger_file_path,
+        translation_memory_file_path=translation_memory_file_path,
+        translation_memory_enabled=translation_memory_enabled,
         preserve_queues_for_debug=config.get('preserve_queues_for_debug', False),
         model_provider=model_provider,
         openai_client=openai_client,

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -34,6 +34,7 @@ class BootstrapPrOptions:
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False
+    reset_branch: bool = False
     push: bool = False
     open_pr: bool = False
 
@@ -84,6 +85,45 @@ def _assert_clean_worktree(repo: Path) -> None:
         raise RuntimeError("target repository working tree is not clean.")
 
 
+def _repo_relative_path(repo: Path, raw_path: str, label: str) -> str:
+    """Return a normalized repo-relative path, rejecting escapes."""
+    path = Path(raw_path)
+    if path.is_absolute():
+        raise ValueError(f"{label} must be inside the target repository.")
+    repo_root = repo.resolve()
+    resolved = (repo_root / path).resolve()
+    try:
+        relative_path = resolved.relative_to(repo_root)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be inside the target repository.") from exc
+    return relative_path.as_posix()
+
+
+def _branch_exists(repo: Path, branch_name: str) -> bool:
+    result = _git(
+        repo,
+        "show-ref",
+        "--verify",
+        "--quiet",
+        f"refs/heads/{branch_name}",
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _checkout_onboarding_branch(repo: Path, options: BootstrapPrOptions, base_branch: str) -> None:
+    _git(repo, "checkout", base_branch)
+    if _branch_exists(repo, options.branch_name):
+        if not options.reset_branch:
+            raise RuntimeError(
+                f"Branch '{options.branch_name}' already exists. "
+                "Re-run with --reset-branch to replace it."
+            )
+        _git(repo, "checkout", "-B", options.branch_name)
+        return
+    _git(repo, "checkout", "-b", options.branch_name)
+
+
 def _assert_can_write(repo: Path, relative_paths: Iterable[str], *, overwrite: bool) -> None:
     for relative_path in relative_paths:
         path = repo / relative_path
@@ -97,11 +137,11 @@ def _copy_example_glossary(target: Path) -> None:
     shutil.copyfile(source, target)
 
 
-def _render_workflow(*, action_ref: str, config_path: str) -> str:
+def _render_workflow(*, action_ref: str, config_path: str, base_branch: str) -> str:
     return f"""name: Translate
 on:
   push:
-    branches: [main]
+    branches: [{base_branch}]
   workflow_dispatch: {{}}
 
 permissions:
@@ -123,10 +163,9 @@ jobs:
 """
 
 
-def _build_onboarding_config(options: BootstrapPrOptions, repo: Path) -> str:
-    if options.input_folder:
-        input_folder = options.input_folder
-        input_folder_abs = repo / input_folder if not Path(input_folder).is_absolute() else Path(input_folder)
+def _build_onboarding_config(options: BootstrapPrOptions, repo: Path, input_folder: str | None) -> str:
+    if input_folder:
+        input_folder_abs = repo / input_folder
         locales = detect_locales(
             str(input_folder_abs),
             source_locale=options.source_locale,
@@ -181,20 +220,31 @@ def create_bootstrap_pr(options: BootstrapPrOptions) -> BootstrapPrResult:
     repo = Path(options.target_project_root).expanduser().resolve()
     _assert_git_repo(repo)
     _assert_clean_worktree(repo)
-    created_files = (options.config_path, options.glossary_path, options.workflow_path)
+    config_path = _repo_relative_path(repo, options.config_path, "config-file")
+    glossary_path = _repo_relative_path(repo, options.glossary_path, "glossary-file")
+    workflow_path = _repo_relative_path(repo, options.workflow_path, "workflow-file")
+    input_folder = (
+        _repo_relative_path(repo, options.input_folder, "input-folder")
+        if options.input_folder
+        else None
+    )
+    created_files = (config_path, glossary_path, workflow_path)
     _assert_can_write(repo, created_files, overwrite=options.overwrite)
+    base_branch = options.base_branch or "main"
 
-    if options.base_branch:
-        _git(repo, "checkout", options.base_branch)
-    _git(repo, "checkout", "-B", options.branch_name)
+    _checkout_onboarding_branch(repo, options, base_branch)
 
-    (repo / options.config_path).parent.mkdir(parents=True, exist_ok=True)
-    (repo / options.config_path).write_text(_build_onboarding_config(options, repo), encoding="utf-8")
-    _copy_example_glossary(repo / options.glossary_path)
-    workflow_file = repo / options.workflow_path
+    (repo / config_path).parent.mkdir(parents=True, exist_ok=True)
+    (repo / config_path).write_text(_build_onboarding_config(options, repo, input_folder), encoding="utf-8")
+    _copy_example_glossary(repo / glossary_path)
+    workflow_file = repo / workflow_path
     workflow_file.parent.mkdir(parents=True, exist_ok=True)
     workflow_file.write_text(
-        _render_workflow(action_ref=options.action_ref, config_path=options.config_path),
+        _render_workflow(
+            action_ref=options.action_ref,
+            config_path=config_path,
+            base_branch=base_branch,
+        ),
         encoding="utf-8",
     )
 
@@ -215,6 +265,8 @@ def create_bootstrap_pr(options: BootstrapPrOptions) -> BootstrapPrResult:
                 "create",
                 "--title",
                 options.pr_title,
+                "--base",
+                base_branch,
                 "--body",
                 "Adds Localize Pipeline config, glossary, and workflow in dry-run mode.",
             ),

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -1,0 +1,231 @@
+"""Create a self-service onboarding branch for a target repository."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+from localize.init_config import (
+    build_config,
+    detect_locales,
+    detect_project_layout,
+    render_config,
+)
+
+
+@dataclass(frozen=True)
+class BootstrapPrOptions:
+    """Options for generating a Localize Pipeline onboarding branch."""
+
+    target_project_root: Path | str = Path(".")
+    input_folder: Optional[str] = None
+    localization_format: str = "java_properties"
+    localization_layout: str = "suffix"
+    source_locale: str = "en"
+    config_path: str = "config.yaml"
+    glossary_path: str = "glossary.json"
+    workflow_path: str = ".github/workflows/translate.yml"
+    branch_name: str = "localize/onboarding"
+    base_branch: Optional[str] = None
+    action_ref: str = "v0.1.0"
+    commit_message: str = "Add Localize Pipeline onboarding"
+    pr_title: str = "Add Localize Pipeline onboarding"
+    overwrite: bool = False
+    push: bool = False
+    open_pr: bool = False
+
+
+@dataclass(frozen=True)
+class BootstrapPrResult:
+    """Summary of generated onboarding work."""
+
+    branch_name: str
+    created_files: tuple[str, ...]
+    commit_sha: str
+    pushed: bool = False
+    opened_pr: bool = False
+
+
+def _run(
+    args: Sequence[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=str(cwd),
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return _run(("git", *args), cwd=repo, check=check)
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _assert_git_repo(repo: Path) -> None:
+    result = _git(repo, "rev-parse", "--show-toplevel")
+    if Path(result.stdout.strip()).resolve() != repo.resolve():
+        raise RuntimeError(f"target_project_root must be the git repository root: {repo}")
+
+
+def _assert_clean_worktree(repo: Path) -> None:
+    status = _git(repo, "status", "--porcelain").stdout.strip()
+    if status:
+        raise RuntimeError("target repository working tree is not clean.")
+
+
+def _assert_can_write(repo: Path, relative_paths: Iterable[str], *, overwrite: bool) -> None:
+    for relative_path in relative_paths:
+        path = repo / relative_path
+        if path.exists() and not overwrite:
+            raise FileExistsError(f"{relative_path} already exists. Re-run with --overwrite to replace it.")
+
+
+def _copy_example_glossary(target: Path) -> None:
+    source = _project_root() / "glossary.example.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, target)
+
+
+def _render_workflow(*, action_ref: str, config_path: str) -> str:
+    return f"""name: Translate
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {{}}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: bisq-network/translate-java-property-files@{action_ref}
+        with:
+          config-file: {config_path}
+          openai-api-key: ${{{{ secrets.OPENAI_API_KEY }}}}
+          dry-run: true
+"""
+
+
+def _build_onboarding_config(options: BootstrapPrOptions, repo: Path) -> str:
+    if options.input_folder:
+        input_folder = options.input_folder
+        input_folder_abs = repo / input_folder if not Path(input_folder).is_absolute() else Path(input_folder)
+        locales = detect_locales(
+            str(input_folder_abs),
+            source_locale=options.source_locale,
+            localization_format=options.localization_format,
+            localization_layout=options.localization_layout,
+        )
+        config = build_config(
+            target_project_root=".",
+            input_folder=input_folder,
+            locales=locales,
+            localization_format=options.localization_format,
+            localization_layout=options.localization_layout,
+            source_locale=options.source_locale,
+            dry_run=True,
+        )
+        return render_config(config)
+
+    detected = detect_project_layout(str(repo), source_locale=options.source_locale)
+    if detected is None:
+        raise RuntimeError(
+            "Could not detect localization files. Pass --input-folder and, if needed, "
+            "--localization-format/--localization-layout."
+        )
+
+    config = build_config(
+        target_project_root=".",
+        input_folder=detected.input_folder,
+        locales=detected.locales,
+        localization_profiles=[
+            (profile_format, profile_layout)
+            for profile_format, profile_layout in detected.localization_profiles
+        ],
+        source_locale=options.source_locale,
+        dry_run=True,
+    )
+    if len(detected.localization_profiles) == 1:
+        profile_format, profile_layout = detected.localization_profiles[0]
+        config = build_config(
+            target_project_root=".",
+            input_folder=detected.input_folder,
+            locales=detected.locales,
+            localization_format=profile_format,
+            localization_layout=profile_layout,
+            source_locale=options.source_locale,
+            dry_run=True,
+        )
+    return render_config(config)
+
+
+def create_bootstrap_pr(options: BootstrapPrOptions) -> BootstrapPrResult:
+    """Create a local onboarding branch and optionally push/open a PR."""
+    repo = Path(options.target_project_root).expanduser().resolve()
+    _assert_git_repo(repo)
+    _assert_clean_worktree(repo)
+    created_files = (options.config_path, options.glossary_path, options.workflow_path)
+    _assert_can_write(repo, created_files, overwrite=options.overwrite)
+
+    if options.base_branch:
+        _git(repo, "checkout", options.base_branch)
+    _git(repo, "checkout", "-B", options.branch_name)
+
+    (repo / options.config_path).parent.mkdir(parents=True, exist_ok=True)
+    (repo / options.config_path).write_text(_build_onboarding_config(options, repo), encoding="utf-8")
+    _copy_example_glossary(repo / options.glossary_path)
+    workflow_file = repo / options.workflow_path
+    workflow_file.parent.mkdir(parents=True, exist_ok=True)
+    workflow_file.write_text(
+        _render_workflow(action_ref=options.action_ref, config_path=options.config_path),
+        encoding="utf-8",
+    )
+
+    _git(repo, "add", *created_files)
+    _git(repo, "commit", "-m", options.commit_message)
+    commit_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    pushed = False
+    opened_pr = False
+    if options.push or options.open_pr:
+        _git(repo, "push", "-u", "origin", options.branch_name)
+        pushed = True
+    if options.open_pr:
+        _run(
+            (
+                "gh",
+                "pr",
+                "create",
+                "--title",
+                options.pr_title,
+                "--body",
+                "Adds Localize Pipeline config, glossary, and workflow in dry-run mode.",
+            ),
+            cwd=repo,
+        )
+        opened_pr = True
+
+    return BootstrapPrResult(
+        branch_name=options.branch_name,
+        created_files=created_files,
+        commit_sha=commit_sha,
+        pushed=pushed,
+        opened_pr=opened_pr,
+    )

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -131,6 +131,7 @@ def _cmd_bootstrap_pr(args: argparse.Namespace) -> int:
                 base_branch=args.base_branch,
                 action_ref=args.action_ref,
                 overwrite=args.overwrite,
+                reset_branch=args.reset_branch,
                 push=args.push,
                 open_pr=args.open_pr,
             )
@@ -256,6 +257,11 @@ def _build_parser() -> argparse.ArgumentParser:
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
     bootstrap_parser.add_argument("--action-ref", default="v0.1.0", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument("--overwrite", action="store_true", help="Replace existing onboarding files.")
+    bootstrap_parser.add_argument(
+        "--reset-branch",
+        action="store_true",
+        help="Reset an existing onboarding branch instead of refusing to overwrite it.",
+    )
     bootstrap_parser.add_argument("--push", action="store_true", help="Push the onboarding branch to origin.")
     bootstrap_parser.add_argument("--open-pr", action="store_true", help="Push and open the onboarding PR with gh.")
     bootstrap_parser.set_defaults(func=_cmd_bootstrap_pr)

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import importlib
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Sequence
@@ -13,6 +14,7 @@ from typing import Any, Sequence
 import yaml
 
 from localize.app_config import ConfigIssue, validate_config
+from localize.bootstrap_pr import BootstrapPrOptions, create_bootstrap_pr
 from localize.formats import list_localization_adapters, list_localization_formats
 from localize.init_config import main as init_config_main
 from localize.plugins import load_plugins
@@ -113,6 +115,39 @@ def _cmd_init(args: argparse.Namespace) -> int:
     return init_config_main(list(args.init_args))
 
 
+def _cmd_bootstrap_pr(args: argparse.Namespace) -> int:
+    try:
+        result = create_bootstrap_pr(
+            BootstrapPrOptions(
+                target_project_root=args.target_project_root,
+                input_folder=args.input_folder,
+                localization_format=args.localization_format,
+                localization_layout=args.localization_layout,
+                source_locale=args.source_locale,
+                config_path=args.config_file,
+                glossary_path=args.glossary_file,
+                workflow_path=args.workflow_file,
+                branch_name=args.branch,
+                base_branch=args.base_branch,
+                action_ref=args.action_ref,
+                overwrite=args.overwrite,
+                push=args.push,
+                open_pr=args.open_pr,
+            )
+        )
+    except (FileExistsError, OSError, RuntimeError, subprocess.CalledProcessError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Created onboarding commit {result.commit_sha} on branch {result.branch_name}")
+    if result.opened_pr:
+        print("Opened onboarding pull request")
+    elif result.pushed:
+        print("Pushed onboarding branch")
+    else:
+        print("Review the branch, then push/open a pull request when ready")
+    return 0
+
+
 def _extract_plugin_args(raw_argv: Sequence[str]) -> tuple[list[str], list[str]]:
     """Return plugin modules and argv with all --plugin flags removed."""
     plugins: list[str] = []
@@ -192,6 +227,38 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Scaffold a minimal config by detecting locales in an input folder.",
     )
     init_parser.set_defaults(func=_cmd_init, init_args=())
+
+    bootstrap_parser = subparsers.add_parser(
+        "bootstrap-pr",
+        help="Create an onboarding branch with config, glossary, and GitHub workflow.",
+    )
+    bootstrap_parser.add_argument("--target-project-root", default=".", help="Target git repository root.")
+    bootstrap_parser.add_argument("--input-folder", default=None, help="Localization folder in the target repo.")
+    bootstrap_parser.add_argument(
+        "--localization-format",
+        default="java_properties",
+        help="Localization format for explicit --input-folder mode.",
+    )
+    bootstrap_parser.add_argument(
+        "--localization-layout",
+        default="suffix",
+        help="Localization layout for explicit --input-folder mode.",
+    )
+    bootstrap_parser.add_argument("--source-locale", default="en", help="Source locale code.")
+    bootstrap_parser.add_argument("--config-file", default="config.yaml", help="Config file to create.")
+    bootstrap_parser.add_argument("--glossary-file", default="glossary.json", help="Glossary file to create.")
+    bootstrap_parser.add_argument(
+        "--workflow-file",
+        default=".github/workflows/translate.yml",
+        help="GitHub Actions workflow file to create.",
+    )
+    bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
+    bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.0", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--overwrite", action="store_true", help="Replace existing onboarding files.")
+    bootstrap_parser.add_argument("--push", action="store_true", help="Push the onboarding branch to origin.")
+    bootstrap_parser.add_argument("--open-pr", action="store_true", help="Push and open the onboarding PR with gh.")
+    bootstrap_parser.set_defaults(func=_cmd_bootstrap_pr)
 
     return parser
 

--- a/localize/init_config.py
+++ b/localize/init_config.py
@@ -402,6 +402,8 @@ def build_config(
         "model_name": model_name,
         "review_model_name": review_model_name,
         "dry_run": dry_run,
+        "translation_memory_enabled": True,
+        "translation_memory_file_path": "logs/translation_memory.json",
         "supported_locales": locales,
     }
     if localization_profiles:

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -1968,17 +1968,6 @@ async def process_translation_queue(
             # Refresh ledger baseline even when no translation was required.
             key_ledger[translation_file] = build_file_key_ledger(source_translations, target_translations)
             save_translation_key_ledger(TRANSLATION_KEY_LEDGER_FILE_PATH, key_ledger)
-            if translation_memory is not None and not DRY_RUN:
-                update_translation_memory(
-                    translation_memory,
-                    source_translations,
-                    target_translations,
-                    list(target_translations.keys()),
-                    locale=language_code,
-                    format_id=localization_format.id,
-                    failed_keys=set(),
-                )
-                save_translation_memory(TRANSLATION_MEMORY_FILE_PATH, translation_memory)
             logger.info(f"No texts to translate in file '{translation_file}'.")
             continue
 

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from email.utils import parsedate_to_datetime
 from typing import Dict, List, Tuple, Optional, Set
 
@@ -51,6 +52,11 @@ from localize.pipeline_core import (
     run_translation_pipeline,
 )
 from localize.translation_prompts import build_translation_system_prompt
+from localize.translation_memory import (
+    TranslationMemory,
+    load_translation_memory,
+    save_translation_memory,
+)
 from localize.translation_validator import (
     check_placeholder_parity,
     check_encoding_and_mojibake,
@@ -99,6 +105,8 @@ LOCALIZATION_PROFILES = config.localization_profiles
 TRANSLATION_QUEUE_FOLDER = config.translation_queue_folder
 TRANSLATED_QUEUE_FOLDER = config.translated_queue_folder
 TRANSLATION_KEY_LEDGER_FILE_PATH = config.translation_key_ledger_file_path
+TRANSLATION_MEMORY_FILE_PATH = config.translation_memory_file_path
+TRANSLATION_MEMORY_ENABLED = config.translation_memory_enabled
 PRESERVE_QUEUES_FOR_DEBUG = config.preserve_queues_for_debug
 MODEL_PROVIDER = config.model_provider
 client = config.openai_client
@@ -249,6 +257,82 @@ def build_file_key_ledger(
             entry["status"] = "failed"
         file_ledger[key] = entry
     return file_ledger
+
+
+@dataclass(frozen=True)
+class TranslationMemoryPlan:
+    """Split of cached translation-memory results and pending model work."""
+
+    cached_results: List[Tuple[int, str]]
+    pending_texts: List[str]
+    pending_line_indices: List[int]
+    pending_keys: List[str]
+    pending_positions: List[int]
+
+
+def apply_translation_memory(
+        *,
+        texts_to_translate: List[str],
+        indices: List[int],
+        keys_to_translate: List[str],
+        memory: Optional[TranslationMemory],
+        locale: str,
+        format_id: str,
+) -> TranslationMemoryPlan:
+    """Reuse exact approved translations and keep unresolved keys for the model."""
+    if memory is None:
+        return TranslationMemoryPlan(
+            cached_results=[],
+            pending_texts=list(texts_to_translate),
+            pending_line_indices=list(indices),
+            pending_keys=list(keys_to_translate),
+            pending_positions=list(range(len(texts_to_translate))),
+        )
+
+    cached_results: List[Tuple[int, str]] = []
+    pending_texts: List[str] = []
+    pending_line_indices: List[int] = []
+    pending_keys: List[str] = []
+    pending_positions: List[int] = []
+    for position, (text, line_index, key) in enumerate(zip(texts_to_translate, indices, keys_to_translate)):
+        cached = memory.lookup(text, locale=locale, format_id=format_id)
+        if cached is not None:
+            cached_results.append((position, cached))
+            logger.info("Reused translation memory for key '%s'.", key)
+            continue
+        pending_texts.append(text)
+        pending_line_indices.append(line_index)
+        pending_keys.append(key)
+        pending_positions.append(position)
+    return TranslationMemoryPlan(
+        cached_results=cached_results,
+        pending_texts=pending_texts,
+        pending_line_indices=pending_line_indices,
+        pending_keys=pending_keys,
+        pending_positions=pending_positions,
+    )
+
+
+def update_translation_memory(
+        memory: TranslationMemory,
+        source_translations: Dict[str, str],
+        final_translations: Dict[str, str],
+        keys: List[str],
+        *,
+        locale: str,
+        format_id: str,
+        failed_keys: Set[str],
+) -> None:
+    """Record successful translations for future exact-match reuse."""
+    for key in keys:
+        if key in failed_keys:
+            continue
+        source_value = source_translations.get(key)
+        target_value = final_translations.get(key)
+        if source_value is None or target_value is None:
+            continue
+        memory.record(source_value, target_value, locale=locale, format_id=format_id)
+
 
 def extract_texts_to_translate(
         parsed_lines: List[Dict],
@@ -1765,6 +1849,11 @@ async def process_translation_queue(
     # Load the glossary from the JSON file
     glossary = load_glossary(glossary_file_path)
     key_ledger = load_translation_key_ledger(TRANSLATION_KEY_LEDGER_FILE_PATH)
+    translation_memory = (
+        load_translation_memory(TRANSLATION_MEMORY_FILE_PATH)
+        if TRANSLATION_MEMORY_ENABLED
+        else None
+    )
 
     # Set up a single semaphore for all API calls to control concurrency globally.
     # A value of 1 ensures that only one API request is active at any time.
@@ -1879,13 +1968,33 @@ async def process_translation_queue(
             # Refresh ledger baseline even when no translation was required.
             key_ledger[translation_file] = build_file_key_ledger(source_translations, target_translations)
             save_translation_key_ledger(TRANSLATION_KEY_LEDGER_FILE_PATH, key_ledger)
+            if translation_memory is not None and not DRY_RUN:
+                update_translation_memory(
+                    translation_memory,
+                    source_translations,
+                    target_translations,
+                    list(target_translations.keys()),
+                    locale=language_code,
+                    format_id=localization_format.id,
+                    failed_keys=set(),
+                )
+                save_translation_memory(TRANSLATION_MEMORY_FILE_PATH, translation_memory)
             logger.info(f"No texts to translate in file '{translation_file}'.")
             continue
+
+        memory_plan = apply_translation_memory(
+            texts_to_translate=texts_to_translate,
+            indices=indices,
+            keys_to_translate=keys_to_translate,
+            memory=translation_memory,
+            locale=language_code,
+            format_id=localization_format.id,
+        )
 
         # Pre-run scope/cost preview for this file (ballpark — actuals logged at the end).
         provider = MODEL_PROVIDER or _FALLBACK_PROVIDER
         file_estimate = provider.estimate_run_cost(
-            num_keys=len(keys_to_translate),
+            num_keys=len(memory_plan.pending_keys),
             locale_codes=[language_code],
             translate_model=MODEL_NAME,
             review_model=REVIEW_MODEL_NAME,
@@ -1905,24 +2014,29 @@ async def process_translation_queue(
                 glossary,
                 semaphore,
                 rate_limiter,  # Pass the rate limiter
-                idx,
+                position,
                 localization_format,
             )
-            for idx, (text, key) in enumerate(zip(texts_to_translate, keys_to_translate))
+            for text, key, position in zip(
+                memory_plan.pending_texts,
+                memory_plan.pending_keys,
+                memory_plan.pending_positions,
+            )
         ]
 
         # Run tasks concurrently with progress indication
-        results = []
+        results = list(memory_plan.cached_results)
         # The tqdm output is directed to stderr by default, which is ideal.
         # It prevents progress bars from being broken by stdout prints.
-        for coro in tqdm(
-                asyncio.as_completed(tasks),
-                desc=f"Translating {translation_file}",
-                unit="translation",
-                total=len(tasks)  # Provide the total number of tasks
-        ):
-            index, result = await coro
-            results.append((index, result))
+        if tasks:
+            for coro in tqdm(
+                    asyncio.as_completed(tasks),
+                    desc=f"Translating {translation_file}",
+                    unit="translation",
+                    total=len(tasks)  # Provide the total number of tasks
+            ):
+                index, result = await coro
+                results.append((index, result))
 
         # Sort results by index to ensure correct order
         results.sort(key=lambda x: x[0])
@@ -1939,16 +2053,6 @@ async def process_translation_queue(
         )
         draft_content = adapter.reassemble_file(draft_lines)
 
-        # --- Holistic Review Step ---
-        # Instead of one large review, we chunk the keys to avoid token limits.
-        logger.info(f"Performing holistic review for {len(keys_to_translate)} keys in '{translation_file}'...")
-
-        # Create chunks of keys
-        key_chunks = [
-            keys_to_translate[i:i + HOLISTIC_REVIEW_CHUNK_SIZE]
-            for i in range(0, len(keys_to_translate), HOLISTIC_REVIEW_CHUNK_SIZE)
-        ]
-
         # We need a dictionary of the draft translations to build targeted context for each chunk.
         # This is easier than parsing the string repeatedly.
         with tempfile.NamedTemporaryFile(
@@ -1963,36 +2067,55 @@ async def process_translation_queue(
         os.remove(temp_draft_path)
 
         final_corrected_translations = {}
-        style_rules_text_for_review = PRECOMPUTED_STYLE_RULES_TEXT.get(language_code, "")
+        if not memory_plan.pending_keys:
+            logger.info(
+                "Skipping holistic review for '%s' because all %d keys came from translation memory.",
+                translation_file,
+                len(keys_to_translate),
+            )
+            for key in keys_to_translate:
+                final_corrected_translations[key] = draft_translations.get(key, "")
+        else:
+            # --- Holistic Review Step ---
+            # Instead of one large review, we chunk the keys to avoid token limits.
+            logger.info(f"Performing holistic review for {len(keys_to_translate)} keys in '{translation_file}'...")
 
-        review_results = await asyncio.gather(
-            *[holistic_review_async(
-                source_content=adapter.build_review_content(source_translations, key_chunk),
-                translated_content=adapter.build_review_content(draft_translations, key_chunk),
-                target_language=target_language,
-                keys_to_review=key_chunk,
-                semaphore=semaphore,
-                rate_limiter=rate_limiter,
-                style_rules_text=style_rules_text_for_review,
-                localization_format=localization_format,
-            ) for key_chunk in key_chunks]
-        )
+            # Create chunks of keys
+            key_chunks = [
+                keys_to_translate[i:i + HOLISTIC_REVIEW_CHUNK_SIZE]
+                for i in range(0, len(keys_to_translate), HOLISTIC_REVIEW_CHUNK_SIZE)
+            ]
 
-        try:
-            for i, (corrected_chunk, key_chunk) in enumerate(zip(review_results, key_chunks)):
-                if corrected_chunk is not None:
-                    if corrected_chunk:
-                        final_corrected_translations.update(corrected_chunk)
+            style_rules_text_for_review = PRECOMPUTED_STYLE_RULES_TEXT.get(language_code, "")
+
+            review_results = await asyncio.gather(
+                *[holistic_review_async(
+                    source_content=adapter.build_review_content(source_translations, key_chunk),
+                    translated_content=adapter.build_review_content(draft_translations, key_chunk),
+                    target_language=target_language,
+                    keys_to_review=key_chunk,
+                    semaphore=semaphore,
+                    rate_limiter=rate_limiter,
+                    style_rules_text=style_rules_text_for_review,
+                    localization_format=localization_format,
+                ) for key_chunk in key_chunks]
+            )
+
+            try:
+                for i, (corrected_chunk, key_chunk) in enumerate(zip(review_results, key_chunks)):
+                    if corrected_chunk is not None:
+                        if corrected_chunk:
+                            final_corrected_translations.update(corrected_chunk)
+                        else:
+                            logger.info("Holistic review returned no corrections for this chunk; keeping draft values.")
+                            for key in key_chunk:
+                                final_corrected_translations[key] = draft_translations.get(key, "")
                     else:
-                        logger.info("Holistic review returned no corrections for this chunk; keeping draft values.")
+                        logger.warning(f"Holistic review for chunk {i + 1} failed; keeping draft values for this chunk.")
                         for key in key_chunk:
                             final_corrected_translations[key] = draft_translations.get(key, "")
-                else:
-                    logger.warning(f"Holistic review for chunk {i + 1} failed; keeping draft values for this chunk.")
-                    for key in key_chunk:
-                        final_corrected_translations[key] = draft_translations.get(key, "")
-        except Exception:
-            logger.exception("An error occurred during asyncio.gather for holistic review of %s", translation_file)
+            except Exception:
+                logger.exception("An error occurred during asyncio.gather for holistic review of %s", translation_file)
 
         # Always apply the results from the review stage, which includes fallbacks to draft for failed chunks.
         logger.info("Applying corrected translations (including any draft fallbacks).")
@@ -2090,6 +2213,17 @@ async def process_translation_queue(
             failed_keys=set(failed_keys)
         )
         save_translation_key_ledger(TRANSLATION_KEY_LEDGER_FILE_PATH, key_ledger)
+        if translation_memory is not None and not DRY_RUN:
+            update_translation_memory(
+                translation_memory,
+                source_translations,
+                valid_translations,
+                keys_to_translate,
+                locale=language_code,
+                format_id=localization_format.id,
+                failed_keys=set(failed_keys),
+            )
+            save_translation_memory(TRANSLATION_MEMORY_FILE_PATH, translation_memory)
 
         processed_files_count += 1
         processed_filenames.append(translation_file)

--- a/localize/translation_memory.py
+++ b/localize/translation_memory.py
@@ -5,18 +5,20 @@ from __future__ import annotations
 import datetime as _dt
 import hashlib
 import json
-import re
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Mapping
+
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_memory_source(value: str | None) -> str:
     """Normalize source text before hashing for stable exact-match reuse."""
     if value is None:
         return ""
-    value = value.replace("\\n", "<newline>").replace("\n", "<newline>")
-    return re.sub(r"\s+", " ", value.strip())
+    return value.replace("\\n", "<newline>").replace("\n", "<newline>")
 
 
 def memory_source_hash(value: str | None) -> str:
@@ -106,12 +108,19 @@ def load_translation_memory(path: str | Path) -> TranslationMemory:
 def save_translation_memory(path: str | Path, memory: TranslationMemory) -> None:
     """Persist translation memory atomically."""
     memory_path = Path(path)
-    memory_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = memory.to_payload()
-    payload["updated_at"] = _dt.datetime.now(_dt.UTC).isoformat().replace("+00:00", "Z")
     temp_path = memory_path.with_suffix(f"{memory_path.suffix}.tmp")
-    temp_path.write_text(
-        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    temp_path.replace(memory_path)
+    try:
+        memory_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = memory.to_payload()
+        payload["updated_at"] = _dt.datetime.now(_dt.UTC).isoformat().replace("+00:00", "Z")
+        temp_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temp_path.replace(memory_path)
+    except OSError as exc:
+        logger.warning("Could not save translation memory to '%s': %s", memory_path, exc)
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/localize/translation_memory.py
+++ b/localize/translation_memory.py
@@ -1,0 +1,117 @@
+"""Exact-match translation memory with conflict-safe reuse."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+
+def normalize_memory_source(value: str | None) -> str:
+    """Normalize source text before hashing for stable exact-match reuse."""
+    if value is None:
+        return ""
+    value = value.replace("\\n", "<newline>").replace("\n", "<newline>")
+    return re.sub(r"\s+", " ", value.strip())
+
+
+def memory_source_hash(value: str | None) -> str:
+    """Return the stable translation-memory hash for a source string."""
+    return hashlib.sha256(normalize_memory_source(value).encode("utf-8")).hexdigest()
+
+
+def _entry_key(source_text: str, locale: str, format_id: str) -> str:
+    return f"{format_id}:{locale}:{memory_source_hash(source_text)}"
+
+
+@dataclass
+class TranslationMemory:
+    """In-memory representation of reusable approved translations."""
+
+    entries: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    def lookup(self, source_text: str, *, locale: str, format_id: str) -> str | None:
+        """Return a reusable translation, or None when absent/ambiguous."""
+        entry = self.entries.get(_entry_key(source_text, locale, format_id))
+        if not entry or entry.get("status") == "conflict":
+            return None
+        target = entry.get("target")
+        return str(target) if target is not None else None
+
+    def record(self, source_text: str, target_text: str, *, locale: str, format_id: str) -> None:
+        """Record one approved translation, marking conflicting targets unsafe."""
+        key = _entry_key(source_text, locale, format_id)
+        source_hash = memory_source_hash(source_text)
+        existing = self.entries.get(key)
+        if not existing:
+            self.entries[key] = {
+                "source_hash": source_hash,
+                "locale": locale,
+                "format_id": format_id,
+                "target": target_text,
+                "status": "active",
+            }
+            return
+
+        if existing.get("status") == "conflict":
+            targets = set(str(target) for target in existing.get("targets", []))
+            targets.add(target_text)
+            existing["targets"] = sorted(targets)
+            return
+
+        if existing.get("target") == target_text:
+            return
+
+        previous_target = str(existing.pop("target", ""))
+        existing["status"] = "conflict"
+        existing["targets"] = sorted({previous_target, target_text} - {""})
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "version": 1,
+            "entries": self.entries,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "TranslationMemory":
+        entries = payload.get("entries", {})
+        if not isinstance(entries, Mapping):
+            return cls()
+        valid_entries = {
+            str(key): dict(value)
+            for key, value in entries.items()
+            if isinstance(value, Mapping)
+        }
+        return cls(entries=valid_entries)
+
+
+def load_translation_memory(path: str | Path) -> TranslationMemory:
+    """Load translation memory from disk, returning empty memory on absence/error."""
+    memory_path = Path(path)
+    if not memory_path.exists():
+        return TranslationMemory()
+    try:
+        payload = json.loads(memory_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return TranslationMemory()
+    if not isinstance(payload, Mapping):
+        return TranslationMemory()
+    return TranslationMemory.from_payload(payload)
+
+
+def save_translation_memory(path: str | Path, memory: TranslationMemory) -> None:
+    """Persist translation memory atomically."""
+    memory_path = Path(path)
+    memory_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = memory.to_payload()
+    payload["updated_at"] = _dt.datetime.now(_dt.UTC).isoformat().replace("+00:00", "Z")
+    temp_path = memory_path.with_suffix(f"{memory_path.suffix}.tmp")
+    temp_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temp_path.replace(memory_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,15 @@ description = "Reusable AI localization translation pipeline"
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "MIT"}
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.11",
+  "Topic :: Software Development :: Internationalization",
+]
 dependencies = [
   "aiolimiter",
   "aisuite==0.1.14",
@@ -26,6 +35,11 @@ dependencies = [
 
 [project.scripts]
 localize = "localize.cli:main"
+
+[project.urls]
+Repository = "https://github.com/bisq-network/translate-java-property-files"
+Changelog = "https://github.com/bisq-network/translate-java-property-files/blob/main/CHANGELOG.md"
+Issues = "https://github.com/bisq-network/translate-java-property-files/issues"
 
 [tool.setuptools.packages.find]
 include = ["localize*"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,12 +17,14 @@ def integration_test_paths():
     translation_queue_dir = os.path.join(tests_root, 'temp_integration_translation_queue')
     translated_queue_dir = os.path.join(tests_root, 'temp_integration_translated_queue')
     mock_glossary_path = os.path.join(tests_root, 'temp_mock_glossary.json')
+    translation_memory_path = os.path.join(tests_root, 'temp_translation_memory.json')
 
     return {
         "input_folder": input_dir,
         "translation_queue_folder": translation_queue_dir,
         "translated_queue_folder": translated_queue_dir,
         "mock_glossary_path": mock_glossary_path,
+        "translation_memory_path": translation_memory_path,
         "project_root": project_root
     }
 
@@ -53,7 +55,8 @@ def setup_global_test_environment(integration_test_paths):
         patch('localize.translate_localization_files.DRY_RUN', False),
         patch('localize.translate_localization_files.REPO_ROOT', paths['project_root']),
         patch('localize.translate_localization_files.LANGUAGE_CODES', mock_language_codes),
-        patch('localize.translate_localization_files.NAME_TO_CODE', mock_name_to_code)
+        patch('localize.translate_localization_files.NAME_TO_CODE', mock_name_to_code),
+        patch('localize.translate_localization_files.TRANSLATION_MEMORY_FILE_PATH', paths['translation_memory_path'])
     ]
     started_patches = []
     try:
@@ -85,6 +88,8 @@ def setup_global_test_environment(integration_test_paths):
                 shutil.rmtree(folder)
             except Exception as e:
                 logging.error(f"Failed to delete directory {folder}. Reason: {e}")
+    if os.path.exists(paths['translation_memory_path']):
+        os.remove(paths['translation_memory_path'])
 
 
 @pytest.fixture
@@ -105,6 +110,8 @@ def integration_test_environment(integration_test_paths):
                     shutil.rmtree(file_path)
             except Exception as e:
                 logging.error(f"Failed to delete {file_path}. Reason: {e}")
+    if os.path.exists(paths['translation_memory_path']):
+        os.remove(paths['translation_memory_path'])
 
     # Create mock glossary for each test
     glossary_content = {"de": {"Hello": "Hallo"}}

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -170,6 +170,40 @@ async def test_process_translation_queue_reuses_translation_memory_without_model
 
 
 @pytest.mark.asyncio
+async def test_process_translation_queue_does_not_seed_memory_for_noop_file(integration_test_environment):
+    env = integration_test_environment
+    source_file_path = os.path.join(env['input_folder'], 'app.properties')
+    target_file_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
+    memory_path = os.path.join(env['input_folder'], 'translation_memory.json')
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.one=value one\n")
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.one=Wert eins\n")
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock()
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
+
+    with patch('localize.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('localize.translate_localization_files.TRANSLATION_MEMORY_ENABLED', True), \
+         patch('localize.translate_localization_files.TRANSLATION_MEMORY_FILE_PATH', memory_path), \
+         patch('localize.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH',
+               os.path.join(env['input_folder'], 'ledger.json')), \
+         patch('localize.translate_localization_files.get_working_tree_changed_keys', return_value=set()):
+        await localize.translate_localization_files.process_translation_queue(
+            translation_queue_folder=env['translation_queue_folder'],
+            translated_queue_folder=env['translated_queue_folder'],
+            glossary_file_path=env['mock_glossary_path_resolved']
+        )
+
+    assert not os.path.exists(memory_path)
+    provider.create_chat_completion.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_handles_already_escaped_quotes_correctly(integration_test_environment):
     env = integration_test_environment
     source_content = "key.name=URL is ''{0}''"

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -14,6 +14,7 @@ import localize.translate_localization_files
 from localize.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
 from localize.localization_layouts import LocalizationLayout
 from localize.localization_profiles import LocalizationProfile
+from localize.translation_memory import TranslationMemory, save_translation_memory
 
 # All fixtures are now defined in conftest.py and are auto-discovered by pytest.
 
@@ -120,6 +121,53 @@ async def test_process_translation_queue_end_to_end(integration_test_environment
         assert "key.two=Wert zwei" in final_content
         assert "key.one=Wert eins" in final_content
         assert len(final_content.strip().split('\n')) == 2
+
+
+@pytest.mark.asyncio
+async def test_process_translation_queue_reuses_translation_memory_without_model_calls(integration_test_environment):
+    env = integration_test_environment
+    source_file_path = os.path.join(env['input_folder'], 'app.properties')
+    target_file_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
+    memory_path = os.path.join(env['input_folder'], 'translation_memory.json')
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.one=value one\nkey.two=value two\n")
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.one=Wert eins\n")
+
+    memory = TranslationMemory()
+    memory.record("value two", "Wert zwei", locale="de", format_id="java_properties")
+    save_translation_memory(memory_path, memory)
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock()
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
+
+    with patch('localize.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('localize.translate_localization_files.TRANSLATION_MEMORY_ENABLED', True), \
+         patch('localize.translate_localization_files.TRANSLATION_MEMORY_FILE_PATH', memory_path), \
+         patch('localize.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH',
+               os.path.join(env['input_folder'], 'ledger.json')), \
+         patch('localize.translate_localization_files.get_working_tree_changed_keys', return_value=set()), \
+         patch('localize.translate_localization_files.holistic_review_async', new_callable=AsyncMock) as review:
+        await localize.translate_localization_files.process_translation_queue(
+            translation_queue_folder=env['translation_queue_folder'],
+            translated_queue_folder=env['translated_queue_folder'],
+            glossary_file_path=env['mock_glossary_path_resolved']
+        )
+
+    output_file_path = os.path.join(env['translated_queue_folder'], 'app_de.properties')
+    assert os.path.exists(output_file_path)
+    with open(output_file_path, 'r', encoding='utf-8') as f:
+        final_content = f.read()
+
+    assert "key.one=Wert eins" in final_content
+    assert "key.two=Wert zwei" in final_content
+    provider.create_chat_completion.assert_not_called()
+    review.assert_not_awaited()
+
 
 @pytest.mark.asyncio
 async def test_handles_already_escaped_quotes_correctly(integration_test_environment):

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -39,6 +39,8 @@ class TestAppConfig:
             translation_queue_folder="/tmp/queue",
             translated_queue_folder="/tmp/translated",
             translation_key_ledger_file_path="/tmp/ledger.json",
+            translation_memory_file_path="/tmp/memory.json",
+            translation_memory_enabled=True,
             preserve_queues_for_debug=False,
             model_provider=None,
             openai_client=None
@@ -66,6 +68,8 @@ class TestLoadAppConfig:
             "dry_run": True,
             "retranslate_identical_source_strings": True,
             "translation_key_ledger_file_path": "/tmp/test-ledger.json",
+            "translation_memory_file_path": "/tmp/test-memory.json",
+            "translation_memory_enabled": False,
             "quality_gate": {
                 "source_identical_min_block_count": 6,
                 "source_identical_max_count": 25,
@@ -103,6 +107,8 @@ class TestLoadAppConfig:
         assert config.dry_run is True
         assert config.retranslate_identical_source_strings is True
         assert config.translation_key_ledger_file_path == "/tmp/test-ledger.json"
+        assert config.translation_memory_file_path == "/tmp/test-memory.json"
+        assert config.translation_memory_enabled is False
         assert config.quality_gate.source_identical_min_block_count == 6
         assert config.quality_gate.source_identical_max_count == 25
         assert config.quality_gate.source_identical_max_ratio == 0.4
@@ -151,6 +157,10 @@ class TestLoadAppConfig:
         assert config.translation_key_ledger_file_path == os.path.join(
             config.project_root, "logs", "translation_key_ledger.json"
         )
+        assert config.translation_memory_file_path == os.path.join(
+            config.project_root, "logs", "translation_memory.json"
+        )
+        assert config.translation_memory_enabled is True
 
     def test_load_config_reads_project_context_and_format(self):
         mock_config = {

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -89,6 +89,37 @@ def test_bootstrap_pr_refuses_to_overwrite_existing_files_without_flag(tmp_path)
         create_bootstrap_pr(BootstrapPrOptions(target_project_root=repo))
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("config_path", "../config.yaml"),
+        ("workflow_path", "/tmp/translate.yml"),
+        ("input_folder", "../i18n"),
+        ("input_folder", "/tmp/i18n"),
+    ],
+)
+def test_bootstrap_pr_rejects_paths_that_escape_repo(tmp_path, field, value):
+    repo = tmp_path / "target"
+    _init_repo(repo)
+    options = {"target_project_root": repo, field: value}
+
+    with pytest.raises(ValueError, match="inside the target repository"):
+        create_bootstrap_pr(BootstrapPrOptions(**options))
+
+
+def test_bootstrap_pr_refuses_to_reset_existing_branch_without_flag(tmp_path):
+    repo = tmp_path / "target"
+    _init_repo(repo)
+    _git(repo, "checkout", "-b", "localize/onboarding")
+    (repo / "branch-only.txt").write_text("keep me\n", encoding="utf-8")
+    _git(repo, "add", "branch-only.txt")
+    _git(repo, "commit", "-m", "Keep branch work")
+    _git(repo, "checkout", "main")
+
+    with pytest.raises(RuntimeError, match="already exists"):
+        create_bootstrap_pr(BootstrapPrOptions(target_project_root=repo))
+
+
 def test_bootstrap_pr_uses_custom_config_path_in_workflow(tmp_path):
     repo = tmp_path / "target"
     _init_repo(repo)
@@ -103,3 +134,21 @@ def test_bootstrap_pr_uses_custom_config_path_in_workflow(tmp_path):
 
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "config-file: .localize/config.yaml" in workflow
+
+
+def test_bootstrap_pr_threads_base_branch_into_workflow(tmp_path):
+    repo = tmp_path / "target"
+    _init_repo(repo)
+    _git(repo, "checkout", "-b", "release")
+    _git(repo, "checkout", "main")
+
+    create_bootstrap_pr(
+        BootstrapPrOptions(
+            target_project_root=repo,
+            branch_name="localize/release-onboarding",
+            base_branch="release",
+        )
+    )
+
+    workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
+    assert "branches: [release]" in workflow

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -1,0 +1,105 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from localize.bootstrap_pr import BootstrapPrOptions, create_bootstrap_pr
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return completed.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "commit.gpgsign", "false")
+    resources = repo / "i18n"
+    resources.mkdir()
+    (resources / "messages.properties").write_text("hello=Hello\n", encoding="utf-8")
+    (resources / "messages_de.properties").write_text("hello=Hallo\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Add localization files")
+
+
+def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
+    repo = tmp_path / "target"
+    _init_repo(repo)
+
+    result = create_bootstrap_pr(
+        BootstrapPrOptions(
+            target_project_root=repo,
+            branch_name="localize/onboarding",
+            action_ref="v0.1.0",
+            push=False,
+            open_pr=False,
+        )
+    )
+
+    assert result.branch_name == "localize/onboarding"
+    assert _git(repo, "branch", "--show-current") == "localize/onboarding"
+    assert _git(repo, "log", "-1", "--format=%s") == "Add Localize Pipeline onboarding"
+    assert result.created_files == (
+        "config.yaml",
+        "glossary.json",
+        ".github/workflows/translate.yml",
+    )
+
+    config = yaml.safe_load((repo / "config.yaml").read_text(encoding="utf-8"))
+    assert config["target_project_root"] == "."
+    assert config["input_folder"] == "i18n"
+    assert config["localization_format"] == "java_properties"
+    assert config["dry_run"] is True
+    assert config["supported_locales"] == [{"code": "de", "name": "German"}]
+
+    workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
+    assert "bisq-network/translate-java-property-files@v0.1.0" in workflow
+    assert "dry-run: true" in workflow
+
+    glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))
+    assert isinstance(glossary, dict)
+
+
+def test_bootstrap_pr_refuses_dirty_repo(tmp_path):
+    repo = tmp_path / "target"
+    _init_repo(repo)
+    (repo / "README.md").write_text("uncommitted\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="working tree is not clean"):
+        create_bootstrap_pr(BootstrapPrOptions(target_project_root=repo))
+
+
+def test_bootstrap_pr_refuses_to_overwrite_existing_files_without_flag(tmp_path):
+    repo = tmp_path / "target"
+    _init_repo(repo)
+    (repo / "config.yaml").write_text("dry_run: true\n", encoding="utf-8")
+    _git(repo, "add", "config.yaml")
+    _git(repo, "commit", "-m", "Add config")
+
+    with pytest.raises(FileExistsError, match="config.yaml"):
+        create_bootstrap_pr(BootstrapPrOptions(target_project_root=repo))
+
+
+def test_bootstrap_pr_uses_custom_config_path_in_workflow(tmp_path):
+    repo = tmp_path / "target"
+    _init_repo(repo)
+
+    create_bootstrap_pr(
+        BootstrapPrOptions(
+            target_project_root=repo,
+            config_path=".localize/config.yaml",
+            branch_name="localize/custom-config",
+        )
+    )
+
+    workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
+    assert "config-file: .localize/config.yaml" in workflow

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -253,32 +253,41 @@ def test_cli_validate_returns_nonzero_for_config_errors(tmp_path, capsys):
 
 
 def test_cli_run_sets_config_env_and_delegates_to_runtime(tmp_path, monkeypatch):
+    monkeypatch.delenv("TRANSLATOR_CONFIG_FILE", raising=False)
     config_path = tmp_path / "config.yaml"
     config_path.write_text("dry_run: true\n", encoding="utf-8")
     runtime = SimpleNamespace(main=AsyncMock())
 
-    with patch("localize.cli.importlib.import_module", return_value=runtime) as import_module:
-        exit_code = cli.main(["run", "--config", str(config_path)])
+    try:
+        with patch("localize.cli.importlib.import_module", return_value=runtime) as import_module:
+            exit_code = cli.main(["run", "--config", str(config_path)])
 
-    assert exit_code == 0
-    assert os.environ["TRANSLATOR_CONFIG_FILE"] == str(config_path)
-    import_module.assert_called_once_with("localize.translate_localization_files")
-    runtime.main.assert_awaited_once()
+        assert exit_code == 0
+        assert os.environ["TRANSLATOR_CONFIG_FILE"] == str(config_path)
+        import_module.assert_called_once_with("localize.translate_localization_files")
+        runtime.main.assert_awaited_once()
+    finally:
+        os.environ.pop("TRANSLATOR_CONFIG_FILE", None)
 
 
 def test_cli_run_dry_run_sets_runtime_override(tmp_path, monkeypatch):
+    monkeypatch.delenv("TRANSLATOR_CONFIG_FILE", raising=False)
     monkeypatch.delenv("LOCALIZE_DRY_RUN", raising=False)
     config_path = tmp_path / "config.yaml"
     config_path.write_text("dry_run: false\n", encoding="utf-8")
     runtime = SimpleNamespace(main=AsyncMock())
 
-    with patch("localize.cli.importlib.import_module", return_value=runtime):
-        exit_code = cli.main(["run", "--config", str(config_path), "--dry-run"])
+    try:
+        with patch("localize.cli.importlib.import_module", return_value=runtime):
+            exit_code = cli.main(["run", "--config", str(config_path), "--dry-run"])
 
-    assert exit_code == 0
-    assert os.environ["TRANSLATOR_CONFIG_FILE"] == str(config_path)
-    assert os.environ["LOCALIZE_DRY_RUN"] == "true"
-    runtime.main.assert_awaited_once()
+        assert exit_code == 0
+        assert os.environ["TRANSLATOR_CONFIG_FILE"] == str(config_path)
+        assert os.environ["LOCALIZE_DRY_RUN"] == "true"
+        runtime.main.assert_awaited_once()
+    finally:
+        os.environ.pop("TRANSLATOR_CONFIG_FILE", None)
+        os.environ.pop("LOCALIZE_DRY_RUN", None)
 
 
 def test_cli_init_delegates_to_existing_init_config():
@@ -289,10 +298,41 @@ def test_cli_init_delegates_to_existing_init_config():
     init_main.assert_called_once_with(["--input-folder", "i18n"])
 
 
+def test_cli_bootstrap_pr_delegates_to_onboarding_generator(capsys):
+    result = SimpleNamespace(
+        branch_name="localize/onboarding",
+        commit_sha="abc123",
+        pushed=False,
+        opened_pr=False,
+    )
+    with patch("localize.cli.create_bootstrap_pr", return_value=result) as create:
+        exit_code = cli.main([
+            "bootstrap-pr",
+            "--target-project-root",
+            "/repo",
+            "--input-folder",
+            "i18n",
+            "--action-ref",
+            "v0.1.0",
+        ])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    options = create.call_args.args[0]
+    assert options.target_project_root == "/repo"
+    assert options.input_folder == "i18n"
+    assert options.action_ref == "v0.1.0"
+    assert "Created onboarding commit abc123" in captured.out
+
+
 def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
+    assert pyproject["project"]["version"] == "0.1.0"
+    assert pyproject["project"]["urls"]["Repository"]
+    assert pyproject["project"]["urls"]["Changelog"]
+    assert "Programming Language :: Python :: 3 :: Only" in pyproject["project"]["classifiers"]
     assert pyproject["project"]["scripts"]["localize"] == "localize.cli:main"
     assert pyproject["tool"]["setuptools"]["packages"]["find"]["include"] == ["localize*"]
 
@@ -304,6 +344,15 @@ def test_readme_documents_cli_quickstart():
     assert "localize check" in readme
     assert "localize validate" in readme
     assert "localize run --dry-run" in readme
+    assert "./init.sh" not in readme
+
+
+def test_package_version_matches_pyproject():
+    import localize
+
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert localize.__version__ == pyproject["project"]["version"]
 
 
 def test_generic_examples_are_cli_validatable():

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -53,11 +53,13 @@ def test_public_docs_describe_aisuite_as_default_provider():
 
 
 def test_docs_use_localize_init_as_stable_onboarding_surface():
-    docs = "\n".join([
-        (PROJECT_ROOT / "README.md").read_text(encoding="utf-8"),
-        (PROJECT_ROOT / "config.example.yaml").read_text(encoding="utf-8"),
-        (PROJECT_ROOT / "action.yml").read_text(encoding="utf-8"),
-    ])
+    paths = [
+        PROJECT_ROOT / "README.md",
+        PROJECT_ROOT / "config.example.yaml",
+        PROJECT_ROOT / "action.yml",
+        *sorted((PROJECT_ROOT / "docs").rglob("*.md")),
+    ]
+    docs = "\n".join(path.read_text(encoding="utf-8") for path in paths)
 
     assert "localize init" in docs
     assert "./init.sh" not in docs

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -52,6 +52,26 @@ def test_public_docs_describe_aisuite_as_default_provider():
     assert "AISuite is optional" not in readme
 
 
+def test_docs_use_localize_init_as_stable_onboarding_surface():
+    docs = "\n".join([
+        (PROJECT_ROOT / "README.md").read_text(encoding="utf-8"),
+        (PROJECT_ROOT / "config.example.yaml").read_text(encoding="utf-8"),
+        (PROJECT_ROOT / "action.yml").read_text(encoding="utf-8"),
+    ])
+
+    assert "localize init" in docs
+    assert "./init.sh" not in docs
+
+
+def test_release_maturity_docs_are_packaged():
+    changelog = PROJECT_ROOT / "CHANGELOG.md"
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert changelog.exists()
+    assert "## [0.1.0]" in changelog.read_text(encoding="utf-8")
+    assert "Pin a tagged release" in readme
+
+
 def test_example_glossary_is_valid_and_small():
     glossary = yaml.safe_load((PROJECT_ROOT / "glossary.example.json").read_text(encoding="utf-8"))
     assert isinstance(glossary, dict) and glossary

--- a/tests/unit/test_translation_memory.py
+++ b/tests/unit/test_translation_memory.py
@@ -33,6 +33,14 @@ def test_translation_memory_marks_conflicts_and_stops_reusing_ambiguous_segments
     assert sorted(entry["targets"]) == ["Offen", "Öffnen"]
 
 
+def test_translation_memory_preserves_spacing_in_exact_match_keys():
+    memory = TranslationMemory()
+    memory.record("Open  trades", "Offene  Trades", locale="de", format_id="json")
+
+    assert memory.lookup("Open  trades", locale="de", format_id="json") == "Offene  Trades"
+    assert memory.lookup("Open trades", locale="de", format_id="json") is None
+
+
 def test_load_translation_memory_missing_or_invalid_file_is_empty(tmp_path):
     assert load_translation_memory(tmp_path / "missing.json").to_payload()["entries"] == {}
 
@@ -40,6 +48,18 @@ def test_load_translation_memory_missing_or_invalid_file_is_empty(tmp_path):
     invalid.write_text(json.dumps({"entries": []}), encoding="utf-8")
 
     assert load_translation_memory(invalid).to_payload()["entries"] == {}
+
+
+def test_save_translation_memory_is_best_effort(monkeypatch, tmp_path):
+    memory = TranslationMemory()
+    memory.record("Save", "Speichern", locale="de", format_id="json")
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("pathlib.Path.write_text", fail_write)
+
+    save_translation_memory(tmp_path / "translation_memory.json", memory)
 
 
 def test_apply_translation_memory_splits_hits_from_model_work():

--- a/tests/unit/test_translation_memory.py
+++ b/tests/unit/test_translation_memory.py
@@ -1,0 +1,62 @@
+import json
+
+from localize.translation_memory import TranslationMemory, load_translation_memory, save_translation_memory
+from localize.translate_localization_files import apply_translation_memory
+
+
+def test_translation_memory_roundtrip_and_lookup(tmp_path):
+    memory = TranslationMemory()
+    memory.record(
+        source_text="Save changes",
+        target_text="Änderungen speichern",
+        locale="de",
+        format_id="json",
+    )
+    path = tmp_path / "translation_memory.json"
+
+    save_translation_memory(path, memory)
+    loaded = load_translation_memory(path)
+
+    assert loaded.lookup("Save changes", locale="de", format_id="json") == "Änderungen speichern"
+    assert loaded.lookup("Save changes", locale="fr", format_id="json") is None
+
+
+def test_translation_memory_marks_conflicts_and_stops_reusing_ambiguous_segments():
+    memory = TranslationMemory()
+    memory.record("Open", "Öffnen", locale="de", format_id="java_properties")
+    memory.record("Open", "Offen", locale="de", format_id="java_properties")
+
+    assert memory.lookup("Open", locale="de", format_id="java_properties") is None
+    payload = memory.to_payload()
+    entry = next(iter(payload["entries"].values()))
+    assert entry["status"] == "conflict"
+    assert sorted(entry["targets"]) == ["Offen", "Öffnen"]
+
+
+def test_load_translation_memory_missing_or_invalid_file_is_empty(tmp_path):
+    assert load_translation_memory(tmp_path / "missing.json").to_payload()["entries"] == {}
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"entries": []}), encoding="utf-8")
+
+    assert load_translation_memory(invalid).to_payload()["entries"] == {}
+
+
+def test_apply_translation_memory_splits_hits_from_model_work():
+    memory = TranslationMemory()
+    memory.record("Save", "Speichern", locale="de", format_id="json")
+
+    plan = apply_translation_memory(
+        texts_to_translate=["Save", "Cancel"],
+        indices=[3, 4],
+        keys_to_translate=["button.save", "button.cancel"],
+        memory=memory,
+        locale="de",
+        format_id="json",
+    )
+
+    assert plan.cached_results == [(0, "Speichern")]
+    assert plan.pending_texts == ["Cancel"]
+    assert plan.pending_line_indices == [4]
+    assert plan.pending_keys == ["button.cancel"]
+    assert plan.pending_positions == [1]


### PR DESCRIPTION
## Summary

- Add `localize bootstrap-pr` for downstream repo onboarding branches.
- Add conflict-safe exact-match translation memory and runtime reuse before model calls.
- Clean up onboarding docs around `localize init` and add release metadata/changelog.

## Validation

- `OPENAI_API_KEY=sk-test-key venv/bin/ruff check .`
- `git diff --check`
- `OPENAI_API_KEY=sk-test-key venv/bin/pytest -q` (`457 passed`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `localize bootstrap-pr` to create onboarding branches and optionally push or open pull requests.
  * Introduced translation memory support to reuse approved translations across runs.
  * Added versioned release metadata, including a public package version and changelog.

* **Documentation**
  * Updated quickstart and workflow docs to use `localize init`.
  * Added guidance on translation memory, release pinning, and onboarding flow.

* **Bug Fixes**
  * Improved stability by handling translation-memory conflicts and preserving untranslated items correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->