### PR TITLE
Create runtime queue folders

### DIFF
--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -4,6 +4,7 @@ import os
 import sys
 import tempfile
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import yaml
@@ -558,6 +559,8 @@ def load_app_config() -> AppConfig:
     translated_queue_name = config.get('translated_queue_folder', 'translated_queue')
     translation_queue_folder = os.path.join(temp_dir, translation_queue_name)
     translated_queue_folder = os.path.join(temp_dir, translated_queue_name)
+    Path(translation_queue_folder).mkdir(parents=True, exist_ok=True)
+    Path(translated_queue_folder).mkdir(parents=True, exist_ok=True)
     translation_key_ledger_file_path = config.get(
         'translation_key_ledger_file_path',
         os.path.join(project_root, 'logs', 'translation_key_ledger.json')

--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -4,7 +4,6 @@ import os
 import sys
 import tempfile
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import yaml
@@ -559,8 +558,6 @@ def load_app_config() -> AppConfig:
     translated_queue_name = config.get('translated_queue_folder', 'translated_queue')
     translation_queue_folder = os.path.join(temp_dir, translation_queue_name)
     translated_queue_folder = os.path.join(temp_dir, translated_queue_name)
-    Path(translation_queue_folder).mkdir(parents=True, exist_ok=True)
-    Path(translated_queue_folder).mkdir(parents=True, exist_ok=True)
     translation_key_ledger_file_path = config.get(
         'translation_key_ledger_file_path',
         os.path.join(project_root, 'logs', 'translation_key_ledger.json')

--- a/localize/localization_formats.py
+++ b/localize/localization_formats.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Mapping, Optional
 
 
 _BCP47_LOCALE_CODE = r"[a-z]{2,3}(?:[-_][A-Za-z0-9]{2,8})*"
+_JAVA_PROPERTIES_LOCALE_CODE = r"(?:[a-z]{2}(?:[-_][A-Za-z0-9]{2,8})*|pcm)"
 
 
 @dataclass(frozen=True)
@@ -108,7 +109,7 @@ JAVA_PROPERTIES_FORMAT = LocalizationFormat(
     display_name="Java .properties",
     file_extension=".properties",
     code_fence="properties",
-    locale_suffix_regex=rf".*_({_BCP47_LOCALE_CODE})\.properties$",
+    locale_suffix_regex=rf".*_({_JAVA_PROPERTIES_LOCALE_CODE})\.properties$",
 )
 
 JSON_FORMAT = LocalizationFormat(

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -1565,6 +1565,18 @@ def copy_translated_files_back(
                     shutil.copy2(translated_file_path, dest_path)
                     logger.info(f"Copied translated file '{translated_file_path}' back to '{dest_path}'.")
 
+def _real_path(path: str) -> str:
+    return os.path.realpath(os.path.abspath(path))
+
+
+def _paths_overlap(first_path: str, second_path: str) -> bool:
+    try:
+        common_path = os.path.commonpath([first_path, second_path])
+    except ValueError:
+        return False
+    return common_path in {first_path, second_path}
+
+
 def validate_paths(input_folder: str, translation_queue: str, translated_queue: str, repo_root: str):
     """
     Validate that the input and queue folders are usable.
@@ -1576,17 +1588,19 @@ def validate_paths(input_folder: str, translation_queue: str, translated_queue: 
         repo_root (str): Path to the Git repository root.
     """
     protected_paths = {
-        os.path.abspath(input_folder),
-        os.path.abspath(repo_root),
+        "Input Folder": _real_path(input_folder),
+        "Repository Root": _real_path(repo_root),
     }
     queue_paths = {
-        os.path.abspath(translation_queue): "Translation Queue Folder",
-        os.path.abspath(translated_queue): "Translated Queue Folder",
+        _real_path(translation_queue): "Translation Queue Folder",
+        _real_path(translated_queue): "Translated Queue Folder",
     }
     if len(queue_paths) != 2:
         raise ValueError("translation_queue and translated_queue must be different folders.")
-    if any(path in protected_paths for path in queue_paths):
-        raise ValueError("Queue folders must be separate from repo_root and input_folder.")
+    for queue_path in queue_paths:
+        for protected_path in protected_paths.values():
+            if _paths_overlap(queue_path, protected_path):
+                raise ValueError("Queue folders must be separate from repo_root and input_folder.")
 
     for path, name in [(input_folder, "Input Folder"), (repo_root, "Repository Root")]:
         if not os.path.exists(path):
@@ -1599,10 +1613,10 @@ def validate_paths(input_folder: str, translation_queue: str, translated_queue: 
             logger.error("%s '%s' is not accessible (required perms: %s).", name, path, "R+W" if required & os.W_OK else "R")
             raise PermissionError(f"{name} '{path}' lacks required permissions.")
     for path, name in queue_paths.items():
-        os.makedirs(path, exist_ok=True)
-        if not os.path.isdir(path):
+        if os.path.exists(path) and not os.path.isdir(path):
             logger.error("%s '%s' is not a directory.", name, path)
             raise NotADirectoryError(f"{name} '{path}' is not a directory.")
+        os.makedirs(path, exist_ok=True)
         if not os.access(path, os.R_OK | os.W_OK):
             logger.error("%s '%s' is not accessible (required perms: R+W).", name, path)
             raise PermissionError(f"{name} '{path}' lacks required permissions.")

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -1567,7 +1567,7 @@ def copy_translated_files_back(
 
 def validate_paths(input_folder: str, translation_queue: str, translated_queue: str, repo_root: str):
     """
-    Validate that the input and queue folders exist and are accessible.
+    Validate that the input and queue folders are usable.
 
     Args:
         input_folder (str): Path to the input folder.
@@ -1575,10 +1575,20 @@ def validate_paths(input_folder: str, translation_queue: str, translated_queue: 
         translated_queue (str): Path to the translated queue folder.
         repo_root (str): Path to the Git repository root.
     """
-    for path, name in [(input_folder, "Input Folder"),
-                       (translation_queue, "Translation Queue Folder"),
-                       (translated_queue, "Translated Queue Folder"),
-                       (repo_root, "Repository Root")]:
+    protected_paths = {
+        os.path.abspath(input_folder),
+        os.path.abspath(repo_root),
+    }
+    queue_paths = {
+        os.path.abspath(translation_queue): "Translation Queue Folder",
+        os.path.abspath(translated_queue): "Translated Queue Folder",
+    }
+    if len(queue_paths) != 2:
+        raise ValueError("translation_queue and translated_queue must be different folders.")
+    if any(path in protected_paths for path in queue_paths):
+        raise ValueError("Queue folders must be separate from repo_root and input_folder.")
+
+    for path, name in [(input_folder, "Input Folder"), (repo_root, "Repository Root")]:
         if not os.path.exists(path):
             logger.error(f"{name} '{path}' does not exist.")
             raise FileNotFoundError(f"{name} '{path}' does not exist.")
@@ -1587,6 +1597,14 @@ def validate_paths(input_folder: str, translation_queue: str, translated_queue: 
             required = os.R_OK
         if not os.access(path, required):
             logger.error("%s '%s' is not accessible (required perms: %s).", name, path, "R+W" if required & os.W_OK else "R")
+            raise PermissionError(f"{name} '{path}' lacks required permissions.")
+    for path, name in queue_paths.items():
+        os.makedirs(path, exist_ok=True)
+        if not os.path.isdir(path):
+            logger.error("%s '%s' is not a directory.", name, path)
+            raise NotADirectoryError(f"{name} '{path}' is not a directory.")
+        if not os.access(path, os.R_OK | os.W_OK):
+            logger.error("%s '%s' is not accessible (required perms: R+W).", name, path)
             raise PermissionError(f"{name} '{path}' lacks required permissions.")
     logger.info("All critical paths are valid and accessible.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -12,10 +13,11 @@ def integration_test_paths():
     """Session-scoped fixture to define the absolute paths for test directories."""
     tests_root = os.path.dirname(os.path.abspath(__file__))
     project_root = os.path.abspath(os.path.join(tests_root, '..'))
-    # Place temp dirs in the root of the tests folder for simplicity
+    scratch_root = tempfile.mkdtemp(prefix='localize_integration_')
+    # Keep the input folder under tests, but place scratch queues outside the repo.
     input_dir = os.path.join(tests_root, 'temp_integration_input')
-    translation_queue_dir = os.path.join(tests_root, 'temp_integration_translation_queue')
-    translated_queue_dir = os.path.join(tests_root, 'temp_integration_translated_queue')
+    translation_queue_dir = os.path.join(scratch_root, 'translation_queue')
+    translated_queue_dir = os.path.join(scratch_root, 'translated_queue')
     mock_glossary_path = os.path.join(tests_root, 'temp_mock_glossary.json')
     translation_memory_path = os.path.join(tests_root, 'temp_translation_memory.json')
 
@@ -25,6 +27,7 @@ def integration_test_paths():
         "translated_queue_folder": translated_queue_dir,
         "mock_glossary_path": mock_glossary_path,
         "translation_memory_path": translation_memory_path,
+        "scratch_root": scratch_root,
         "project_root": project_root
     }
 
@@ -90,6 +93,8 @@ def setup_global_test_environment(integration_test_paths):
                 logging.error(f"Failed to delete directory {folder}. Reason: {e}")
     if os.path.exists(paths['translation_memory_path']):
         os.remove(paths['translation_memory_path'])
+    if os.path.exists(paths['scratch_root']):
+        shutil.rmtree(paths['scratch_root'])
 
 
 @pytest.fixture

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -162,6 +162,19 @@ class TestLoadAppConfig:
         )
         assert config.translation_memory_enabled is True
 
+    def test_load_config_creates_default_queue_folders(self, tmp_path):
+        mock_config = {"dry_run": True}
+
+        with patch("localize.app_config._load_yaml_config", return_value=mock_config):
+            with patch("localize.app_config.tempfile.gettempdir", return_value=str(tmp_path)):
+                with patch("localize.app_config.setup_logger") as mock_logger:
+                    mock_logger.return_value = MagicMock()
+                    with patch.dict(os.environ, {}, clear=True):
+                        config = load_app_config()
+
+        assert os.path.isdir(config.translation_queue_folder)
+        assert os.path.isdir(config.translated_queue_folder)
+
     def test_load_config_reads_project_context_and_format(self):
         mock_config = {
             "dry_run": True,

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -162,7 +162,7 @@ class TestLoadAppConfig:
         )
         assert config.translation_memory_enabled is True
 
-    def test_load_config_creates_default_queue_folders(self, tmp_path):
+    def test_load_config_resolves_queue_folders_without_creating_them(self, tmp_path):
         mock_config = {"dry_run": True}
 
         with patch("localize.app_config._load_yaml_config", return_value=mock_config):
@@ -172,8 +172,11 @@ class TestLoadAppConfig:
                     with patch.dict(os.environ, {}, clear=True):
                         config = load_app_config()
 
-        assert os.path.isdir(config.translation_queue_folder)
-        assert os.path.isdir(config.translated_queue_folder)
+        assert config.translation_queue_folder == os.path.join(str(tmp_path), "translation_queue")
+        assert config.translated_queue_folder == os.path.join(str(tmp_path), "translated_queue")
+        assert not os.path.exists(config.translation_queue_folder)
+        assert not os.path.exists(config.translated_queue_folder)
+
 
     def test_load_config_reads_project_context_and_format(self):
         mock_config = {

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -19,12 +19,34 @@ from localize.translate_localization_files import (
     filter_git_changed_keys_by_source,
     get_working_tree_changed_keys,
     extract_language_from_filename,
-    run_post_translation_validation
+    run_post_translation_validation,
+    validate_paths,
 )
 from localize.properties_parser import parse_properties_file, reassemble_file
 
 
 class TestCoreLogic(unittest.TestCase):
+
+    def test_validate_paths_creates_missing_queue_folders(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_folder = os.path.join(temp_dir, 'i18n')
+            queue_folder = os.path.join(temp_dir, 'translation_queue')
+            translated_folder = os.path.join(temp_dir, 'translated_queue')
+            os.mkdir(input_folder)
+
+            validate_paths(input_folder, queue_folder, translated_folder, temp_dir)
+
+            self.assertTrue(os.path.isdir(queue_folder))
+            self.assertTrue(os.path.isdir(translated_folder))
+
+    def test_validate_paths_rejects_queue_path_collisions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_folder = os.path.join(temp_dir, 'i18n')
+            translated_folder = os.path.join(temp_dir, 'translated_queue')
+            os.mkdir(input_folder)
+
+            with self.assertRaisesRegex(ValueError, 'separate from repo_root and input_folder'):
+                validate_paths(input_folder, input_folder, translated_folder, temp_dir)
 
     def test_parse_properties_file_with_multiline_values(self):
         """

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -29,24 +29,49 @@ class TestCoreLogic(unittest.TestCase):
 
     def test_validate_paths_creates_missing_queue_folders(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            input_folder = os.path.join(temp_dir, 'i18n')
+            repo_root = os.path.join(temp_dir, 'repo')
+            input_folder = os.path.join(repo_root, 'i18n')
             queue_folder = os.path.join(temp_dir, 'translation_queue')
             translated_folder = os.path.join(temp_dir, 'translated_queue')
-            os.mkdir(input_folder)
+            os.makedirs(input_folder)
 
-            validate_paths(input_folder, queue_folder, translated_folder, temp_dir)
+            validate_paths(input_folder, queue_folder, translated_folder, repo_root)
 
             self.assertTrue(os.path.isdir(queue_folder))
             self.assertTrue(os.path.isdir(translated_folder))
 
     def test_validate_paths_rejects_queue_path_collisions(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            input_folder = os.path.join(temp_dir, 'i18n')
-            translated_folder = os.path.join(temp_dir, 'translated_queue')
-            os.mkdir(input_folder)
+            repo_root = os.path.join(temp_dir, 'repo')
+            input_folder = os.path.join(repo_root, 'i18n')
+            safe_queue = os.path.join(temp_dir, 'translation_queue')
+            safe_translated = os.path.join(temp_dir, 'translated_queue')
+            os.makedirs(input_folder)
 
-            with self.assertRaisesRegex(ValueError, 'separate from repo_root and input_folder'):
-                validate_paths(input_folder, input_folder, translated_folder, temp_dir)
+            unsafe_cases = [
+                (input_folder, safe_translated),
+                (os.path.join(repo_root, '.translation_queue'), safe_translated),
+                (temp_dir, safe_translated),
+                (safe_queue, os.path.join(input_folder, 'translated_queue')),
+            ]
+
+            for queue_folder, translated_folder in unsafe_cases:
+                with self.subTest(queue_folder=queue_folder, translated_folder=translated_folder):
+                    with self.assertRaisesRegex(ValueError, 'separate from repo_root and input_folder'):
+                        validate_paths(input_folder, queue_folder, translated_folder, repo_root)
+
+    def test_validate_paths_rejects_existing_queue_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = os.path.join(temp_dir, 'repo')
+            input_folder = os.path.join(repo_root, 'i18n')
+            queue_file = os.path.join(temp_dir, 'translation_queue')
+            translated_folder = os.path.join(temp_dir, 'translated_queue')
+            os.makedirs(input_folder)
+            with open(queue_file, 'w', encoding='utf-8') as file:
+                file.write('not a directory')
+
+            with self.assertRaises(NotADirectoryError):
+                validate_paths(input_folder, queue_file, translated_folder, repo_root)
 
     def test_parse_properties_file_with_multiline_values(self):
         """

--- a/tests/unit/test_init_config.py
+++ b/tests/unit/test_init_config.py
@@ -152,6 +152,17 @@ class TestDetectProjectLayout:
         codes = [loc["code"] for loc in detect_locales(str(tmp_path), source_locale="en")]
         assert codes == ["de"]
 
+    def test_ignores_source_filenames_with_locale_like_underscores(self, tmp_path):
+        _make_props(str(tmp_path), [
+            "mu_sig.properties",
+            "account.properties",
+            "account_de.properties",
+        ])
+
+        codes = [loc["code"] for loc in detect_locales(str(tmp_path), source_locale="en")]
+
+        assert codes == ["de"]
+
     def test_detects_json_locale_suffixes_when_requested(self, tmp_path):
         _make_json(str(tmp_path), [
             "app.json", "app_en.json", "app_de.json", "messages.pt-BR.json", "messages.es-419.json",

--- a/tests/unit/test_locale_utils.py
+++ b/tests/unit/test_locale_utils.py
@@ -25,6 +25,9 @@ class TestExtractLocaleSuffix:
         # 'test' is 4 lowercase letters -> not a valid 2-3 char language code
         assert extract_locale_suffix("app_test.properties") is None
 
+    def test_source_filename_with_three_letter_suffix_is_none(self):
+        assert extract_locale_suffix("mu_sig.properties") is None
+
 
 class TestIsLocaleFile:
     def test_true_for_locale_file(self):


### PR DESCRIPTION
## Summary
- create configured runtime queue folders during config loading and legacy path validation
- reject queue folder collisions with the repository root or input folder before cleanup can touch project files
- tighten Java .properties locale suffix detection so source files like mu_sig.properties are not treated as locale targets

## Production context
- Bisq main production is running and currently exits cleanly when Transifex has no modified files
- Bisq mobile production pulled updated target files but failed before AI processing because the runtime queue folders were missing
- this should let the next mobile run process the accumulated mobile_*.properties changes into a translation PR

## Tests
- OPENAI_API_KEY=sk-test-key venv/bin/ruff check .
- OPENAI_API_KEY=sk-test-key venv/bin/pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder handling so required translation directories are created automatically when needed.
  * Tightened path validation to prevent invalid or overlapping folder locations and provide clearer errors.
  * Refined locale detection so file names that merely look locale-like are no longer misidentified.
  * Updated recognition of language codes for certain file types, improving localized file matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->