### PR TITLE
Add plugin onboarding and memory tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 - `localize` CLI with `init`, `check`, `validate`, `run`, `formats`, and
   `bootstrap-pr` commands.
 - Self-service onboarding branch generation for downstream repositories.
+- Generated target-repository onboarding guide with rollout checklist.
+- First-class GitHub Action plugin install/module inputs for custom adapters.
 - Built-in Java `.properties` and JSON localization adapters.
 - Mixed-format profile support through `localization_formats`.
 - AISuite-backed model-provider abstraction with OpenAI-compatible fallback.
 - Exact-match translation memory with conflict-safe reuse.
+- Translation-memory import/export/stats/promote commands and fuzzy suggestions
+  for human review.
 - GitHub Action and Docker Compose cron deployment paths.
 - Public `localize.core`, `localize.formats`, and `localize.providers` packages.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
+localize memory stats --memory-file logs/translation_memory.json
 ```
 
 Custom adapter modules can be loaded before any command:
@@ -205,8 +206,11 @@ commits:
 - `config.yaml` generated from detected localization files
 - `glossary.json` copied from the generic example
 - `.github/workflows/translate.yml` in safe `dry-run: true` mode
+- `docs/localize-pipeline.md` with the target repository's rollout checklist
 
 Add `--push --open-pr` when the target repo has `origin` and `gh` configured.
+For custom adapters, pass `--plugin-module` and `--plugin-install-command`; the
+generated workflow will install and load the adapter before running checks.
 
 ## Public Python API
 
@@ -239,6 +243,25 @@ translation_memory_file_path: "logs/translation_memory.json"
 ```
 
 Use a shared path if several projects should reuse one approved memory store.
+Manage memory stores with:
+
+```bash
+localize memory stats --memory-file logs/translation_memory.json
+localize memory export --memory-file logs/translation_memory.json --output shared-memory.json
+localize memory import --memory-file logs/translation_memory.json --input shared-memory.json
+localize memory promote --memory-file logs/translation_memory.json \
+  --source-text "Save changes" \
+  --target-text "Änderungen speichern" \
+  --locale de \
+  --format-id json
+localize memory suggest --memory-file logs/translation_memory.json \
+  --source-text "Save change" \
+  --locale de \
+  --format-id json
+```
+
+Fuzzy memory suggestions are review aids only. The runtime still reuses exact
+matches only.
 
 ## Releases
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: "Override the holistic-review model (maps to REVIEW_MODEL_NAME)."
     required: false
     default: ""
+  plugin-modules:
+    description: "Comma-separated localize plugin modules to import before check/run."
+    required: false
+    default: ""
+  plugin-install-command:
+    description: "Optional shell command to install custom adapter packages before check/run."
+    required: false
+    default: ""
   diff-base:
     description: >-
       Git ref to detect changed source strings against (e.g. the push/PR base). The
@@ -78,6 +86,15 @@ runs:
       shell: bash
       run: pip install -r "${{ github.action_path }}/requirements.txt"
 
+    - name: Install plugin dependencies
+      if: ${{ inputs.plugin-install-command != '' }}
+      shell: bash
+      env:
+        PLUGIN_INSTALL_COMMAND: ${{ inputs.plugin-install-command }}
+      run: |
+        set -euo pipefail
+        bash -lc "$PLUGIN_INSTALL_COMMAND"
+
     - name: Check localization setup
       shell: bash
       working-directory: ${{ github.workspace }}
@@ -88,6 +105,7 @@ runs:
         OPENAI_BASE_URL: ${{ inputs.api-base-url }}
         REVIEW_MODEL_NAME: ${{ inputs.review-model }}
         LOCALIZE_DRY_RUN: ${{ inputs.dry-run }}
+        LOCALIZE_PLUGIN_MODULES: ${{ inputs.plugin-modules }}
       run: |
         set -euo pipefail
         python -m localize.cli check --config "$TRANSLATOR_CONFIG_FILE"
@@ -104,6 +122,7 @@ runs:
         PROCESS_ALL_FILES: ${{ inputs.process-all-files }}
         DIFF_BASE_INPUT: ${{ inputs.diff-base }}
         LOCALIZE_DRY_RUN: ${{ inputs.dry-run }}
+        LOCALIZE_PLUGIN_MODULES: ${{ inputs.plugin-modules }}
       run: |
         set -euo pipefail
         # An all-zero SHA (first push to a branch) is not a valid diff base; fall back

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -101,6 +101,24 @@ AISuite is the default provider abstraction. Bare names such as `gpt-4o-mini`
 are treated as OpenAI models. Explicit names such as `openai:gpt-4o-mini` are
 also accepted.
 
+## Custom Format Plugins
+
+For custom adapters, install the package and list the adapter modules with the
+first-class plugin inputs:
+
+```yaml
+      - uses: bisq-network/translate-java-property-files@v0.1.0
+        with:
+          config-file: config.yaml
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          plugin-install-command: python -m pip install .
+          plugin-modules: my_project.localize_adapter
+```
+
+`plugin-install-command` runs after the pipeline dependencies are installed.
+`plugin-modules` maps to `LOCALIZE_PLUGIN_MODULES`, so the same adapter loading
+path is used by local CLI runs and the Action.
+
 ## Pull Request Events
 
 For `pull_request` workflows, set `diff-base` to the PR base SHA:
@@ -132,6 +150,8 @@ jobs:
 | `openai-api-key` | empty | OpenAI key. Omit for keyless local endpoints. |
 | `api-base-url` | empty | OpenAI-compatible endpoint. Overrides config. |
 | `review-model` | empty | Override the holistic-review model. |
+| `plugin-modules` | empty | Comma-separated plugin modules to load before check/run. |
+| `plugin-install-command` | empty | Shell command to install custom adapter packages before check/run. |
 | `diff-base` | `${{ github.event.before }}` | Ref used for changed-string detection. |
 | `process-all-files` | `false` | Translate all target files. Use for backfills. |
 | `dry-run` | `false` | Preview discovery and validation without model calls or translation writes. |
@@ -162,6 +182,6 @@ use it only when that is intentional.
 ## Custom Formats
 
 The action includes built-in Java `.properties` and JSON adapters. For custom
