### PR TITLE
Scope pre-translation validation

### DIFF
--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -742,6 +742,8 @@ def run_pre_translation_validation(
         target_file_path: str,
         source_file_path: str,
         localization_format: Optional[LocalizationFormat] = None,
+        git_changed_keys: Optional[Set[str]] = None,
+        file_ledger_entries: Optional[Dict[str, Dict[str, str]]] = None,
 ) -> Tuple[List[str], Set[str]]:
     """
     Runs validation and preparation checks on a target localization file.
@@ -788,13 +790,28 @@ def run_pre_translation_validation(
         errors.append(f"Could not parse localization file after key sync: {e}")
         return errors, newly_added_keys
 
+    changed_keys_for_run: Optional[Set[str]] = None
+    if git_changed_keys is not None:
+        changed_keys_for_run = newly_added_keys.union(
+            filter_git_changed_keys_by_source(
+                git_changed_keys,
+                source_translations,
+                file_ledger_entries or {},
+                target_translations=target_translations,
+            )
+        )
+
     # 3. Check placeholder parity
     common_keys = set(source_translations.keys()).intersection(set(target_translations.keys()))
     for key in common_keys:
         source_value = source_translations.get(key, "")
         target_value = target_translations.get(key, "")
         if not check_placeholder_parity(source_value, target_value):
-            errors.append(f"Placeholder mismatch for key `{key}`.")
+            message = f"Placeholder mismatch for key `{key}`."
+            if changed_keys_for_run is None or key in changed_keys_for_run:
+                errors.append(message)
+            else:
+                logger.warning("Pre-existing validation issue ignored for unchanged key in '%s': %s", filename, message)
 
     if not errors:
         logger.info(f"Pre-translation validation passed for '{filename}'.")
@@ -1936,10 +1953,19 @@ async def process_translation_queue(
         logger.info(f"Processing file '{translation_file}' for language '{target_language}'...")
 
         # --- Pre-flight Validator ---
+        file_ledger_entries = key_ledger.get(translation_file, {})
+        original_input_file_path = os.path.join(INPUT_FOLDER, translation_file)
+        raw_git_changed_keys = get_working_tree_changed_keys(
+            original_input_file_path,
+            REPO_ROOT,
+            localization_format,
+        )
         validation_errors, newly_added_keys = run_pre_translation_validation(
             translation_file_path,
             source_file_path,
             localization_format,
+            git_changed_keys=raw_git_changed_keys,
+            file_ledger_entries=file_ledger_entries,
         )
         if validation_errors:
             logger.error(f"Skipping translation for '{translation_file}' due to pre-translation validation errors.")
@@ -1965,13 +1991,7 @@ async def process_translation_queue(
         _, source_translations = adapter.parse_file(source_file_path)
 
         # Extract texts to translate
-        file_ledger_entries = key_ledger.get(translation_file, {})
-        original_input_file_path = os.path.join(INPUT_FOLDER, translation_file)
-        git_changed_keys = get_working_tree_changed_keys(
-            original_input_file_path,
-            REPO_ROOT,
-            localization_format,
-        )
+        git_changed_keys = raw_git_changed_keys
         # Only re-translate git-dirty keys if their English source actually changed.
         # This prevents an infinite cycle where Transifex community translations
         # are overwritten by AI, then Transifex re-serves the community version.
@@ -2195,8 +2215,13 @@ async def process_translation_queue(
                         f"(has_tokens={has_protection_tokens}, has_placeholders={has_real_placeholders})")
 
         # Validate each key individually and selectively revert failures
+        changed_final_translations = {
+            key: final_translations[key]
+            for key in keys_to_translate
+            if key in final_translations
+        }
         valid_translations, per_key_summary = run_per_key_validation_with_summary(
-            final_translations,
+            changed_final_translations,
             source_translations,
             translation_file
         )

--- a/localize/translation_semantic_reviewer.py
+++ b/localize/translation_semantic_reviewer.py
@@ -103,21 +103,33 @@ def normalize_review_response(
     changes: Sequence[TranslationChange],
 ) -> List[Dict[str, str]]:
     parsed = json.loads(response_text)
-    jsonschema.validate(instance=parsed, schema=SEMANTIC_REVIEW_SCHEMA)
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("findings"), list):
+        jsonschema.validate(instance=parsed, schema=SEMANTIC_REVIEW_SCHEMA)
     changes_by_identity = {(change.file, change.key): change for change in changes}
     findings: List[Dict[str, str]] = []
 
     for raw_finding in parsed.get("findings", []):
-        file = raw_finding["file"]
-        key = raw_finding["key"]
+        if not isinstance(raw_finding, dict):
+            continue
+        file = str(raw_finding.get("file") or "")
+        key = str(raw_finding.get("key") or "")
+        severity = raw_finding.get("severity")
+        reason = raw_finding.get("reason")
+        if severity not in {"error", "warning"} or not isinstance(reason, str) or not reason:
+            continue
+        if not key and file:
+            matching_changes = [change for change in changes if change.key == file]
+            if len(matching_changes) == 1:
+                file = matching_changes[0].file
+                key = matching_changes[0].key
         change = changes_by_identity.get((file, key))
         if not change:
             continue
         finding = {
             "file": change.file,
             "key": key,
-            "severity": raw_finding["severity"],
-            "reason": raw_finding["reason"],
+            "severity": severity,
+            "reason": reason,
             "value": change.new_value,
             "source": "ai-review",
             "rule_id": "ai-review",

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -20,6 +20,7 @@ from localize.translate_localization_files import (
     get_working_tree_changed_keys,
     extract_language_from_filename,
     run_post_translation_validation,
+    run_pre_translation_validation,
     validate_paths,
 )
 from localize.properties_parser import parse_properties_file, reassemble_file
@@ -72,6 +73,42 @@ class TestCoreLogic(unittest.TestCase):
 
             with self.assertRaises(NotADirectoryError):
                 validate_paths(input_folder, queue_file, translated_folder, repo_root)
+
+    def test_pre_validation_ignores_unchanged_placeholder_mismatch(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = os.path.join(temp_dir, 'mobile.properties')
+            target_path = os.path.join(temp_dir, 'mobile_de.properties')
+            with open(source_path, 'w', encoding='utf-8') as file:
+                file.write('old.key=Old {0}\nnew.key=New {0}\n')
+            with open(target_path, 'w', encoding='utf-8') as file:
+                file.write('old.key=Alt\nnew.key=New {0}\n')
+
+            errors, _newly_added_keys = run_pre_translation_validation(
+                target_path,
+                source_path,
+                git_changed_keys={'new.key'},
+                file_ledger_entries={},
+            )
+
+            self.assertEqual(errors, [])
+
+    def test_pre_validation_blocks_changed_placeholder_mismatch(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = os.path.join(temp_dir, 'mobile.properties')
+            target_path = os.path.join(temp_dir, 'mobile_de.properties')
+            with open(source_path, 'w', encoding='utf-8') as file:
+                file.write('old.key=Old {0}\nnew.key=New {0}\n')
+            with open(target_path, 'w', encoding='utf-8') as file:
+                file.write('old.key=Alt\nnew.key=Neu\n')
+
+            errors, _newly_added_keys = run_pre_translation_validation(
+                target_path,
+                source_path,
+                git_changed_keys={'new.key'},
+                file_ledger_entries={},
+            )
+
+            self.assertEqual(errors, ['Placeholder mismatch for key `new.key`.'])
 
     def test_parse_properties_file_with_multiline_values(self):
         """

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -129,6 +129,38 @@ def test_normalize_review_response_matches_duplicate_keys_by_file_and_key():
     assert findings[0]["value"] == "Limpiar"
 
 
