### PR TITLE
Ignore prose percentages in placeholder detection

### DIFF
--- a/localize/placeholder_rules.py
+++ b/localize/placeholder_rules.py
@@ -12,7 +12,7 @@ _HTML_TAG = r"<[^<>]+>"
 _I18NEXT_TOKEN = r"\{\{[^{}\n]+\}\}"
 _BRACE_TOKEN = r"\{[A-Za-z0-9_][^{}\n]*\}"
 _PYTHON_NAMED_PRINTF = r"%\([^)]+\)[#0 +\-]*(?:\d+|\*)?(?:\.(?:\d+|\*))?[a-zA-Z]"
-_POSITIONAL_PRINTF = r"%(?:\d+\$)?[#0 +\-]*(?:\d+|\*)?(?:\.(?:\d+|\*))?[a-zA-Z@]"
+_POSITIONAL_PRINTF = r"%(?:\d+\$)?[#0+\-]*(?:\d+|\*)?(?:\.(?:\d+|\*))?[a-zA-Z@]"
 
 PLACEHOLDER_PATTERN = re.compile(
     "|".join(

--- a/tests/unit/test_placeholder_rules.py
+++ b/tests/unit/test_placeholder_rules.py
@@ -34,6 +34,24 @@ def test_placeholder_parity_rejects_missing_i18next_token():
     assert not check_placeholder_parity("Hello {{name}}", "Hallo")
 
 
+def test_literal_percent_prose_is_not_a_placeholder():
+    source = "Trade price must be greater than -10% of market price"
+    target = "Handelspreis muss größer als -10% des Marktpreises sein"
+
+    assert extract_placeholder_tokens(source) == Counter()
+    assert extract_placeholder_tokens(target) == Counter()
+    assert check_placeholder_parity(source, target)
+
+
+def test_percent_after_brace_placeholder_is_literal_in_prose():
+    source = "Starting Tor {0}%"
+    target = "Tor {0}% başlatılıyor"
+
+    assert extract_placeholder_tokens(source) == Counter({"{0}": 1})
+    assert extract_placeholder_tokens(target) == Counter({"{0}": 1})
+    assert check_placeholder_parity(source, target)
+
+
 def test_json_structural_braces_are_not_placeholders():
     source = '{\n  "/title": "Title"\n}'
     target = '{\n  "/title": "Titel"\n}'


### PR DESCRIPTION
## Summary
- stop treating literal percentage prose like `10% of` or `{0}% başlatılıyor` as printf placeholders
- keep existing positional/named printf, brace, i18next, and HTML placeholder support
- add regression coverage for the mobile price/Tor strings that triggered false placeholder debt

## Validation
- `OPENAI_API_KEY=sk-test-key venv/bin/ruff check .`
- `git diff --check`
- `OPENAI_API_KEY=sk-test-key venv/bin/pytest -q`