### PR TITLE
Add static docs homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ incremental runs.
 
 Full guide: [docs/github-action.md](docs/github-action.md).
 
+## Documentation Site
+
+The polished docs entry point is [docs/index.html](docs/index.html). It is a
+static page that can be served by GitHub Pages from the `docs/` directory or
+opened directly in a browser.
+
 ## Configuration Model
 
 Single-format projects use:

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,0 +1,383 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f5ef;
+  --panel: #ffffff;
+  --panel-muted: #f1efe7;
+  --ink: #1f2528;
+  --muted: #5f696d;
+  --line: #d8d3c7;
+  --accent: #0f766e;
+  --accent-strong: #0b4f49;
+  --accent-soft: #d9f0ec;
+  --gold: #ad7c1b;
+  --shadow: 0 16px 40px rgb(31 37 40 / 10%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  line-height: 1.55;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+code,
+pre {
+  font-family:
+    "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 18px clamp(20px, 5vw, 72px);
+  border-bottom: 1px solid rgb(216 211 199 / 70%);
+  background: rgb(247 245 239 / 92%);
+  backdrop-filter: blur(16px);
+}
+
+.brand,
+.top-nav,
+.hero-actions,
+.site-footer {
+  display: flex;
+  align-items: center;
+}
+
+.brand {
+  gap: 10px;
+  font-weight: 720;
+}
+
+.brand-mark {
+  display: inline-grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+  font-size: 12px;
+  letter-spacing: 0;
+}
+
+.top-nav {
+  gap: 22px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.top-nav a:hover,
+.site-footer a:hover,
+.doc-list a:hover {
+  color: var(--accent-strong);
+}
+
+main {
+  width: min(1180px, calc(100% - 40px));
+  margin: 0 auto;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 0.9fr);
+  gap: clamp(32px, 7vw, 86px);
+  align-items: center;
+  min-height: calc(100svh - 76px);
+  padding: 64px 0 40px;
+}
+
+.hero-copy {
+  max-width: 680px;
+}
+
+.eyebrow,
+.card-kicker {
+  margin: 0 0 12px;
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 760;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 22px;
+  font-size: clamp(46px, 7vw, 84px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 14px;
+  font-size: clamp(30px, 4vw, 48px);
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+h3 {
+  margin-bottom: 8px;
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.lede {
+  max-width: 620px;
+  color: var(--muted);
+  font-size: clamp(18px, 2.1vw, 22px);
+}
+
+.hero-actions {
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 30px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  border: 1px solid var(--ink);
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.button.primary {
+  background: var(--ink);
+  color: #ffffff;
+}
+
+.button.secondary {
+  background: transparent;
+}
+
+.workflow-visual {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  padding: 20px;
+}
+
+.workflow-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-muted);
+}
+
+.workflow-row.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.step-label {
+  font-weight: 760;
+}
+
+.step-state {
+  color: var(--muted);
+  text-align: right;
+}
+
+.workflow-line {
+  width: 1px;
+  height: 22px;
+  margin: 0 auto;
+  background: var(--line);
+}
+
+.workflow-visual pre,
+.command-panel {
+  overflow-x: auto;
+  margin: 20px 0 0;
+  border: 1px solid #273035;
+  border-radius: 8px;
+  background: #151a1d;
+  color: #e9eee9;
+}
+
+.workflow-visual pre {
+  padding: 18px;
+}
+
+.workflow-visual code {
+  white-space: pre;
+}
+
+.quick-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: -28px;
+  padding-bottom: 90px;
+}
+
+.guide-card {
+  display: grid;
+  gap: 8px;
+  min-height: 190px;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.guide-card strong {
+  font-size: 22px;
+}
+
+.guide-card span:last-child,
+.section p,
+.timeline p {
+  color: var(--muted);
+}
+
+.section {
+  padding: 86px 0;
+  border-top: 1px solid var(--line);
+}
+
+.section-heading {
+  max-width: 760px;
+  margin-bottom: 28px;
+}
+
+.timeline {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.timeline > div {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.number {
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  margin-bottom: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.7fr);
+  gap: 44px;
+  align-items: start;
+}
+
+.doc-list {
+  display: grid;
+  gap: 10px;
+}
+
+.doc-list a {
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  font-weight: 700;
+}
+
+.command-panel {
+  display: grid;
+  gap: 0;
+  padding: 8px;
+}
+
+.command-panel code {
+  display: block;
+  padding: 12px 14px;
+  border-bottom: 1px solid rgb(255 255 255 / 10%);
+  white-space: nowrap;
+}
+
+.command-panel code:last-child {
+  border-bottom: 0;
+}
+
+.site-footer {
+  justify-content: center;
+  gap: 18px;
+  padding: 38px 20px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.site-footer span {
+  color: var(--ink);
+  font-weight: 760;
+}
+
+@media (max-width: 900px) {
+  .site-header,
+  .top-nav,
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .top-nav {
+    gap: 10px;
+  }
+
+  .hero,
+  .quick-grid,
+  .timeline,
+  .split {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    min-height: auto;
+    padding-top: 48px;
+  }
+
+  .quick-grid {
+    margin-top: 0;
+    padding-bottom: 48px;
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Localize Pipeline - AI localization as pull requests</title>
+    <meta
+      name="description"
+      content="Localize Pipeline translates Java .properties and JSON localization files with model-provider abstraction, review gates, translation memory, and pull-request workflows."
+    >
+    <link rel="stylesheet" href="assets/site.css">
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="../README.md" aria-label="Localize Pipeline README">
+        <span class="brand-mark" aria-hidden="true">LP</span>
+        <span>Localize Pipeline</span>
+      </a>
+      <nav class="top-nav" aria-label="Primary">
+        <a href="localization-cli.md">CLI</a>
+        <a href="github-action.md">GitHub Action</a>
+        <a href="new-project-deployment.md">Server</a>
+        <a href="../README.md">README</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-copy">
+          <p class="eyebrow">AI localization for maintainers</p>
+          <h1>Ship translations as normal pull requests.</h1>
+          <p class="lede">
+            Localize Pipeline detects changed source strings, translates Java .properties
+            and JSON files, runs quality checks, and opens reviewable PRs from your own
+            CI or server.
+          </p>
+          <div class="hero-actions" aria-label="Quick links">
+            <a class="button primary" href="localization-cli.md">Start with the CLI</a>
+            <a class="button secondary" href="github-action.md">Use the Action</a>
+          </div>
+        </div>
+
+        <div class="workflow-visual" aria-label="Localization workflow overview">
+          <div class="workflow-row">
+            <span class="step-label">Source repo</span>
+            <span class="step-state">Changed strings</span>
+          </div>
+          <div class="workflow-line" aria-hidden="true"></div>
+          <div class="workflow-row active">
+            <span class="step-label">Localize Pipeline</span>
+            <span class="step-state">AISuite provider, glossary, review</span>
+          </div>
+          <div class="workflow-line" aria-hidden="true"></div>
+          <div class="workflow-row">
+            <span class="step-label">Translation PR</span>
+            <span class="step-state">Diff, checks, memory update</span>
+          </div>
+          <pre><code>localize bootstrap-pr --target-project-root repo
+localize check --config config.yaml
+localize run --dry-run --config config.yaml
+localize memory stats --memory-file logs/translation_memory.json</code></pre>
+        </div>
+      </section>
+
+      <section class="quick-grid" aria-label="Primary paths">
+        <a class="guide-card" href="localization-cli.md">
+          <span class="card-kicker">Local development</span>
+          <strong>CLI guide</strong>
+          <span>Scaffold config, validate setup, run dry checks, and manage memory.</span>
+        </a>
+        <a class="guide-card" href="github-action.md">
+          <span class="card-kicker">CI workflow</span>
+          <strong>GitHub Action</strong>
+          <span>Translate changed strings and open pull requests from normal CI.</span>
+        </a>
+        <a class="guide-card" href="new-project-deployment.md">
+          <span class="card-kicker">Scheduled service</span>
+          <strong>Server deployment</strong>
+          <span>Run Docker Compose plus cron for Transifex-backed production jobs.</span>
+        </a>
+      </section>
+
+      <section class="section">
+        <div class="section-heading">
+          <p class="eyebrow">Adoption path</p>
+          <h2>Onboard a repository in one reviewable PR.</h2>
+        </div>
+        <div class="timeline">
+          <div>
+            <span class="number">1</span>
+            <h3>Generate</h3>
+            <p>Run <code>localize bootstrap-pr</code> to create config, glossary, workflow, and a target-repo guide.</p>
+          </div>
+          <div>
+            <span class="number">2</span>
+            <h3>Validate</h3>
+            <p>Keep <code>dry-run: true</code>, add credentials or a local endpoint, and run preflight checks.</p>
+          </div>
+          <div>
+            <span class="number">3</span>
+            <h3>Translate</h3>
+            <p>Enable writes, run an initial backfill, and review translations through normal PR review.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section split">
+        <div>
+          <p class="eyebrow">Formats and providers</p>
+          <h2>Built for extension without rewriting the pipeline.</h2>
+          <p>
+            Java .properties and JSON are built in. Custom adapters can be loaded
+            through CLI plugins, Action plugin inputs, or Python entry points.
+            AISuite is the default model-provider abstraction, with an explicit
+            OpenAI-compatible fallback for local endpoints.
+          </p>
+        </div>
+        <div class="doc-list" aria-label="Implementation references">
+          <a href="repository-structure.md">Repository structure</a>
+          <a href="../examples/generic-java-properties/README.md">Java .properties example</a>
+          <a href="../examples/generic-json/README.md">JSON example</a>
+          <a href="adding-new-locales.md">Adding locales</a>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-heading">
+          <p class="eyebrow">Operational surface</p>
+          <h2>Keep translation state visible and portable.</h2>
+        </div>
+        <div class="command-panel">
+          <code>localize memory stats --memory-file logs/translation_memory.json</code>
+          <code>localize memory export --memory-file logs/translation_memory.json --output shared-memory.json</code>
+          <code>localize memory import --memory-file logs/translation_memory.json --input shared-memory.json</code>
+          <code>localize memory suggest --source-text "Save change" --locale de --format-id json</code>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <span>Localize Pipeline</span>
+      <a href="../README.md">Project README</a>
+      <a href="how-to-run-locally.md">Run locally</a>
+      <a href="maintenance/disk-space-management.md">Maintenance</a>
+    </footer>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="../README.md" aria-label="Localize Pipeline README">
+      <a class="brand" href="index.html" aria-label="Localize Pipeline docs homepage">
         <span class="brand-mark" aria-hidden="true">LP</span>
         <span>Localize Pipeline</span>
       </a>
@@ -20,7 +20,7 @@
         <a href="localization-cli.md">CLI</a>
         <a href="github-action.md">GitHub Action</a>
         <a href="new-project-deployment.md">Server</a>
-        <a href="../README.md">README</a>
+        <a href="repository-structure.md">Structure</a>
       </nav>
     </header>
 
@@ -117,8 +117,8 @@ localize memory stats --memory-file logs/translation_memory.json</code></pre>
         </div>
         <div class="doc-list" aria-label="Implementation references">
           <a href="repository-structure.md">Repository structure</a>
-          <a href="../examples/generic-java-properties/README.md">Java .properties example</a>
-          <a href="../examples/generic-json/README.md">JSON example</a>
+          <a href="localization-cli.md">CLI commands</a>
+          <a href="how-to-run-locally.md">Local runs</a>
           <a href="adding-new-locales.md">Adding locales</a>
         </div>
       </section>
@@ -139,7 +139,7 @@ localize memory stats --memory-file logs/translation_memory.json</code></pre>
 
     <footer class="site-footer">
       <span>Localize Pipeline</span>
-      <a href="../README.md">Project README</a>
+      <a href="repository-structure.md">Repository structure</a>
       <a href="how-to-run-locally.md">Run locally</a>
       <a href="maintenance/disk-space-management.md">Maintenance</a>
     </footer>

--- a/tests/unit/test_docs_site.py
+++ b/tests/unit/test_docs_site.py
@@ -1,0 +1,77 @@
+"""Static checks for the public docs homepage."""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DOCS_ROOT = PROJECT_ROOT / "docs"
+
+
+class _LinkParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag not in {"a", "link", "script", "img"}:
+            return
+        attr_name = "href" if tag in {"a", "link"} else "src"
+        for name, value in attrs:
+            if name == attr_name and value:
+                self.links.append(value)
+
+
+def _homepage_links() -> list[str]:
+    parser = _LinkParser()
+    parser.feed((DOCS_ROOT / "index.html").read_text(encoding="utf-8"))
+    return parser.links
+
+
+def test_docs_homepage_is_packaged_for_github_pages():
+    homepage = DOCS_ROOT / "index.html"
+    stylesheet = DOCS_ROOT / "assets" / "site.css"
+    readme = PROJECT_ROOT / "README.md"
+
+    assert homepage.exists()
+    assert stylesheet.exists()
+
+    html = homepage.read_text(encoding="utf-8")
+    css = stylesheet.read_text(encoding="utf-8")
+
+    assert "<title>Localize Pipeline" in html
+    assert 'href="assets/site.css"' in html
+    assert "localize bootstrap-pr" in html
+    assert "localize memory stats" in html
+    assert "GitHub Action" in html
+    assert "Java .properties" in html
+    assert "JSON" in html
+    assert ".hero" in css
+    assert "@media" in css
+    assert "[docs/index.html](docs/index.html)" in readme.read_text(encoding="utf-8")
+
+
+def test_docs_homepage_links_to_primary_guides():
+    links = set(_homepage_links())
+
+    assert "localization-cli.md" in links
+    assert "github-action.md" in links
+    assert "new-project-deployment.md" in links
+    assert "../README.md" in links
+    assert "../examples/generic-json/README.md" in links
+
+
+def test_docs_homepage_internal_links_exist():
+    for link in _homepage_links():
+        parsed = urlparse(link)
+        if parsed.scheme or parsed.netloc or link.startswith("#") or link.startswith("mailto:"):
+            continue
+        target = (DOCS_ROOT / parsed.path).resolve()
+        try:
+            target.relative_to(PROJECT_ROOT)
+        except ValueError as exc:
+            raise AssertionError(f"docs homepage link escapes repository: {link}") from exc
+        assert target.exists(), f"docs homepage link is broken: {link}"

--- a/tests/unit/test_docs_site.py
+++ b/tests/unit/test_docs_site.py
@@ -60,8 +60,8 @@ def test_docs_homepage_links_to_primary_guides():
     assert "localization-cli.md" in links
     assert "github-action.md" in links
     assert "new-project-deployment.md" in links
-    assert "../README.md" in links
-    assert "../examples/generic-json/README.md" in links
+    assert "repository-structure.md" in links
+    assert "adding-new-locales.md" in links
 
 
 def test_docs_homepage_internal_links_exist():
@@ -71,7 +71,7 @@ def test_docs_homepage_internal_links_exist():
             continue
         target = (DOCS_ROOT / parsed.path).resolve()
         try:
-            target.relative_to(PROJECT_ROOT)
+            target.relative_to(DOCS_ROOT)
         except ValueError as exc:
-            raise AssertionError(f"docs homepage link escapes repository: {link}") from exc
+            raise AssertionError(f"docs homepage link escapes published docs root: {link}") from exc
         assert target.exists(), f"docs homepage link is broken: {link}"


### PR DESCRIPTION
## Summary
- add a polished no-build docs homepage under docs/index.html
- add responsive docs styling under docs/assets/site.css
- link the docs homepage from README
- add static tests for homepage content and internal links

## Validation
- OPENAI_API_KEY=sk-test-key venv/bin/ruff check .
- git diff --check
- OPENAI_API_KEY=sk-test-key venv/bin/pytest -q (480 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a polished documentation site landing page with navigation, overview content, quick links, adoption steps, and operational references.
  * Introduced a dedicated README section pointing readers to the new docs entry point.

* **Style**
  * Added full visual styling for the docs site, including responsive layouts, theming, and formatted content sections.

* **Tests**
  * Added checks to ensure the docs homepage is packaged correctly and that its links resolve to valid files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->