-adapters, publish a small wrapper action or install step that places your adapter
-package on `PYTHONPATH` and exposes a `localize.format_adapters` entry point.
-Then reference that adapter id in `config.yaml`.
+adapters, use `plugin-install-command` and `plugin-modules`, or publish a package
+that exposes a `localize.format_adapters` entry point. Then reference that adapter
+id in `config.yaml`.

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -29,6 +29,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
+localize memory stats --memory-file logs/translation_memory.json
 ```
 
 | Command | What it does |
@@ -39,6 +40,7 @@ localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
 | `validate` | Checks config shape, paths, locales, formats, layouts, and endpoint settings. |
 | `run` | Executes the translation pipeline. Use `--dry-run` to force a preview without editing config. |
 | `bootstrap-pr` | Creates an onboarding branch with generated config, glossary, and GitHub workflow files. |
+| `memory` | Inspects, imports, exports, promotes, and suggests translation-memory entries. |
 
 The module form is equivalent:
 
@@ -101,8 +103,9 @@ localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
-`config.yaml`, `glossary.json`, and `.github/workflows/translate.yml`, then
-commits them locally. The generated workflow starts with `dry-run: true`.
+`config.yaml`, `glossary.json`, `.github/workflows/translate.yml`, and
+`docs/localize-pipeline.md`, then commits them locally. The generated workflow
+starts with `dry-run: true`.
 
 Add network actions explicitly:
 
@@ -112,6 +115,19 @@ localize bootstrap-pr --target-project-root path/to/repo --push --open-pr
 
 `--open-pr` uses the GitHub CLI and expects `gh` plus an `origin` remote to be
 configured in the target repository.
+
+For custom adapters:
+
+```bash
+localize bootstrap-pr \
+  --target-project-root path/to/repo \
+  --action-ref v0.1.0 \
+  --plugin-module my_project.localize_adapter \
+  --plugin-install-command "python -m pip install ."
+```
+
+The generated workflow forwards those values to the Action's first-class plugin
+inputs.
 
 ## Mixed-Format Config
 
@@ -179,6 +195,53 @@ my_format = "my_package.localize_adapter:register"
 
 The entry point can be a callable registration function or a module-level object
 whose import registers adapters.
+
+## Translation Memory
+
+Exact-match translation memory is stored in JSON. The runtime records
+validation-safe translations and reuses exact source/locale/format matches.
+
+Inspect a memory file:
+
+```bash
+localize memory stats --memory-file logs/translation_memory.json
+localize memory stats --memory-file logs/translation_memory.json --output-format json
+```
+
+Share approved entries across projects:
+
+```bash
+localize memory export \
+  --memory-file logs/translation_memory.json \
+  --output shared-memory.json
+
+localize memory import \
+  --memory-file logs/translation_memory.json \
+  --input shared-memory.json
+```
+
+Promote a reviewed translation manually:
+
+```bash
+localize memory promote \
+  --memory-file logs/translation_memory.json \
+  --source-text "Save changes" \
+  --target-text "Änderungen speichern" \
+  --locale de \
+  --format-id json
+```
+
+Find fuzzy candidates for human review:
+
+```bash
+localize memory suggest \
+  --memory-file logs/translation_memory.json \
+  --source-text "Save change" \
+  --locale de \
+  --format-id json
+```
+
+Fuzzy candidates are never applied automatically by the pipeline.
 
 ## Custom Adapter Contract
 

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -26,7 +26,7 @@ This project has three supported surfaces:
 
 | Path | Purpose |
 | --- | --- |
-| `localize/cli.py` | `localize formats/init/check/validate/run/bootstrap-pr`. |
+| `localize/cli.py` | `localize formats/init/check/validate/run/bootstrap-pr/memory`. |
 | `localize/bootstrap_pr.py` | Self-service onboarding branch and PR generation. |
 | `localize/init_config.py` | Config scaffolding and locale detection. |
 | `localize/pipeline_core.py` | Format-agnostic orchestration with injected steps. |
@@ -39,7 +39,7 @@ This project has three supported surfaces:
 | `localize/plugins.py` | Plugin loading through entry points, env modules, and `--plugin`. |
 | `localize/providers/` | Public provider API. |
 | `localize/model_provider.py` | AISuite and direct OpenAI-compatible provider implementations. |
-| `localize/translation_memory.py` | Exact-match translation memory store and conflict handling. |
+| `localize/translation_memory.py` | Exact-match translation memory store, import/export, fuzzy suggestions, and conflict handling. |
 | `localize/translate_localization_files.py` | Runtime translation pipeline. |
 | `localize/translation_quality_gate.py` | Deterministic PR quality gate. |
 | `localize/translation_semantic_reviewer.py` | AI semantic review sidecar. |

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -249,8 +249,8 @@ and the team explicitly enables translation writes.
 ```bash
 python3 -m venv venv
 ./venv/bin/pip install localize-pipeline
-localize check --config {config_path}
-localize run --dry-run --config {config_path}
+./venv/bin/localize check --config {config_path}
+./venv/bin/localize run --dry-run --config {config_path}
 ```
 
 ## Enable The GitHub Action

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -35,6 +35,9 @@ class BootstrapPrOptions:
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False
     reset_branch: bool = False
+    onboarding_guide_path: Optional[str] = "docs/localize-pipeline.md"
+    plugin_modules: tuple[str, ...] = ()
+    plugin_install_command: Optional[str] = None
     push: bool = False
     open_pr: bool = False
 
@@ -137,7 +140,43 @@ def _copy_example_glossary(target: Path) -> None:
     shutil.copyfile(source, target)
 
 
-def _render_workflow(*, action_ref: str, config_path: str, base_branch: str) -> str:
+def _indent_block(value: str, spaces: int) -> str:
+    prefix = " " * spaces
+    return "\n".join(f"{prefix}{line}" if line else prefix for line in value.splitlines())
+
+
+def _render_action_inputs(
+    *,
+    config_path: str,
+    plugin_modules: Sequence[str],
+    plugin_install_command: str | None,
+) -> str:
+    lines = [
+        f"          config-file: {config_path}",
+        "          openai-api-key: ${{ secrets.OPENAI_API_KEY }}",
+        "          dry-run: true",
+    ]
+    if plugin_modules:
+        lines.append(f"          plugin-modules: {','.join(plugin_modules)}")
+    if plugin_install_command:
+        lines.append("          plugin-install-command: |")
+        lines.append(_indent_block(plugin_install_command, 12))
+    return "\n".join(lines)
+
+
+def _render_workflow(
+    *,
+    action_ref: str,
+    config_path: str,
+    base_branch: str,
+    plugin_modules: Sequence[str],
+    plugin_install_command: str | None,
+) -> str:
+    action_inputs = _render_action_inputs(
+        config_path=config_path,
+        plugin_modules=plugin_modules,
+        plugin_install_command=plugin_install_command,
+    )
     return f"""name: Translate
 on:
   push:
@@ -157,9 +196,80 @@ jobs:
           fetch-depth: 0
       - uses: bisq-network/translate-java-property-files@{action_ref}
         with:
-          config-file: {config_path}
-          openai-api-key: ${{{{ secrets.OPENAI_API_KEY }}}}
-          dry-run: true
+{action_inputs}
+"""
+
+
+def _render_onboarding_guide(
+    *,
+    config_path: str,
+    glossary_path: str,
+    workflow_path: str,
+    action_ref: str,
+    plugin_modules: Sequence[str],
+    plugin_install_command: str | None,
+) -> str:
+    plugin_section = ""
+    if plugin_modules or plugin_install_command:
+        plugin_lines = ["## Custom Format Plugins", ""]
+        if plugin_modules:
+            plugin_lines.extend([
+                "The generated workflow loads these adapter modules:",
+                "",
+                "```text",
+                ",".join(plugin_modules),
+                "```",
+                "",
+            ])
+        if plugin_install_command:
+            plugin_lines.extend([
+                "It installs plugin dependencies with:",
+                "",
+                "```bash",
+                plugin_install_command,
+                "```",
+                "",
+            ])
+        plugin_section = "\n".join(plugin_lines)
+
+    return f"""# Localize Pipeline Onboarding
+
+This repository was bootstrapped for Localize Pipeline. The generated workflow is
+safe by default: it runs with `dry-run: true` until the first setup PR is merged
+and the team explicitly enables translation writes.
+
+## Files
+
+- `{config_path}`: pipeline config generated from the detected localization files.
+- `{glossary_path}`: starter glossary for project-specific terms.
+- `{workflow_path}`: GitHub Action workflow pinned to `{action_ref}`.
+
+## Validate Locally
+
+```bash
+python3 -m venv venv
+./venv/bin/pip install localize-pipeline
+localize check --config {config_path}
+localize run --dry-run --config {config_path}
+```
+
+## Enable The GitHub Action
+
+1. Add the `OPENAI_API_KEY` repository secret, or configure `api-base-url` for a
+   local OpenAI-compatible endpoint.
+2. Merge this onboarding PR while the workflow still has `dry-run: true`.
+3. Trigger one manual workflow run with `process-all-files: true` for the first
+   backfill.
+4. Review the translation PR.
+5. Set `dry-run: false` for normal incremental translation runs.
+
+{plugin_section}## Maintenance
+
+- Keep glossary changes reviewed like code.
+- Use `localize memory stats --memory-file logs/translation_memory.json` to
+  inspect the exact-match translation memory.
+- Use `localize memory export` and `localize memory import` when sharing approved
+  translation memory between projects.
 """
 
 