+def test_normalize_review_response_recovers_key_written_as_file():
+    response = json.dumps(
+        {
+            "findings": [
+                {
+                    "file": "mobile.connectivity.reconnecting.client.details.ios",
+                    "severity": "error",
+                    "reason": "Still in English.",
+                    "suggested_value": "Localized value.",
+                }
+            ]
+        }
+    )
+    changes = [
+        TranslationChange(
+            file="resources/mobile_id.properties",
+            locale_code="id",
+            key="mobile.connectivity.reconnecting.client.details.ios",
+            source_value="This may occur if the app was in the background.",
+            old_value=None,
+            new_value="This may occur if the app was in the background.",
+        )
+    ]
+
+    findings = normalize_review_response(response, changes)
+
+    assert len(findings) == 1
+    assert findings[0]["file"] == "resources/mobile_id.properties"
+    assert findings[0]["key"] == "mobile.connectivity.reconnecting.client.details.ios"
+    assert findings[0]["suggested_value"] == "Localized value."
+
+
 def test_append_semantic_review_findings_preserves_existing_summary(tmp_path):
     summary_path = tmp_path / "translation_validation_summary.json"
     summary_path.write_text(


### PR DESCRIPTION
## Summary
- validate pre-existing placeholder mismatches as hard errors only when they affect keys changed in the current run
- keep per-key validation scoped to generated/current-run translations so old target-file debt does not skip unrelated new strings
- make semantic review tolerate malformed model findings where the key is accidentally returned in the file field

## Production context
- the mobile production rerun after PR #94 created bisq-mobile PR #1549, proving the queue-folder outage is fixed
- PR #1549 failed quality gate because 12 locale files were skipped due old placeholder mismatches unrelated to the new FAQ/connectivity strings
- this patch lets those new keys translate while keeping deterministic validation for generated output

## Tests
- OPENAI_API_KEY=sk-test-key venv/bin/ruff check .
- git diff --check
- OPENAI_API_KEY=sk-test-key venv/bin/pytest -q