@@ -223,12 +333,21 @@ def create_bootstrap_pr(options: BootstrapPrOptions) -> BootstrapPrResult:
     config_path = _repo_relative_path(repo, options.config_path, "config-file")
     glossary_path = _repo_relative_path(repo, options.glossary_path, "glossary-file")
     workflow_path = _repo_relative_path(repo, options.workflow_path, "workflow-file")
+    onboarding_guide_path = (
+        _repo_relative_path(repo, options.onboarding_guide_path, "onboarding-guide-file")
+        if options.onboarding_guide_path
+        else None
+    )
     input_folder = (
         _repo_relative_path(repo, options.input_folder, "input-folder")
         if options.input_folder
         else None
     )
-    created_files = (config_path, glossary_path, workflow_path)
+    created_files = tuple(
+        path
+        for path in (config_path, glossary_path, workflow_path, onboarding_guide_path)
+        if path is not None
+    )
     _assert_can_write(repo, created_files, overwrite=options.overwrite)
     base_branch = options.base_branch or "main"
 
@@ -244,9 +363,25 @@ def create_bootstrap_pr(options: BootstrapPrOptions) -> BootstrapPrResult:
             action_ref=options.action_ref,
             config_path=config_path,
             base_branch=base_branch,
+            plugin_modules=options.plugin_modules,
+            plugin_install_command=options.plugin_install_command,
         ),
         encoding="utf-8",
     )
+    if onboarding_guide_path:
+        guide_file = repo / onboarding_guide_path
+        guide_file.parent.mkdir(parents=True, exist_ok=True)
+        guide_file.write_text(
+            _render_onboarding_guide(
+                config_path=config_path,
+                glossary_path=glossary_path,
+                workflow_path=workflow_path,
+                action_ref=options.action_ref,
+                plugin_modules=options.plugin_modules,
+                plugin_install_command=options.plugin_install_command,
+            ),
+            encoding="utf-8",
+        )
 
     _git(repo, "add", *created_files)
     _git(repo, "commit", "-m", options.commit_message)

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -20,6 +20,7 @@ from localize.formats import list_localization_adapters, list_localization_forma
 from localize.init_config import main as init_config_main
 from localize.plugins import load_plugins
 from localize.translation_memory import (
+    load_translation_memory_strict,
     load_translation_memory,
     merge_translation_memory,
     translation_memory_suggestions,
@@ -181,7 +182,11 @@ def _print_memory_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_memory_export(args: argparse.Namespace) -> int:
-    memory = load_translation_memory(args.memory_file)
+    try:
+        memory = load_translation_memory_strict(args.memory_file, require_exists=True)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     try:
         write_translation_memory(args.output, memory)
     except OSError as exc:
@@ -192,8 +197,12 @@ def _cmd_memory_export(args: argparse.Namespace) -> int:
 
 
 def _cmd_memory_import(args: argparse.Namespace) -> int:
-    target = load_translation_memory(args.memory_file)
-    incoming = load_translation_memory(args.input)
+    try:
+        target = load_translation_memory_strict(args.memory_file)
+        incoming = load_translation_memory_strict(args.input, require_exists=True)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     result = merge_translation_memory(target, incoming)
     try:
         write_translation_memory(args.memory_file, target)
@@ -210,7 +219,11 @@ def _cmd_memory_import(args: argparse.Namespace) -> int:
 
 
 def _cmd_memory_promote(args: argparse.Namespace) -> int:
-    memory = load_translation_memory(args.memory_file)
+    try:
+        memory = load_translation_memory_strict(args.memory_file)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     memory.record(
         args.source_text,
         args.target_text,
@@ -227,7 +240,11 @@ def _cmd_memory_promote(args: argparse.Namespace) -> int:
 
 
 def _cmd_memory_suggest(args: argparse.Namespace) -> int:
-    memory = load_translation_memory(args.memory_file)
+    try:
+        memory = load_translation_memory_strict(args.memory_file)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     suggestions = translation_memory_suggestions(
         memory,
         args.source_text,
@@ -242,6 +259,16 @@ def _cmd_memory_suggest(args: argparse.Namespace) -> int:
             f"{suggestion.source_text}\t{suggestion.target_text}"
         )
     return 0
+
+
+def _non_negative_int(raw_value: str) -> int:
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected a non-negative integer") from exc
+    if value < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative integer")
+    return value
 
 
 def _extract_plugin_args(raw_argv: Sequence[str]) -> tuple[list[str], list[str]]:
@@ -425,7 +452,7 @@ def _build_parser() -> argparse.ArgumentParser:
     memory_suggest.add_argument("--locale", required=True, help="Target locale code.")
     memory_suggest.add_argument("--format-id", required=True, help="Localization format id.")
     memory_suggest.add_argument("--min-score", type=float, default=0.72, help="Minimum fuzzy match score.")
-    memory_suggest.add_argument("--limit", type=int, default=5, help="Maximum suggestions to print.")
+    memory_suggest.add_argument("--limit", type=_non_negative_int, default=5, help="Maximum suggestions to print.")
     memory_suggest.set_defaults(func=_cmd_memory_suggest)
 
     return parser

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import importlib
+import json
 import os
 import subprocess
 import sys
@@ -18,6 +19,12 @@ from localize.bootstrap_pr import BootstrapPrOptions, create_bootstrap_pr
 from localize.formats import list_localization_adapters, list_localization_formats
 from localize.init_config import main as init_config_main
 from localize.plugins import load_plugins
+from localize.translation_memory import (
+    load_translation_memory,
+    merge_translation_memory,
+    translation_memory_suggestions,
+    write_translation_memory,
+)
 
 
 def _load_config_file(config_path: Path) -> dict[str, Any]:
@@ -132,6 +139,9 @@ def _cmd_bootstrap_pr(args: argparse.Namespace) -> int:
                 action_ref=args.action_ref,
                 overwrite=args.overwrite,
                 reset_branch=args.reset_branch,
+                onboarding_guide_path=None if args.skip_onboarding_guide else args.onboarding_guide_file,
+                plugin_modules=tuple(args.plugin_module),
+                plugin_install_command=args.plugin_install_command,
                 push=args.push,
                 open_pr=args.open_pr,
             )
@@ -146,6 +156,91 @@ def _cmd_bootstrap_pr(args: argparse.Namespace) -> int:
         print("Pushed onboarding branch")
     else:
         print("Review the branch, then push/open a pull request when ready")
+    return 0
+
+
+def _print_memory_stats(args: argparse.Namespace) -> int:
+    memory = load_translation_memory(args.memory_file)
+    stats = memory.stats()
+    if args.output_format == "json":
+        print(json.dumps({
+            "total_entries": stats.total_entries,
+            "active_entries": stats.active_entries,
+            "conflict_entries": stats.conflict_entries,
+            "locales": list(stats.locales),
+            "formats": list(stats.formats),
+        }, ensure_ascii=False, sort_keys=True))
+        return 0
+
+    print(f"total_entries: {stats.total_entries}")
+    print(f"active_entries: {stats.active_entries}")
+    print(f"conflict_entries: {stats.conflict_entries}")
+    print(f"locales: {', '.join(stats.locales) if stats.locales else '-'}")
+    print(f"formats: {', '.join(stats.formats) if stats.formats else '-'}")
+    return 0
+
+
+def _cmd_memory_export(args: argparse.Namespace) -> int:
+    memory = load_translation_memory(args.memory_file)
+    try:
+        write_translation_memory(args.output, memory)
+    except OSError as exc:
+        print(f"error: could not export translation memory: {exc}", file=sys.stderr)
+        return 1
+    print(f"Exported {memory.stats().total_entries} translation memory entries to {args.output}")
+    return 0
+
+
+def _cmd_memory_import(args: argparse.Namespace) -> int:
+    target = load_translation_memory(args.memory_file)
+    incoming = load_translation_memory(args.input)
+    result = merge_translation_memory(target, incoming)
+    try:
+        write_translation_memory(args.memory_file, target)
+    except OSError as exc:
+        print(f"error: could not import translation memory: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "Imported translation memory: "
+        f"imported={result.imported_entries} "
+        f"unchanged={result.unchanged_entries} "
+        f"conflicts={result.conflict_entries}"
+    )
+    return 0
+
+
+def _cmd_memory_promote(args: argparse.Namespace) -> int:
+    memory = load_translation_memory(args.memory_file)
+    memory.record(
+        args.source_text,
+        args.target_text,
+        locale=args.locale,
+        format_id=args.format_id,
+    )
+    try:
+        write_translation_memory(args.memory_file, memory)
+    except OSError as exc:
+        print(f"error: could not promote translation memory entry: {exc}", file=sys.stderr)
+        return 1
+    print("Promoted translation memory entry")
+    return 0
+
+
+def _cmd_memory_suggest(args: argparse.Namespace) -> int:
+    memory = load_translation_memory(args.memory_file)
+    suggestions = translation_memory_suggestions(
+        memory,
+        args.source_text,
+        locale=args.locale,
+        format_id=args.format_id,
+        min_score=args.min_score,
+        limit=args.limit,
+    )
+    for suggestion in suggestions:
+        print(
+            f"{suggestion.score:.3f}\t{suggestion.locale}\t{suggestion.format_id}\t"
+            f"{suggestion.source_text}\t{suggestion.target_text}"
+        )
     return 0
 
 
@@ -256,6 +351,27 @@ def _build_parser() -> argparse.ArgumentParser:
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
     bootstrap_parser.add_argument("--action-ref", default="v0.1.0", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument(
+        "--onboarding-guide-file",
+        default="docs/localize-pipeline.md",
+        help="Target-repo onboarding guide to create.",
+    )
+    bootstrap_parser.add_argument(
+        "--skip-onboarding-guide",
+        action="store_true",
+        help="Do not create a target-repo onboarding guide.",
+    )
+    bootstrap_parser.add_argument(
+        "--plugin-module",
+        action="append",
+        default=[],
+        help="Plugin module to load in the generated GitHub Action workflow. Repeatable.",
+    )
+    bootstrap_parser.add_argument(
+        "--plugin-install-command",
+        default=None,
+        help="Optional shell command that installs custom adapter dependencies in the generated workflow.",
+    )
     bootstrap_parser.add_argument("--overwrite", action="store_true", help="Replace existing onboarding files.")
     bootstrap_parser.add_argument(
         "--reset-branch",
@@ -265,6 +381,52 @@ def _build_parser() -> argparse.ArgumentParser:
     bootstrap_parser.add_argument("--push", action="store_true", help="Push the onboarding branch to origin.")
     bootstrap_parser.add_argument("--open-pr", action="store_true", help="Push and open the onboarding PR with gh.")
     bootstrap_parser.set_defaults(func=_cmd_bootstrap_pr)
+
+    memory_parser = subparsers.add_parser(
+        "memory",
+        help="Inspect, import, export, and promote translation-memory entries.",
+    )
+    memory_subparsers = memory_parser.add_subparsers(dest="memory_command", required=True)
+
+    memory_stats = memory_subparsers.add_parser("stats", help="Print translation-memory statistics.")
+    memory_stats.add_argument("--memory-file", default="logs/translation_memory.json", help="Memory file to inspect.")
+    memory_stats.add_argument(
+        "--output-format",
+        choices=("text", "json"),
+        default="text",
+        help="Stats output format.",
+    )
+    memory_stats.set_defaults(func=_print_memory_stats)
+
+    memory_export = memory_subparsers.add_parser("export", help="Export a translation-memory file.")
+    memory_export.add_argument("--memory-file", default="logs/translation_memory.json", help="Memory file to export.")
+    memory_export.add_argument("--output", required=True, help="Destination memory JSON file.")
+    memory_export.set_defaults(func=_cmd_memory_export)
+
+    memory_import = memory_subparsers.add_parser("import", help="Merge an exported memory into a memory file.")
+    memory_import.add_argument("--memory-file", default="logs/translation_memory.json", help="Target memory file.")
+    memory_import.add_argument("--input", required=True, help="Source memory JSON file to import.")
+    memory_import.set_defaults(func=_cmd_memory_import)
+
+    memory_promote = memory_subparsers.add_parser("promote", help="Record one reviewed translation-memory entry.")
+    memory_promote.add_argument("--memory-file", default="logs/translation_memory.json", help="Target memory file.")
+    memory_promote.add_argument("--source-text", required=True, help="Reviewed source text.")
+    memory_promote.add_argument("--target-text", required=True, help="Reviewed target translation.")
+    memory_promote.add_argument("--locale", required=True, help="Target locale code.")
+    memory_promote.add_argument("--format-id", required=True, help="Localization format id.")
+    memory_promote.set_defaults(func=_cmd_memory_promote)
+
+    memory_suggest = memory_subparsers.add_parser(
+        "suggest",
+        help="Show fuzzy memory candidates for human review without automatic reuse.",
+    )
+    memory_suggest.add_argument("--memory-file", default="logs/translation_memory.json", help="Memory file.")
+    memory_suggest.add_argument("--source-text", required=True, help="Source text to match.")
+    memory_suggest.add_argument("--locale", required=True, help="Target locale code.")
+    memory_suggest.add_argument("--format-id", required=True, help="Localization format id.")
+    memory_suggest.add_argument("--min-score", type=float, default=0.72, help="Minimum fuzzy match score.")
+    memory_suggest.add_argument("--limit", type=int, default=5, help="Maximum suggestions to print.")
+    memory_suggest.set_defaults(func=_cmd_memory_suggest)
 
     return parser
 

--- a/localize/translation_memory.py
+++ b/localize/translation_memory.py
@@ -241,14 +241,20 @@ def translation_memory_suggestions(
             continue
         entry_source = entry.get("source")
         target_text = entry.get("target")
-        if entry_source is None or target_text is None:
+        if target_text is None:
             continue
-        score = SequenceMatcher(
-            None,
-            normalized_source,
-            normalize_memory_source(str(entry_source)),
-        ).ratio()
-        if score >= min_score and score < 1.0:
+        if entry_source is None:
+            if entry.get("source_hash") != memory_source_hash(source_text):
+                continue
+            entry_source = source_text
+            score = 1.0
+        else:
+            score = SequenceMatcher(
+                None,
+                normalized_source,
+                normalize_memory_source(str(entry_source)),
+            ).ratio()
+        if score >= min_score:
             suggestions.append(
                 TranslationMemorySuggestion(
                     source_text=str(entry_source),
@@ -291,6 +297,29 @@ def load_translation_memory(path: str | Path) -> TranslationMemory:
         return TranslationMemory()
     if not isinstance(payload, Mapping):
         return TranslationMemory()
+    return TranslationMemory.from_payload(payload)
+
+
+def load_translation_memory_strict(
+    path: str | Path,
+    *,
+    require_exists: bool = False,
+) -> TranslationMemory:
+    """Load memory for explicit file-management commands, raising on bad input."""
+    memory_path = Path(path)
+    if not memory_path.exists():
+        if require_exists:
+            raise FileNotFoundError(f"translation memory file not found: {memory_path}")
+        return TranslationMemory()
+    try:
+        payload = json.loads(memory_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid translation memory file: {memory_path}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"invalid translation memory file: {memory_path}")
+    entries = payload.get("entries", {})
+    if not isinstance(entries, Mapping):
+        raise ValueError(f"invalid translation memory entries in: {memory_path}")
     return TranslationMemory.from_payload(payload)
 
 

--- a/localize/translation_memory.py
+++ b/localize/translation_memory.py
@@ -6,7 +6,9 @@ import datetime as _dt
 import hashlib
 import json
 import logging
+from copy import deepcopy
 from dataclasses import dataclass, field
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, Mapping
 
@@ -30,6 +32,37 @@ def _entry_key(source_text: str, locale: str, format_id: str) -> str:
     return f"{format_id}:{locale}:{memory_source_hash(source_text)}"
 
 
+@dataclass(frozen=True)
+class TranslationMemoryStats:
+    """Aggregate counts for one translation memory store."""
+
+    total_entries: int
+    active_entries: int
+    conflict_entries: int
+    locales: tuple[str, ...]
+    formats: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TranslationMemoryMergeResult:
+    """Result of merging an imported memory into a target memory."""
+
+    imported_entries: int = 0
+    unchanged_entries: int = 0
+    conflict_entries: int = 0
+
+
+@dataclass(frozen=True)
+class TranslationMemorySuggestion:
+    """A fuzzy translation-memory candidate for human review."""
+
+    source_text: str
+    target_text: str
+    locale: str
+    format_id: str
+    score: float
+
+
 @dataclass
 class TranslationMemory:
     """In-memory representation of reusable approved translations."""
@@ -51,6 +84,7 @@ class TranslationMemory:
         existing = self.entries.get(key)
         if not existing:
             self.entries[key] = {
+                "source": source_text,
                 "source_hash": source_hash,
                 "locale": locale,
                 "format_id": format_id,
@@ -63,14 +97,76 @@ class TranslationMemory:
             targets = set(str(target) for target in existing.get("targets", []))
             targets.add(target_text)
             existing["targets"] = sorted(targets)
+            existing.setdefault("source", source_text)
             return
 
         if existing.get("target") == target_text:
+            existing.setdefault("source", source_text)
             return
 
         previous_target = str(existing.pop("target", ""))
         existing["status"] = "conflict"
         existing["targets"] = sorted({previous_target, target_text} - {""})
+        existing.setdefault("source", source_text)
+
+    def stats(self) -> TranslationMemoryStats:
+        """Return high-level counts for observability and onboarding checks."""
+        active_entries = 0
+        conflict_entries = 0
+        locales: set[str] = set()
+        formats: set[str] = set()
+        for entry in self.entries.values():
+            status = entry.get("status", "active")
+            if status == "conflict":
+                conflict_entries += 1
+            else:
+                active_entries += 1
+            locale = entry.get("locale")
+            format_id = entry.get("format_id")
+            if locale:
+                locales.add(str(locale))
+            if format_id:
+                formats.add(str(format_id))
+        return TranslationMemoryStats(
+            total_entries=len(self.entries),
+            active_entries=active_entries,
+            conflict_entries=conflict_entries,
+            locales=tuple(sorted(locales)),
+            formats=tuple(sorted(formats)),
+        )
+
+    def merge_from(self, other: "TranslationMemory") -> TranslationMemoryMergeResult:
+        """Merge another memory into this one, marking disagreements unsafe."""
+        imported = 0
+        unchanged = 0
+        conflicts = 0
+        for key, incoming in other.entries.items():
+            existing = self.entries.get(key)
+            incoming_copy = deepcopy(incoming)
+            if existing is None:
+                self.entries[key] = incoming_copy
+                imported += 1
+                continue
+
+            if _entries_match(existing, incoming):
+                _fill_missing_metadata(existing, incoming)
+                unchanged += 1
+                continue
+
+            targets = _entry_targets(existing) | _entry_targets(incoming)
+            if len(targets) <= 1:
+                _fill_missing_metadata(existing, incoming)
+                unchanged += 1
+                continue
+
+            _mark_conflict(existing, incoming, targets)
+            conflicts += 1
+
+        return TranslationMemoryMergeResult(
+            imported_entries=imported,
+            unchanged_entries=unchanged,
+            conflict_entries=conflicts,
+        )
 
     def to_payload(self) -> Dict[str, Any]:
         return {
@@ -89,6 +185,99 @@ class TranslationMemory:
             if isinstance(value, Mapping)
         }
         return cls(entries=valid_entries)
+
+
+def _entry_targets(entry: Mapping[str, Any]) -> set[str]:
+    if entry.get("status") == "conflict":
+        return {str(target) for target in entry.get("targets", []) if target is not None}
+    target = entry.get("target")
+    return {str(target)} if target is not None else set()
+
+
+def _entries_match(left: Mapping[str, Any], right: Mapping[str, Any]) -> bool:
+    return (
+        left.get("status", "active") == right.get("status", "active")
+        and _entry_targets(left) == _entry_targets(right)
+    )
+
+
+def _fill_missing_metadata(target: Dict[str, Any], source: Mapping[str, Any]) -> None:
+    for key in ("source", "source_hash", "locale", "format_id"):
+        if key not in target and key in source:
+            target[key] = source[key]
+
+
+def _mark_conflict(target: Dict[str, Any], source: Mapping[str, Any], targets: set[str]) -> None:
+    target.pop("target", None)
+    target["status"] = "conflict"
+    target["targets"] = sorted(targets)
+    _fill_missing_metadata(target, source)
+
+
+def merge_translation_memory(
+    target: TranslationMemory,
+    incoming: TranslationMemory,
+) -> TranslationMemoryMergeResult:
+    """Merge incoming approved translations into target memory."""
+    return target.merge_from(incoming)
+
+
+def translation_memory_suggestions(
+    memory: TranslationMemory,
+    source_text: str,
+    *,
+    locale: str,
+    format_id: str,
+    min_score: float = 0.72,
+    limit: int = 5,
+) -> tuple[TranslationMemorySuggestion, ...]:
+    """Return fuzzy candidates for human review without automatic reuse."""
+    normalized_source = normalize_memory_source(source_text)
+    suggestions: list[TranslationMemorySuggestion] = []
+    for entry in memory.entries.values():
+        if entry.get("status", "active") == "conflict":
+            continue
+        if entry.get("locale") != locale or entry.get("format_id") != format_id:
+            continue
+        entry_source = entry.get("source")
+        target_text = entry.get("target")
+        if entry_source is None or target_text is None:
+            continue
+        score = SequenceMatcher(
+            None,
+            normalized_source,
+            normalize_memory_source(str(entry_source)),
+        ).ratio()
+        if score >= min_score and score < 1.0:
+            suggestions.append(
+                TranslationMemorySuggestion(
+                    source_text=str(entry_source),
+                    target_text=str(target_text),
+                    locale=str(locale),
+                    format_id=str(format_id),
+                    score=score,
+                )
+            )
+    suggestions.sort(key=lambda candidate: candidate.score, reverse=True)
+    return tuple(suggestions[:limit])
+
+
+def _payload_with_timestamp(memory: TranslationMemory) -> Dict[str, Any]:
+    payload = memory.to_payload()
+    payload["updated_at"] = _dt.datetime.now(_dt.UTC).isoformat().replace("+00:00", "Z")
+    return payload
+
+
+def write_translation_memory(path: str | Path, memory: TranslationMemory) -> None:
+    """Persist translation memory atomically, raising write errors."""
+    memory_path = Path(path)
+    temp_path = memory_path.with_suffix(f"{memory_path.suffix}.tmp")
+    memory_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path.write_text(
+        json.dumps(_payload_with_timestamp(memory), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temp_path.replace(memory_path)
 
 
 def load_translation_memory(path: str | Path) -> TranslationMemory:
@@ -110,14 +299,7 @@ def save_translation_memory(path: str | Path, memory: TranslationMemory) -> None
     memory_path = Path(path)
     temp_path = memory_path.with_suffix(f"{memory_path.suffix}.tmp")
     try:
-        memory_path.parent.mkdir(parents=True, exist_ok=True)
-        payload = memory.to_payload()
-        payload["updated_at"] = _dt.datetime.now(_dt.UTC).isoformat().replace("+00:00", "Z")
-        temp_path.write_text(
-            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        temp_path.replace(memory_path)
+        write_translation_memory(memory_path, memory)
     except OSError as exc:
         logger.warning("Could not save translation memory to '%s': %s", memory_path, exc)
         try:

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -70,7 +70,9 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     assert isinstance(glossary, dict)
 
     guide = (repo / "docs/localize-pipeline.md").read_text(encoding="utf-8")
-    assert "localize check --config config.yaml" in guide
+    assert "./venv/bin/localize check --config config.yaml" in guide
+    assert "./venv/bin/localize run --dry-run --config config.yaml" in guide
+    assert "\nlocalize check --config config.yaml" not in guide
     assert "dry-run: true" in guide
     assert "OPENAI_API_KEY" in guide
     assert "process-all-files: true" in guide

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -52,6 +52,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
         "config.yaml",
         "glossary.json",
         ".github/workflows/translate.yml",
+        "docs/localize-pipeline.md",
     )
 
     config = yaml.safe_load((repo / "config.yaml").read_text(encoding="utf-8"))
@@ -67,6 +68,12 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))
     assert isinstance(glossary, dict)
+
+    guide = (repo / "docs/localize-pipeline.md").read_text(encoding="utf-8")
+    assert "localize check --config config.yaml" in guide
+    assert "dry-run: true" in guide
+    assert "OPENAI_API_KEY" in guide
+    assert "process-all-files: true" in guide
 
 
 def test_bootstrap_pr_refuses_dirty_repo(tmp_path):
@@ -134,6 +141,29 @@ def test_bootstrap_pr_uses_custom_config_path_in_workflow(tmp_path):
 
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "config-file: .localize/config.yaml" in workflow
+
+
+def test_bootstrap_pr_generates_plugin_aware_workflow_and_guide(tmp_path):
+    repo = tmp_path / "target"
+    _init_repo(repo)
+
+    create_bootstrap_pr(
+        BootstrapPrOptions(
+            target_project_root=repo,
+            branch_name="localize/plugin-onboarding",
+            plugin_modules=("target_repo.localize_adapter",),
+            plugin_install_command="python -m pip install .",
+        )
+    )
+
+    workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
+    assert "plugin-modules: target_repo.localize_adapter" in workflow
+    assert "plugin-install-command: |" in workflow
+    assert "python -m pip install ." in workflow
+
+    guide = (repo / "docs/localize-pipeline.md").read_text(encoding="utf-8")
+    assert "target_repo.localize_adapter" in guide
+    assert "python -m pip install ." in guide
 
 
 def test_bootstrap_pr_threads_base_branch_into_workflow(tmp_path):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,6 +8,7 @@ import yaml
 
 from localize import cli
 from localize.formats import unregister_localization_adapter
+from localize.translation_memory import TranslationMemory, load_translation_memory, save_translation_memory
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -314,6 +315,10 @@ def test_cli_bootstrap_pr_delegates_to_onboarding_generator(capsys):
             "i18n",
             "--action-ref",
             "v0.1.0",
+            "--plugin-module",
+            "target_repo.localize_adapter",
+            "--plugin-install-command",
+            "python -m pip install .",
         ])
 
     captured = capsys.readouterr()
@@ -322,7 +327,49 @@ def test_cli_bootstrap_pr_delegates_to_onboarding_generator(capsys):
     assert options.target_project_root == "/repo"
     assert options.input_folder == "i18n"
     assert options.action_ref == "v0.1.0"
+    assert options.plugin_modules == ("target_repo.localize_adapter",)
+    assert options.plugin_install_command == "python -m pip install ."
     assert "Created onboarding commit abc123" in captured.out
+
+
+def test_cli_memory_import_export_stats_and_suggest(tmp_path, capsys):
+    source = tmp_path / "source-memory.json"
+    destination = tmp_path / "destination-memory.json"
+    exported = tmp_path / "exported-memory.json"
+
+    memory = TranslationMemory()
+    memory.record("Save changes", "Änderungen speichern", locale="de", format_id="json")
+    save_translation_memory(source, memory)
+
+    assert cli.main(["memory", "export", "--memory-file", str(source), "--output", str(exported)]) == 0
+    assert exported.exists()
+
+    assert cli.main(["memory", "import", "--memory-file", str(destination), "--input", str(exported)]) == 0
+    imported = load_translation_memory(destination)
+    assert imported.lookup("Save changes", locale="de", format_id="json") == "Änderungen speichern"
+
+    assert cli.main(["memory", "stats", "--memory-file", str(destination)]) == 0
+    stats_output = capsys.readouterr().out
+    assert "active_entries: 1" in stats_output
+    assert "locales: de" in stats_output
+
+    assert cli.main([
+        "memory",
+        "suggest",
+        "--memory-file",
+        str(destination),
+        "--source-text",
+        "Save change",
+        "--locale",
+        "de",
+        "--format-id",
+        "json",
+        "--min-score",
+        "0.75",
+    ]) == 0
+    suggestions = capsys.readouterr().out
+    assert "Save changes" in suggestions
+    assert "Änderungen speichern" in suggestions
 
 
 def test_pyproject_exposes_localize_console_script():

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -372,6 +372,66 @@ def test_cli_memory_import_export_stats_and_suggest(tmp_path, capsys):
     assert "Änderungen speichern" in suggestions
 
 
+def test_cli_memory_import_rejects_invalid_input_file(tmp_path, capsys):
+    destination = tmp_path / "destination-memory.json"
+    invalid = tmp_path / "invalid-memory.json"
+    invalid.write_text("{not-json", encoding="utf-8")
+
+    exit_code = cli.main(["memory", "import", "--memory-file", str(destination), "--input", str(invalid)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "invalid translation memory" in captured.err
+    assert not destination.exists()
+
+
+def test_cli_memory_promote_rejects_corrupt_target_file(tmp_path, capsys):
+    corrupt = tmp_path / "corrupt-memory.json"
+    corrupt.write_text("{not-json", encoding="utf-8")
+
+    exit_code = cli.main([
+        "memory",
+        "promote",
+        "--memory-file",
+        str(corrupt),
+        "--source-text",
+        "Save",
+        "--target-text",
+        "Speichern",
+        "--locale",
+        "de",
+        "--format-id",
+        "json",
+    ])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "invalid translation memory" in captured.err
+    assert corrupt.read_text(encoding="utf-8") == "{not-json"
+
+
+def test_cli_memory_suggest_rejects_negative_limit(capsys):
+    try:
+        cli.main([
+            "memory",
+            "suggest",
+            "--source-text",
+            "Save",
+            "--locale",
+            "de",
+            "--format-id",
+            "json",
+            "--limit",
+            "-1",
+        ])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("negative limit should fail argument parsing")
+
+    assert "non-negative integer" in capsys.readouterr().err
+
+
 def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 

--- a/tests/unit/test_github_action.py
+++ b/tests/unit/test_github_action.py
@@ -40,6 +40,7 @@ def test_translate_step_wires_provider_and_process_all_env(action):
     assert env["OPENAI_BASE_URL"] == "${{ inputs.api-base-url }}"
     assert env["PROCESS_ALL_FILES"] == "${{ inputs.process-all-files }}"
     assert env["LOCALIZE_DRY_RUN"] == "${{ inputs.dry-run }}"
+    assert env["LOCALIZE_PLUGIN_MODULES"] == "${{ inputs.plugin-modules }}"
     assert 'python -m localize.cli run --config "$TRANSLATOR_CONFIG_FILE"' in translate["run"]
 
 
@@ -50,7 +51,25 @@ def test_action_runs_preflight_check_before_translation(action):
     assert preflight_index < translate_index
     assert steps[preflight_index]["env"]["OPENAI_BASE_URL"] == "${{ inputs.api-base-url }}"
     assert steps[preflight_index]["env"]["REVIEW_MODEL_NAME"] == "${{ inputs.review-model }}"
+    assert steps[preflight_index]["env"]["LOCALIZE_PLUGIN_MODULES"] == "${{ inputs.plugin-modules }}"
     assert 'python -m localize.cli check --config "$TRANSLATOR_CONFIG_FILE"' in steps[preflight_index]["run"]
+
+
+def test_action_has_first_class_plugin_install_and_module_inputs(action):
+    inputs = action["inputs"]
+    assert inputs["plugin-modules"]["default"] == ""
+    assert inputs["plugin-install-command"]["default"] == ""
+
+    steps = action["runs"]["steps"]
+    dependency_index = next(i for i, step in enumerate(steps) if step["name"] == "Install pipeline dependencies")
+    plugin_index = next(i for i, step in enumerate(steps) if step["name"] == "Install plugin dependencies")
+    preflight_index = next(i for i, step in enumerate(steps) if step["name"] == "Check localization setup")
+
+    assert dependency_index < plugin_index < preflight_index
+    plugin_step = steps[plugin_index]
+    assert "plugin-install-command" in plugin_step["if"]
+    assert plugin_step["env"]["PLUGIN_INSTALL_COMMAND"] == "${{ inputs.plugin-install-command }}"
+    assert 'bash -lc "$PLUGIN_INSTALL_COMMAND"' in plugin_step["run"]
 
 
 def test_incremental_by_default_via_diff_base(action):

--- a/tests/unit/test_translation_memory.py
+++ b/tests/unit/test_translation_memory.py
@@ -1,6 +1,12 @@
 import json
 
-from localize.translation_memory import TranslationMemory, load_translation_memory, save_translation_memory
+from localize.translation_memory import (
+    TranslationMemory,
+    load_translation_memory,
+    merge_translation_memory,
+    save_translation_memory,
+    translation_memory_suggestions,
+)
 from localize.translate_localization_files import apply_translation_memory
 
 
@@ -60,6 +66,55 @@ def test_save_translation_memory_is_best_effort(monkeypatch, tmp_path):
     monkeypatch.setattr("pathlib.Path.write_text", fail_write)
 
     save_translation_memory(tmp_path / "translation_memory.json", memory)
+
+
+def test_translation_memory_stats_counts_active_conflict_locale_and_format():
+    memory = TranslationMemory()
+    memory.record("Save", "Speichern", locale="de", format_id="json")
+    memory.record("Open", "Öffnen", locale="de", format_id="java_properties")
+    memory.record("Open", "Offen", locale="de", format_id="java_properties")
+
+    stats = memory.stats()
+
+    assert stats.total_entries == 2
+    assert stats.active_entries == 1
+    assert stats.conflict_entries == 1
+    assert stats.locales == ("de",)
+    assert stats.formats == ("java_properties", "json")
+
+
+def test_merge_translation_memory_imports_entries_and_marks_conflicts():
+    base = TranslationMemory()
+    incoming = TranslationMemory()
+    base.record("Save", "Speichern", locale="de", format_id="json")
+    incoming.record("Cancel", "Abbrechen", locale="de", format_id="json")
+    incoming.record("Save", "Sichern", locale="de", format_id="json")
+
+    result = merge_translation_memory(base, incoming)
+
+    assert result.imported_entries == 1
+    assert result.conflict_entries == 1
+    assert base.lookup("Cancel", locale="de", format_id="json") == "Abbrechen"
+    assert base.lookup("Save", locale="de", format_id="json") is None
+
+
+def test_translation_memory_suggestions_are_fuzzy_but_not_automatic_reuse():
+    memory = TranslationMemory()
+    memory.record("Save changes", "Änderungen speichern", locale="de", format_id="json")
+    memory.record("Delete account", "Konto löschen", locale="de", format_id="json")
+
+    suggestions = translation_memory_suggestions(
+        memory,
+        "Save change",
+        locale="de",
+        format_id="json",
+        min_score=0.75,
+    )
+
+    assert suggestions[0].source_text == "Save changes"
+    assert suggestions[0].target_text == "Änderungen speichern"
+    assert suggestions[0].score < 1.0
+    assert memory.lookup("Save change", locale="de", format_id="json") is None
 
 
 def test_apply_translation_memory_splits_hits_from_model_work():

--- a/tests/unit/test_translation_memory.py
+++ b/tests/unit/test_translation_memory.py
@@ -2,7 +2,9 @@ import json
 
 from localize.translation_memory import (
     TranslationMemory,
+    load_translation_memory_strict,
     load_translation_memory,
+    memory_source_hash,
     merge_translation_memory,
     save_translation_memory,
     translation_memory_suggestions,
@@ -54,6 +56,26 @@ def test_load_translation_memory_missing_or_invalid_file_is_empty(tmp_path):
     invalid.write_text(json.dumps({"entries": []}), encoding="utf-8")
 
     assert load_translation_memory(invalid).to_payload()["entries"] == {}
+
+
+def test_strict_load_translation_memory_rejects_missing_and_invalid_files(tmp_path):
+    missing = tmp_path / "missing.json"
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{not-json", encoding="utf-8")
+
+    try:
+        load_translation_memory_strict(missing, require_exists=True)
+    except FileNotFoundError:
+        pass
+    else:
+        raise AssertionError("missing strict memory file should fail")
+
+    try:
+        load_translation_memory_strict(invalid)
+    except ValueError as exc:
+        assert "invalid translation memory" in str(exc)
+    else:
+        raise AssertionError("invalid strict memory file should fail")
 
 
 def test_save_translation_memory_is_best_effort(monkeypatch, tmp_path):
@@ -115,6 +137,32 @@ def test_translation_memory_suggestions_are_fuzzy_but_not_automatic_reuse():
     assert suggestions[0].target_text == "Änderungen speichern"
     assert suggestions[0].score < 1.0
     assert memory.lookup("Save change", locale="de", format_id="json") is None
+
+
+def test_translation_memory_suggestions_include_legacy_exact_hash_entries():
+    legacy = TranslationMemory.from_payload({
+        "entries": {
+            "json:de:legacy": {
+                "source_hash": memory_source_hash("Save changes"),
+                "locale": "de",
+                "format_id": "json",
+                "target": "Änderungen speichern",
+                "status": "active",
+            }
+        }
+    })
+
+    suggestions = translation_memory_suggestions(
+        legacy,
+        "Save changes",
+        locale="de",
+        format_id="json",
+        min_score=1.0,
+    )
+
+    assert suggestions[0].source_text == "Save changes"
+    assert suggestions[0].target_text == "Änderungen speichern"
+    assert suggestions[0].score == 1.0
 
 
 def test_apply_translation_memory_splits_hits_from_model_work():


### PR DESCRIPTION
## Summary

- Generate a target-repository onboarding guide from `localize bootstrap-pr`.
- Add first-class GitHub Action inputs for custom format plugin installation and module loading.
- Add `localize memory` commands for stats, import, export, promotion, and fuzzy review suggestions.

## Notes

Fuzzy memory suggestions are review aids only. Runtime translation still automatically reuses exact translation-memory matches only.

## Validation

- `OPENAI_API_KEY=sk-test-key venv/bin/ruff check .`
- `git diff --check`
- `OPENAI_API_KEY=sk-test-key venv/bin/pytest -q` (`472 passed`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added translation memory commands for stats, export, import, promote, and fuzzy suggestions.
  * Expanded onboarding and GitHub Action setup to support custom adapter modules and optional dependency installation.
  * Added a generated onboarding guide to the bootstrap PR flow.

* **Bug Fixes**
  * Improved translation memory merging to handle conflicts safely and preserve existing entries.
  * Clarified that fuzzy matches are shown as suggestions only, while exact matches are reused automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->