### PR TITLE
Harden Localize Pipeline reuse and agent setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Localize Pipeline
 
-AI localization for projects that want translations as normal pull requests.
+Agent-friendly AI localization for projects that want translations as normal
+pull requests.
 
 Localize Pipeline detects changed source strings, translates the matching target
 locale entries, runs deterministic and AI review checks, and opens a PR that your
 team can inspect before merge. It runs in your CI or on your own server with your
 model provider and your credentials.
+
+Repository: <https://github.com/bisq-network/localize-pipeline>
 
 ## Why Use It
 
@@ -22,6 +25,8 @@ model provider and your credentials.
   projects use a profile list.
 - **Reusable by other projects.** The stable surfaces are the `localize` CLI,
   `localize.core`, `localize.formats`, and `localize.providers`.
+- **Agent discoverable.** `llms.txt`, examples, profiles, and docs point agents
+  to stable commands and module boundaries.
 
 ## Quickstart
 
@@ -34,6 +39,8 @@ python3 -m venv venv
 ./venv/bin/pip install -e .
 localize init
 localize check --config config.yaml
+localize doctor --config config.yaml
+localize smoke --config config.yaml
 localize run --dry-run --config config.yaml
 ```
 
@@ -102,7 +109,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/translate-java-property-files@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.0
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -173,6 +180,8 @@ Examples:
 - [examples/generic-json](examples/generic-json) shows JSON.
 - [profiles/bisq](profiles/bisq) is the production Bisq profile with richer
   style and semantic QA rules.
+- [profiles/bisq-mobile](profiles/bisq-mobile) mirrors the production mobile
+  profile shape without secrets.
 
 ## CLI
 
@@ -180,9 +189,12 @@ Examples:
 localize formats
 localize init
 localize check --config config.yaml
+localize doctor --config config.yaml
+localize smoke --config config.yaml
 localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
+localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
 localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
 localize memory stats --memory-file logs/translation_memory.json
 ```
@@ -232,6 +244,17 @@ Use these packages for reusable code:
 Avoid importing implementation modules directly unless you are contributing to
 this repository.
 
+## Modularity Guardrails
+
+Java properties, JSON, Bisq, and Bisq mobile are supported profiles, not core
+assumptions. New validation, queue handling, prompt behavior, and publishing
+logic should flow through config, adapters, providers, connectors, or profiles.
+
+Before adding another localization format, use
+[docs/new-format-checklist.md](docs/new-format-checklist.md). The minimum bar is
+an adapter, conformance tests, realistic placeholder/escaping coverage, an
+example project, dry-run integration coverage, and docs.
+
 ## Translation Memory
 
 The runtime maintains an exact-match translation memory at
@@ -274,7 +297,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/translate-java-property-files@v0.1.0
+- uses: bisq-network/localize-pipeline@v0.1.0
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: "AI localization translation"
+name: "Localize Pipeline"
 description: >-
-  Translate changed Java .properties or JSON localization files with OpenAI,
-  AISuite providers, or a local OpenAI-compatible endpoint, then open a pull
-  request from your CI workflow.
+  Agent-friendly AI localization pipeline that translates changed Java
+  .properties or JSON files with AISuite, OpenAI-compatible endpoints, or local
+  models, then opens a reviewable pull request.
 
 branding:
   icon: globe

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,7 +2,7 @@
 #
 # This is a small, generic starting point. For a richer, real-world example with
 # per-locale style rules, learned semantic quality rules, and a large glossary,
-# see profiles/bisq/config.yaml (the Bisq production profile).
+# see profiles/bisq/config.yaml and profiles/bisq-mobile/config.yaml.
 #
 # Tip: run `localize init --input-folder path/to/i18n` to scaffold this automatically
 # by detecting the locales from your existing localization files.
@@ -51,6 +51,14 @@ translation_source: "git"
 model_provider: "aisuite"           # Default AISuite-backed provider abstraction.
 model_name: "gpt-4o-mini"          # fast initial translation
 review_model_name: "gpt-4o"        # holistic review pass (set equal to model_name to save cost)
+
+# Optional semantic sidecar. If auto_apply_error_suggestions is true, only
+# error-level findings with concrete suggested_value are applied, and only after
+# deterministic placeholder/control-character checks pass.
+# semantic_review:
+#   enabled: true
+#   model: "gpt-4o"
+#   auto_apply_error_suggestions: false
 
 # (Optional) OpenAI-compatible endpoint. Point this at a local Ollama server to
 # translate with zero data egress and no API key (set the model names to a model

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/translate-java-property-files@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.0
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -88,7 +88,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/translate-java-property-files@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.0
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -107,7 +107,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/translate-java-property-files@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.0
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/translate-java-property-files@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.0
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}
@@ -176,7 +176,7 @@ inputs are passed through environment variables, not interpolated directly into
 shell scripts.
 
 Pin a tagged release for production workflows. A workflow reference such as
-`bisq-network/translate-java-property-files@main` follows unreleased changes;
+`bisq-network/localize-pipeline@main` follows unreleased changes;
 use it only when that is intentional.
 
 ## Custom Formats

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -25,9 +25,12 @@ For development:
 localize formats
 localize init
 localize check --config config.yaml
+localize doctor --config config.yaml
+localize smoke --config config.yaml
 localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
+localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
 localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
 localize memory stats --memory-file logs/translation_memory.json
 ```
@@ -37,8 +40,11 @@ localize memory stats --memory-file logs/translation_memory.json
 | `formats` | Lists registered formats and whether each has a runtime adapter. |
 | `init` | Scaffolds a dry-run config and detects input folder, formats, layouts, and locales from existing files. |
 | `check` | Runs self-service preflight checks for config, paths, formats, endpoint, and required credentials. |
+| `doctor` | Prints redacted effective config for deploy debugging: profile, folders, provider, endpoint, and semantic review. |
+| `smoke` | Runs read-only startup checks and creates runtime scratch directories without translation or GitHub mutation. |
 | `validate` | Checks config shape, paths, locales, formats, layouts, and endpoint settings. |
 | `run` | Executes the translation pipeline. Use `--dry-run` to force a preview without editing config. |
+| `quality-gate` | Recomputes the PR quality-gate JSON/Markdown report for changed files after manual fixes. |
 | `bootstrap-pr` | Creates an onboarding branch with generated config, glossary, and GitHub workflow files. |
 | `memory` | Inspects, imports, exports, promotes, and suggests translation-memory entries. |
 
@@ -146,6 +152,22 @@ localization_formats:
 Every runtime component resolves a queued file to one profile before source-file
 lookup, parsing, validation, prompt construction, semantic review, quality gate
 checks, serialization, and publishing.
+
+## Semantic Review Remediation
+
+Profiles can let the AI semantic reviewer auto-apply concrete error-level
+suggestions before the PR quality gate runs:
+
+```yaml
+semantic_review:
+  enabled: true
+  auto_apply_error_suggestions: true
+```
+
+Only findings with `severity: error` and `suggested_value` are considered. The
+pipeline applies a suggestion only when the configured format adapter can find
+the file/key and deterministic checks confirm placeholder parity and control
+characters. Skipped suggestions stay in the quality report for manual review.
 
 ## JSON Behavior
 

--- a/docs/new-format-checklist.md
+++ b/docs/new-format-checklist.md
@@ -1,0 +1,41 @@
+# New Localization Format Checklist
+
+Localize Pipeline treats Java properties and JSON as built-in examples, not as
+architectural defaults. Add every new file format through the same adapter and
+profile boundaries.
+
+## Required Work
+
+1. Add a `LocalizationFormat` entry with a stable id, display name, file
+   extension, code fence, and locale detection rules.
+2. Add a `LocalizationFileAdapter` implementation for parse, reassemble,
+   synchronize, lint, diff-key extraction, review rendering, and escaping.
+3. Add adapter conformance tests that prove parse/reassemble is lossless for the
+   format features you support.
+4. Add changed-key detection tests from a realistic git diff.
+5. Add placeholder and escaping tests using representative strings from that
+   ecosystem.
+6. Add a minimal example project under `examples/`.
+7. Add a dry-run integration test that uses `localize run --dry-run` with the
+   example config.
+8. Update `localize init` autodetection when the format can be detected safely.
+9. Document config snippets, layout choices, placeholder rules, and known limits.
+
+## Guardrails
+
+- Keep project-specific rules in `profiles/<project>/`, not in `localize.core`.
+- Do not hardcode paths, queue folders, source repositories, or provider choices
+  inside adapters.
+- Keep validation scoped to changed keys unless the profile explicitly requests a
+  full audit.
+- Preserve source comments and ordering when the target format supports them.
+- If a deterministic rule cannot validate a suggestion, skip the suggestion and
+  surface it in the quality report instead of mutating the file.
+
+## Definition Of Done
+
+- `pytest` passes.
+- `localize formats` lists the format.
+- `localize init` either detects the format or documents why it cannot.
+- `localize check`, `localize doctor`, and `localize smoke` pass for the example.
+- `localize quality-gate` can re-run on a generated PR diff for the format.

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -43,6 +43,7 @@ This project has three supported surfaces:
 | `localize/translate_localization_files.py` | Runtime translation pipeline. |
 | `localize/translation_quality_gate.py` | Deterministic PR quality gate. |
 | `localize/translation_semantic_reviewer.py` | AI semantic review sidecar. |
+| `localize/semantic_remediation.py` | Optional safe auto-application of AI review suggestions. |
 | `localize/semantic_quality.py` | Semantic QA rule evaluation. |
 
 Downstream projects should import from:
@@ -58,6 +59,7 @@ Implementation modules are for contributors to this repository.
 | Path | Purpose |
 | --- | --- |
 | `profiles/bisq/` | Production Bisq profile and glossary. |
+| `profiles/bisq-mobile/` | Sanitized Bisq mobile production-shape profile and glossary. |
 | `examples/generic-java-properties/` | Small Java `.properties` example. |
 | `examples/generic-json/` | Small JSON example. |
 
@@ -99,6 +101,7 @@ OPENAI_API_KEY=sk-test-key venv/bin/pytest -q
 | `docs/github-action.md` | GitHub Action setup and inputs. |
 | `docs/localization-cli.md` | CLI, plugins, custom adapters, and public API. |
 | `docs/new-project-deployment.md` | Docker Compose server deployment. |
+| `docs/new-format-checklist.md` | Required tests/docs for adding localization formats. |
 | `docs/adding-new-locales.md` | Locale onboarding workflow. |
 | `docs/maintenance/` | Host maintenance and disk cleanup. |
 | `docs/llm/` | Historical debugging notes, not the public usage guide. |

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,57 @@
+# Localize Pipeline
+
+Agent-friendly AI localization pipeline for generating reviewable translation
+pull requests. The repository is `bisq-network/localize-pipeline`.
+
+## Use This Project For
+
+- Translating changed localization strings into pull requests.
+- Java properties and JSON localization files.
+- Mixed-format localization projects through configured profiles.
+- GitHub Actions, local CLI dry-runs, or Docker Compose plus cron deployments.
+- AISuite, OpenAI-compatible endpoints, or local model endpoints.
+
+## Stable Agent Entry Points
+
+- `README.md` - product overview and quickstart.
+- `docs/localization-cli.md` - full `localize` CLI reference.
+- `docs/github-action.md` - reusable GitHub Action setup.
+- `docs/new-project-deployment.md` - Docker/server deployment.
+- `docs/repository-structure.md` - module boundaries.
+- `docs/new-format-checklist.md` - required work for future formats.
+- `config.example.yaml` - minimal generic starter config.
+- `examples/generic-java-properties/` - Java properties example.
+- `examples/generic-json/` - JSON example.
+- `profiles/bisq/` and `profiles/bisq-mobile/` - production profile examples.
+
+## Commands Agents Should Prefer
+
+```bash
+localize init
+localize check --config config.yaml
+localize doctor --config config.yaml
+localize smoke --config config.yaml
+localize run --dry-run --config config.yaml
+localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
+```
+
+## Stable Python Boundaries
+
+- `localize.core` - format-agnostic orchestration.
+- `localize.formats` - localization format adapter API and conformance helpers.
+- `localize.providers` - model provider abstraction.
+- `localize.connectors` - source, reporter, publisher, and filesystem/GitHub contracts.
+- `profiles/` - project-specific configuration, glossary, paths, locales, and policy.
+
+Treat `profiles/bisq/` as one production profile, not as a product default.
+Treat `profiles/bisq-mobile/` the same way. Core modules must stay reusable and
+must not depend on Bisq paths, terms, or Transifex behavior.
+
+## Supported Built-In Formats
+
+- Java properties (`localization_format: java_properties`)
+- JSON (`localization_format: json`)
+
+Future formats should add an adapter, adapter conformance tests, a minimal
+example, dry-run integration coverage, docs, autodetection where practical, and
+placeholder/escaping notes.

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -194,7 +194,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/translate-java-property-files@{action_ref}
+      - uses: bisq-network/localize-pipeline@{action_ref}
         with:
 {action_inputs}
 """

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -18,7 +18,9 @@ from localize.app_config import ConfigIssue, validate_config
 from localize.bootstrap_pr import BootstrapPrOptions, create_bootstrap_pr
 from localize.formats import list_localization_adapters, list_localization_formats
 from localize.init_config import main as init_config_main
+from localize.localization_profiles import load_localization_profiles
 from localize.plugins import load_plugins
+from localize.translation_quality_gate import main as translation_quality_gate_main
 from localize.translation_memory import (
     load_translation_memory_strict,
     load_translation_memory,
@@ -109,6 +111,102 @@ def _cmd_check(args: argparse.Namespace) -> int:
     return _cmd_validate_config(args, success_message="Preflight OK")
 
 
+def _resolve_input_folder(config: dict[str, Any]) -> Path:
+    target_root = Path(str(config.get("target_project_root") or ".")).expanduser()
+    input_folder = Path(str(config.get("input_folder") or ".")).expanduser()
+    if not input_folder.is_absolute():
+        input_folder = target_root / input_folder
+    return input_folder.resolve()
+
+
+def _runtime_dir(raw_path: Any, *, config_path: Path) -> Path:
+    path = Path(str(raw_path)).expanduser()
+    if path.is_absolute():
+        return path
+    return (config_path.parent / path).resolve()
+
+
+def _load_checked_config(config_path: Path) -> tuple[dict[str, Any], list[ConfigIssue]]:
+    config = _load_config_file(config_path)
+    review_model_override = os.environ.get("REVIEW_MODEL_NAME")
+    if review_model_override:
+        config = {**config, "review_model_name": review_model_override}
+    issues = validate_config(
+        config,
+        effective_api_base_url=_effective_api_base_url(config),
+        api_key_available=bool(os.environ.get("OPENAI_API_KEY")),
+        dry_run_override=_effective_dry_run_override(),
+    )
+    return config, issues
+
+
+def _cmd_doctor(args: argparse.Namespace) -> int:
+    config_path = Path(args.config).expanduser().resolve()
+    if not config_path.exists():
+        print(f"error: configuration file not found: {config_path}", file=sys.stderr)
+        return 1
+    try:
+        config, issues = _load_checked_config(config_path)
+        profiles = load_localization_profiles(config)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"error: could not inspect configuration: {exc}", file=sys.stderr)
+        return 1
+
+    profile = os.environ.get("TRANSLATOR_PROFILE") or "default"
+    target_root = Path(str(config.get("target_project_root") or ".")).expanduser().resolve()
+    input_folder = _resolve_input_folder(config)
+    semantic_review = config.get("semantic_review", {}) or {}
+    semantic_status = "enabled" if bool(semantic_review.get("enabled", False)) else "disabled"
+    api_base_url = _effective_api_base_url(config) or "default"
+    model_provider = str(config.get("model_provider", "aisuite"))
+    queue = _runtime_dir(config.get("translation_queue_folder", "translation_queue"), config_path=config_path)
+    translated = _runtime_dir(config.get("translated_queue_folder", "translated_queue"), config_path=config_path)
+    formats = ", ".join(
+        f"{profile.localization_format.id}/{profile.localization_layout.id}"
+        for profile in profiles
+    )
+
+    print("Localize Pipeline doctor")
+    print(f"profile: {profile}")
+    print(f"config: {config_path}")
+    print(f"target_project_root: {target_root}")
+    print(f"input_folder: {input_folder}")
+    print(f"translation_queue_folder: {queue}")
+    print(f"translated_queue_folder: {translated}")
+    print(f"localization_profiles: {formats}")
+    print(f"model_provider: {model_provider}")
+    print(f"model_name: {config.get('model_name', 'gpt-4')}")
+    print(f"review_model_name: {config.get('review_model_name', config.get('model_name', 'gpt-4'))}")
+    print(f"api_base_url: {api_base_url}")
+    print(f"semantic_review: {semantic_status}")
+    print(f"OPENAI_API_KEY: {'set' if os.environ.get('OPENAI_API_KEY') else 'unset'}")
+    _print_config_issues(issues)
+    return 1 if any(issue.level == "error" for issue in issues) else 0
+
+
+def _cmd_smoke(args: argparse.Namespace) -> int:
+    config_path = Path(args.config).expanduser().resolve()
+    if not config_path.exists():
+        print(f"error: configuration file not found: {config_path}", file=sys.stderr)
+        return 1
+    try:
+        config, issues = _load_checked_config(config_path)
+        load_localization_profiles(config)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"error: smoke check failed: {exc}", file=sys.stderr)
+        return 1
+    _print_config_issues(issues)
+    if any(issue.level == "error" for issue in issues):
+        return 1
+
+    queue = _runtime_dir(config.get("translation_queue_folder", "translation_queue"), config_path=config_path)
+    translated = _runtime_dir(config.get("translated_queue_folder", "translated_queue"), config_path=config_path)
+    queue.mkdir(parents=True, exist_ok=True)
+    translated.mkdir(parents=True, exist_ok=True)
+    print("Smoke OK")
+    return 0
+
+
 def _cmd_run(args: argparse.Namespace) -> int:
     config_path = Path(args.config).expanduser().resolve()
     os.environ["TRANSLATOR_CONFIG_FILE"] = str(config_path)
@@ -158,6 +256,28 @@ def _cmd_bootstrap_pr(args: argparse.Namespace) -> int:
     else:
         print("Review the branch, then push/open a pull request when ready")
     return 0
+
+
+def _cmd_quality_gate(args: argparse.Namespace) -> int:
+    quality_args = [
+        "--repo-root",
+        args.repo_root,
+        "--input-folder",
+        args.input_folder,
+        "--config",
+        args.config,
+        "--validation-summary",
+        args.validation_summary,
+        "--output-json",
+        args.output_json,
+        "--output-markdown",
+        args.output_markdown,
+    ]
+    if args.audit_scope:
+        quality_args.extend(["--audit-scope", args.audit_scope])
+    quality_args.append("--changed-files")
+    quality_args.extend(args.changed_files)
+    return int(translation_quality_gate_main(quality_args))
 
 
 def _print_memory_stats(args: argparse.Namespace) -> int:
@@ -332,6 +452,20 @@ def _build_parser() -> argparse.ArgumentParser:
     check_parser.add_argument("--config", default="config.yaml", help="Path to config.yaml.")
     check_parser.set_defaults(func=_cmd_check)
 
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Print redacted effective config for deploy/debug checks.",
+    )
+    doctor_parser.add_argument("--config", default="config.yaml", help="Path to config.yaml.")
+    doctor_parser.set_defaults(func=_cmd_doctor)
+
+    smoke_parser = subparsers.add_parser(
+        "smoke",
+        help="Run read-only startup checks and create runtime scratch directories.",
+    )
+    smoke_parser.add_argument("--config", default="config.yaml", help="Path to config.yaml.")
+    smoke_parser.set_defaults(func=_cmd_smoke)
+
     run_parser = subparsers.add_parser(
         "run",
         help="Run the configured translation pipeline.",
@@ -408,6 +542,20 @@ def _build_parser() -> argparse.ArgumentParser:
     bootstrap_parser.add_argument("--push", action="store_true", help="Push the onboarding branch to origin.")
     bootstrap_parser.add_argument("--open-pr", action="store_true", help="Push and open the onboarding PR with gh.")
     bootstrap_parser.set_defaults(func=_cmd_bootstrap_pr)
+
+    quality_parser = subparsers.add_parser(
+        "quality-gate",
+        help="Recompute the translation quality gate report for changed files.",
+    )
+    quality_parser.add_argument("--repo-root", required=True)
+    quality_parser.add_argument("--input-folder", required=True)
+    quality_parser.add_argument("--config", required=True)
+    quality_parser.add_argument("--validation-summary", required=True)
+    quality_parser.add_argument("--output-json", required=True)
+    quality_parser.add_argument("--output-markdown", required=True)
+    quality_parser.add_argument("--changed-files", nargs="+", required=True)
+    quality_parser.add_argument("--audit-scope", choices=["changed", "all"], default=None)
+    quality_parser.set_defaults(func=_cmd_quality_gate)
 
     memory_parser = subparsers.add_parser(
         "memory",

--- a/localize/semantic_remediation.py
+++ b/localize/semantic_remediation.py
@@ -1,0 +1,169 @@
+"""Apply safe semantic-review suggestions to localization files."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping, Sequence
+
+from localize.localization_adapters import get_localization_adapter
+from localize.localization_profiles import LocalizationProfile
+from localize.translation_validator import (
+    check_placeholder_parity,
+    find_disallowed_control_characters,
+)
+
+
+@dataclass
+class SemanticRemediationResult:
+    """Summary of semantic review suggestions applied to files."""
+
+    applied: list[Dict[str, str]] = field(default_factory=list)
+    skipped: list[Dict[str, str]] = field(default_factory=list)
+
+    @property
+    def applied_count(self) -> int:
+        return len(self.applied)
+
+    @property
+    def skipped_count(self) -> int:
+        return len(self.skipped)
+
+    @property
+    def applied_identities(self) -> set[tuple[str, str]]:
+        return {
+            (item["file"], item["key"])
+            for item in self.applied
+        }
+
+
+def _input_folder_path(repo_root: str, input_folder: str) -> Path:
+    path = Path(input_folder).expanduser()
+    if path.is_absolute():
+        return path
+    return (Path(repo_root).expanduser() / path).resolve()
+
+
+def _finding_file_path(input_folder: Path, file_name: str) -> Path:
+    path = Path(file_name)
+    if path.is_absolute():
+        return path
+    return input_folder / path
+
+
+def _relative_to_input(path: Path, input_folder: Path) -> str:
+    try:
+        return path.relative_to(input_folder).as_posix()
+    except ValueError:
+        return os.path.relpath(path, input_folder)
+
+
+def _matching_profile(
+    relative_file: str,
+    locale_codes: Sequence[str],
+    localization_profiles: Sequence[LocalizationProfile],
+) -> LocalizationProfile | None:
+    for profile in localization_profiles:
+        if not profile.localization_format.is_supported_file(relative_file):
+            continue
+        if profile.localization_layout.is_target_file(
+            relative_file,
+            locale_codes,
+            profile.localization_format,
+        ):
+            return profile
+    return None
+
+
+def _skip(result: SemanticRemediationResult, finding: Mapping[str, Any], reason: str) -> None:
+    result.skipped.append({
+        "file": str(finding.get("file", "")),
+        "key": str(finding.get("key", "")),
+        "reason": reason,
+    })
+
+
+def apply_semantic_review_suggestions(
+    *,
+    repo_root: str,
+    input_folder: str,
+    findings: Sequence[Mapping[str, Any]],
+    locale_codes: Sequence[str],
+    localization_profiles: Sequence[LocalizationProfile],
+) -> SemanticRemediationResult:
+    """Apply error-level AI review suggestions that pass deterministic checks.
+
+    Suggestions are intentionally conservative: the finding must name a changed
+    target file/key, provide ``suggested_value``, map to a configured format
+    profile, and preserve source placeholder parity.
+    """
+    result = SemanticRemediationResult()
+    input_path = _input_folder_path(repo_root, input_folder)
+
+    for finding in findings:
+        if str(finding.get("severity", "")).lower() != "error":
+            _skip(result, finding, "only error-level findings are auto-applied")
+            continue
+        suggested_value = finding.get("suggested_value")
+        if not isinstance(suggested_value, str) or not suggested_value:
+            _skip(result, finding, "missing suggested_value")
+            continue
+        file_name = str(finding.get("file") or "")
+        key = str(finding.get("key") or "")
+        if not file_name or not key:
+            _skip(result, finding, "missing file or key")
+            continue
+
+        target_path = _finding_file_path(input_path, file_name)
+        if not target_path.exists():
+            _skip(result, finding, "target file not found")
+            continue
+        relative_file = _relative_to_input(target_path, input_path)
+        profile = _matching_profile(relative_file, locale_codes, localization_profiles)
+        if profile is None:
+            _skip(result, finding, "no configured localization profile matched the target file")
+            continue
+
+        adapter = get_localization_adapter(profile.localization_format)
+        parsed_lines, target_translations = adapter.parse_file(str(target_path))
+        if key not in target_translations:
+            _skip(result, finding, "key not found in target file")
+            continue
+
+        source_rel = profile.localization_layout.source_path_for_target(
+            relative_file,
+            locale_codes,
+            profile.localization_format,
+        )
+        source_path = input_path / source_rel
+        if not source_path.exists():
+            _skip(result, finding, "source file not found")
+            continue
+        _, source_translations = adapter.parse_file(str(source_path))
+        source_value = source_translations.get(key)
+        if source_value is None:
+            _skip(result, finding, "source key not found")
+            continue
+
+        escaped_value = adapter.escape_translation(source_value, suggested_value)
+        if find_disallowed_control_characters(escaped_value):
+            _skip(result, finding, "suggestion contains disallowed control characters")
+            continue
+        if not check_placeholder_parity(source_value, escaped_value):
+            _skip(result, finding, "suggestion does not preserve source placeholders")
+            continue
+
+        for line in parsed_lines:
+            if line.get("type") == "entry" and line.get("key") == key:
+                line["value"] = escaped_value
+                break
+        target_path.write_text(adapter.reassemble_file(parsed_lines), encoding="utf-8")
+        result.applied.append({
+            "file": relative_file,
+            "key": key,
+            "suggested_value": escaped_value,
+            "source": str(finding.get("source", "ai-review")),
+        })
+
+    return result

--- a/localize/semantic_remediation.py
+++ b/localize/semantic_remediation.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import os
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Mapping, Sequence
+from typing import Any, Dict, Iterable, Mapping, Sequence
 
 from localize.localization_adapters import get_localization_adapter
 from localize.localization_profiles import LocalizationProfile
@@ -37,11 +37,19 @@ class SemanticRemediationResult:
             for item in self.applied
         }
 
+    @property
+    def applied_finding_signatures(self) -> set[str]:
+        return {
+            item["finding_signature"]
+            for item in self.applied
+            if item.get("finding_signature")
+        }
+
 
 def _input_folder_path(repo_root: str, input_folder: str) -> Path:
     path = Path(input_folder).expanduser()
     if path.is_absolute():
-        return path
+        return path.resolve()
     return (Path(repo_root).expanduser() / path).resolve()
 
 
@@ -52,11 +60,36 @@ def _finding_file_path(input_folder: Path, file_name: str) -> Path:
     return input_folder / path
 
 
-def _relative_to_input(path: Path, input_folder: Path) -> str:
+def _resolve_within(base: Path, candidate: Path) -> Path | None:
+    resolved_base = base.resolve()
+    resolved_candidate = candidate.resolve()
     try:
-        return path.relative_to(input_folder).as_posix()
+        resolved_candidate.relative_to(resolved_base)
     except ValueError:
-        return os.path.relpath(path, input_folder)
+        return None
+    return resolved_candidate
+
+
+def semantic_review_finding_signature(
+    finding: Mapping[str, Any],
+    *,
+    file_name: str | None = None,
+    key: str | None = None,
+) -> str:
+    """Return a stable identity for one concrete semantic-review finding."""
+    return json.dumps(
+        [
+            file_name if file_name is not None else str(finding.get("file", "")),
+            key if key is not None else str(finding.get("key", "")),
+            str(finding.get("severity", "")),
+            str(finding.get("reason", "")),
+            str(finding.get("suggested_value", "")),
+            str(finding.get("source", "")),
+            str(finding.get("rule_id", "")),
+        ],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
 
 
 def _matching_profile(
@@ -91,6 +124,7 @@ def apply_semantic_review_suggestions(
     findings: Sequence[Mapping[str, Any]],
     locale_codes: Sequence[str],
     localization_profiles: Sequence[LocalizationProfile],
+    changed_identities: Iterable[tuple[str, str]],
 ) -> SemanticRemediationResult:
     """Apply error-level AI review suggestions that pass deterministic checks.
 
@@ -100,6 +134,8 @@ def apply_semantic_review_suggestions(
     """
     result = SemanticRemediationResult()
     input_path = _input_folder_path(repo_root, input_folder)
+    changed_identity_set = set(changed_identities)
+    seen_candidate_identities: set[tuple[str, str]] = set()
 
     for finding in findings:
         if str(finding.get("severity", "")).lower() != "error":
@@ -115,11 +151,23 @@ def apply_semantic_review_suggestions(
             _skip(result, finding, "missing file or key")
             continue
 
-        target_path = _finding_file_path(input_path, file_name)
+        target_path = _resolve_within(input_path, _finding_file_path(input_path, file_name))
+        if target_path is None:
+            _skip(result, finding, "target file is outside input_folder")
+            continue
         if not target_path.exists():
             _skip(result, finding, "target file not found")
             continue
-        relative_file = _relative_to_input(target_path, input_path)
+        relative_file = target_path.relative_to(input_path).as_posix()
+        identity = (relative_file, key)
+        if identity not in changed_identity_set:
+            _skip(result, finding, "finding is not scoped to a changed entry")
+            continue
+        if identity in seen_candidate_identities:
+            _skip(result, finding, "duplicate finding for changed entry")
+            continue
+        seen_candidate_identities.add(identity)
+
         profile = _matching_profile(relative_file, locale_codes, localization_profiles)
         if profile is None:
             _skip(result, finding, "no configured localization profile matched the target file")
@@ -136,7 +184,10 @@ def apply_semantic_review_suggestions(
             locale_codes,
             profile.localization_format,
         )
-        source_path = input_path / source_rel
+        source_path = _resolve_within(input_path, input_path / source_rel)
+        if source_path is None:
+            _skip(result, finding, "source file is outside input_folder")
+            continue
         if not source_path.exists():
             _skip(result, finding, "source file not found")
             continue
@@ -162,8 +213,17 @@ def apply_semantic_review_suggestions(
         result.applied.append({
             "file": relative_file,
             "key": key,
+            "severity": "error",
+            "reason": str(finding.get("reason", "")),
+            "value": str(finding.get("value", "")),
+            "rule_id": str(finding.get("rule_id", "")),
             "suggested_value": escaped_value,
             "source": str(finding.get("source", "ai-review")),
+            "finding_signature": semantic_review_finding_signature(
+                finding,
+                file_name=relative_file,
+                key=key,
+            ),
         })
 
     return result

--- a/localize/translation_semantic_reviewer.py
+++ b/localize/translation_semantic_reviewer.py
@@ -25,6 +25,10 @@ from localize.semantic_quality import (
     TranslationChange,
     iter_translation_changes_from_diff,
 )
+from localize.semantic_remediation import (
+    SemanticRemediationResult,
+    apply_semantic_review_suggestions,
+)
 from localize.translation_quality_gate import get_staged_diff, load_quality_gate_localization_profiles
 
 
@@ -144,20 +148,57 @@ def append_semantic_review_findings(
     validation_summary_path: str,
     findings: Sequence[Dict[str, str]],
 ) -> None:
-    if os.path.exists(validation_summary_path):
-        with open(validation_summary_path, "r", encoding="utf-8") as file:
-            summary = json.load(file)
-    else:
-        summary = {"files": {}, "pipeline_warnings": []}
+    summary = _load_validation_summary(validation_summary_path)
 
     summary.setdefault("files", {})
     summary.setdefault("pipeline_warnings", [])
     summary.setdefault("semantic_review_findings", [])
     summary["semantic_review_findings"].extend(findings)
 
+    _write_validation_summary(validation_summary_path, summary)
+
+
+def append_semantic_review_remediations(
+    validation_summary_path: str,
+    result: SemanticRemediationResult,
+) -> None:
+    summary = _load_validation_summary(validation_summary_path)
+    summary.setdefault("files", {})
+    summary.setdefault("pipeline_warnings", [])
+    summary.setdefault("semantic_review_findings", [])
+    summary.setdefault("semantic_review_remediations", [])
+    summary["semantic_review_remediations"].extend(result.applied)
+    if result.skipped:
+        summary.setdefault("semantic_review_remediation_skips", [])
+        summary["semantic_review_remediation_skips"].extend(result.skipped)
+    _write_validation_summary(validation_summary_path, summary)
+
+
+def _load_validation_summary(validation_summary_path: str) -> Dict[str, Any]:
+    if os.path.exists(validation_summary_path):
+        with open(validation_summary_path, "r", encoding="utf-8") as file:
+            summary = json.load(file)
+        if isinstance(summary, dict):
+            return summary
+    return {"files": {}, "pipeline_warnings": []}
+
+
+def _write_validation_summary(validation_summary_path: str, summary: Dict[str, Any]) -> None:
     Path(validation_summary_path).parent.mkdir(parents=True, exist_ok=True)
     with open(validation_summary_path, "w", encoding="utf-8") as file:
         json.dump(summary, file, ensure_ascii=False, indent=2)
+
+
+def _auto_apply_suggestions_enabled(
+    config: Dict[str, Any],
+    semantic_review_config: Dict[str, Any],
+) -> bool:
+    return bool(
+        semantic_review_config.get(
+            "auto_apply_error_suggestions",
+            config.get("auto_apply_semantic_review_suggestions", False),
+        )
+    )
 
 
 async def review_translation_changes(
@@ -285,6 +326,22 @@ async def _run(argv: Optional[Sequence[str]]) -> int:
                 model_provider=provider,
             )
         )
+
+    if _auto_apply_suggestions_enabled(config, semantic_review_config):
+        remediation = apply_semantic_review_suggestions(
+            repo_root=args.repo_root,
+            input_folder=args.input_folder,
+            findings=findings,
+            locale_codes=locales,
+            localization_profiles=localization_profiles,
+        )
+        append_semantic_review_remediations(args.validation_summary, remediation)
+        applied = remediation.applied_identities
+        findings = [
+            finding
+            for finding in findings
+            if (finding["file"], finding["key"]) not in applied
+        ]
 
     append_semantic_review_findings(args.validation_summary, findings)
     return 0

--- a/localize/translation_semantic_reviewer.py
+++ b/localize/translation_semantic_reviewer.py
@@ -28,6 +28,7 @@ from localize.semantic_quality import (
 from localize.semantic_remediation import (
     SemanticRemediationResult,
     apply_semantic_review_suggestions,
+    semantic_review_finding_signature,
 )
 from localize.translation_quality_gate import get_staged_diff, load_quality_gate_localization_profiles
 
@@ -328,19 +329,24 @@ async def _run(argv: Optional[Sequence[str]]) -> int:
         )
 
     if _auto_apply_suggestions_enabled(config, semantic_review_config):
+        changed_identities = {
+            (change.file, change.key)
+            for change in changes
+        }
         remediation = apply_semantic_review_suggestions(
             repo_root=args.repo_root,
             input_folder=args.input_folder,
             findings=findings,
             locale_codes=locales,
             localization_profiles=localization_profiles,
+            changed_identities=changed_identities,
         )
         append_semantic_review_remediations(args.validation_summary, remediation)
-        applied = remediation.applied_identities
+        applied = remediation.applied_finding_signatures
         findings = [
             finding
             for finding in findings
-            if (finding["file"], finding["key"]) not in applied
+            if semantic_review_finding_signature(finding) not in applied
         ]
 
     append_semantic_review_findings(args.validation_summary, findings)

--- a/profiles/bisq-mobile/config.yaml
+++ b/profiles/bisq-mobile/config.yaml
@@ -1,0 +1,127 @@
+target_project_root: "/target_repo"
+input_folder: "/target_repo/shared/domain/src/commonMain/resources/mobile"
+glossary_file_path: "glossary.json"
+localization_format: "java_properties"
+translation_source: "git"
+project_context: >
+  Translate for Bisq mobile, the Kotlin Multiplatform mobile companion for the
+  Bisq peer-to-peer bitcoin trading ecosystem. Keep navigation labels concise,
+  preserve product names, and prefer mobile UI wording over long desktop-style
+  phrases.
+model_name: "gpt-4o-mini"
+translation_queue_folder: "translation_queue"
+translated_queue_folder: "translated_queue"
+dry_run: false
+retranslate_identical_source_strings: false
+translation_key_ledger_file_path: "/app/logs/translation_key_ledger.json"
+quality_gate:
+  source_identical_min_block_count: 5
+  source_identical_max_count: 20
+  source_identical_max_ratio: 0.30
+  block_on_pipeline_warnings: true
+  block_on_semantic_qa_findings: true
+  block_on_semantic_qa_warnings: false
+  semantic_qa_audit_scope: "changed"
+  retained_source_word_allowlist:
+    es: ["personal"]
+    fr: ["information", "message", "messages"]
+    it: ["reporting"]
+semantic_review:
+  enabled: true
+  model: "gpt-5.4-mini"
+  auto_apply_error_suggestions: true
+semantic_quality_rules:
+  - id: "trade-history-traders-label"
+    message: "Fully localize the Trade Details traders/role label; do not retain the English term 'Traders'."
+    locales: ["*"]
+    excluded_locales: ["en", "pcm"]
+    keys: ["mobile.tradeHistory.details.tradersAndRole"]
+    forbidden_target_regex: "\\bTraders\\b"
+    severity: "error"
+    source: "bisq-mobile#1478 CodeRabbit"
+  - id: "af-trade-history-counts-trades"
+    message: "Afrikaans trade-count labels must count trades, not traders."
+    locales: ["af_ZA"]
+    keys: ["mobile.tradeHistory.count.many", "mobile.tradeHistory.count.filtered"]
+    forbidden_target_regex: "\\bhandelaars\\b"
+    severity: "error"
+    source: "bisq-mobile#1478 CodeRabbit"
+  - id: "vi-clearnet-clear-network-address"
+    message: "Vietnamese networkAddress.clear must describe a clearnet/open network address, not a delete action."
+    locales: ["vi"]
+    keys: ["mobile.tradeHistory.details.networkAddress.clear"]
+    forbidden_target_regex: "^xóa\\b"
+    severity: "error"
+    source: "bisq-mobile#1478 CodeRabbit"
+  - id: "analytics-cta-truncated-reporting"
+    message: "Analytics CTA labels must not contain truncated English words such as 'reportin'."
+    locales: ["*"]
+    keys: ["*"]
+    forbidden_target_regex: "\\breportin\\b"
+    severity: "error"
+    source: "bisq-mobile#1490 CodeRabbit"
+  - id: "analytics-cta-reporting-loanword"
+    message: "French and Italian analytics CTA labels must fully localize 'reporting'."
+    locales: ["fr", "it"]
+    keys: ["mobile.welcomeCarousel.analytics.action"]
+    forbidden_target_regex: "\\breporting\\b"
+    severity: "error"
+    source: "bisq-mobile#1490 CodeRabbit"
+  - id: "it-analytics-self-hosted"
+    message: "Italian analytics copy must localize 'self-hosted' instead of retaining the English term."
+    locales: ["it"]
+    keys: ["*"]
+    forbidden_target_regex: "\\bself-hosted\\b"
+    severity: "error"
+    source: "bisq-mobile#1484 CodeRabbit"
+  - id: "fr-analytics-no-pii-negation"
+    message: "French no-PII analytics copy must keep parallel negation for accounts and device identifiers."
+    locales: ["fr"]
+    keys: ["mobile.settings.analytics.info.noPii"]
+    forbidden_target_regex: "^Aucune information personnelle,\\s*comptes\\b"
+    severity: "error"
+    source: "bisq-mobile#1484 CodeRabbit"
+supported_locales:
+  - code: "af_ZA"
+    name: "Afrikaans"
+  - code: "cs"
+    name: "Czech"
+  - code: "da"
+    name: "Danish"
+  - code: "de"
+    name: "German"
+  - code: "es"
+    name: "Spanish"
+  - code: "fr"
+    name: "French"
+  - code: "id"
+    name: "Indonesian"
+  - code: "it"
+    name: "Italian"
+  - code: "pt_BR"
+    name: "Brazilian Portuguese"
+  - code: "pt_PT"
+    name: "Portuguese"
+  - code: "ru"
+    name: "Russian"
+  - code: "sv"
+    name: "Swedish"
+  - code: "th"
+    name: "Thai"
+  - code: "vi"
+    name: "Vietnamese"
+style_rules:
+  de:
+    - "Use natural mobile labels; prefer 'Haeufige Fragen' over source-identical 'FAQs' when a short native label fits."
+  es:
+    - "Keep navigation labels short and fully localized unless the term is a brand name."
+  fr:
+    - "Do not retain English analytics terms such as reporting when a natural French equivalent is available."
+brand_technical_glossary:
+  - "Bisq"
+  - "Bisq Easy"
+  - "Bitcoin"
+  - "BTC"
+  - "Lightning"
+  - "MuSig"
+  - "Tor"

--- a/profiles/bisq-mobile/config.yaml
+++ b/profiles/bisq-mobile/config.yaml
@@ -112,7 +112,7 @@ supported_locales:
     name: "Vietnamese"
 style_rules:
   de:
-    - "Use natural mobile labels; prefer 'Haeufige Fragen' over source-identical 'FAQs' when a short native label fits."
+    - "Use natural mobile labels; prefer 'Häufige Fragen' over source-identical 'FAQs' when a short native label fits."
   es:
     - "Keep navigation labels short and fully localized unless the term is a brand name."
   fr:

--- a/profiles/bisq-mobile/glossary.json
+++ b/profiles/bisq-mobile/glossary.json
@@ -1,0 +1,62 @@
+{
+  "de": {
+    "account": "Konto",
+    "analytics": "Analyse",
+    "backup": "Sicherung",
+    "fee": "Gebühr",
+    "mediator": "Mediator",
+    "payment account": "Zahlungskonto",
+    "trade": "Handel",
+    "wallet": "Wallet"
+  },
+  "es": {
+    "account": "cuenta",
+    "analytics": "analítica",
+    "backup": "copia de seguridad",
+    "fee": "comisión",
+    "mediator": "mediador",
+    "payment account": "cuenta de pago",
+    "trade": "operacion",
+    "wallet": "wallet"
+  },
+  "fr": {
+    "account": "compte",
+    "analytics": "analyse",
+    "backup": "sauvegarde",
+    "fee": "frais",
+    "mediator": "médiateur",
+    "payment account": "compte de paiement",
+    "trade": "transaction",
+    "wallet": "portefeuille"
+  },
+  "id": {
+    "account": "akun",
+    "analytics": "analitik",
+    "backup": "cadangan",
+    "fee": "biaya",
+    "mediator": "mediator",
+    "payment account": "akun pembayaran",
+    "trade": "perdagangan",
+    "wallet": "dompet"
+  },
+  "it": {
+    "account": "account",
+    "analytics": "analisi",
+    "backup": "backup",
+    "fee": "commissione",
+    "mediator": "mediatore",
+    "payment account": "conto di pagamento",
+    "trade": "scambio",
+    "wallet": "wallet"
+  },
+  "vi": {
+    "account": "tài khoản",
+    "analytics": "phân tích",
+    "backup": "sao lưu",
+    "fee": "phí",
+    "mediator": "hòa giải viên",
+    "payment account": "tài khoản thanh toán",
+    "trade": "giao dịch",
+    "wallet": "ví"
+  }
+}

--- a/profiles/bisq-mobile/glossary.json
+++ b/profiles/bisq-mobile/glossary.json
@@ -16,7 +16,7 @@
     "fee": "comisión",
     "mediator": "mediador",
     "payment account": "cuenta de pago",
-    "trade": "operacion",
+    "trade": "operación",
     "wallet": "wallet"
   },
   "fr": {

--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -32,6 +32,7 @@ quality_gate:
 semantic_review:
   enabled: true
   model: "gpt-5.4-mini"
+  auto_apply_error_suggestions: true
 semantic_quality_rules:
   - id: "trade-history-traders-label"
     message: "Fully localize the Trade Details traders/role label; do not retain the English term 'Traders'."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "localize-pipeline"
 version = "0.1.0"
-description = "Reusable AI localization translation pipeline"
+description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "MIT"}
+keywords = ["ai", "agents", "i18n", "l10n", "localization", "translation", "github-actions"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
@@ -37,9 +38,9 @@ dependencies = [
 localize = "localize.cli:main"
 
 [project.urls]
-Repository = "https://github.com/bisq-network/translate-java-property-files"
-Changelog = "https://github.com/bisq-network/translate-java-property-files/blob/main/CHANGELOG.md"
-Issues = "https://github.com/bisq-network/translate-java-property-files/issues"
+Repository = "https://github.com/bisq-network/localize-pipeline"
+Changelog = "https://github.com/bisq-network/localize-pipeline/blob/main/CHANGELOG.md"
+Issues = "https://github.com/bisq-network/localize-pipeline/issues"
 
 [tool.setuptools.packages.find]
 include = ["localize*"]

--- a/scripts/check-translation-services.sh
+++ b/scripts/check-translation-services.sh
@@ -6,7 +6,19 @@
 set -euo pipefail
 
 ALERT_FILE="/var/log/translation-service-alerts.log"
-GITHUB_TOKEN=$(sed -n 's/^GITHUB_TOKEN=//p' /opt/translate-java-property-files/docker/.env 2>/dev/null | tail -n1 || true)
+INSTALL_ROOT="${LOCALIZE_PIPELINE_ROOT:-/opt/localize-pipeline}"
+MOBILE_INSTALL_ROOT="${LOCALIZE_PIPELINE_MOBILE_ROOT:-/opt/localize-pipeline-mobile}"
+LEGACY_INSTALL_ROOT="/opt/translate-java-property-files"
+LEGACY_MOBILE_INSTALL_ROOT="/opt/translate-java-property-files-mobile-app"
+
+if [ ! -d "$INSTALL_ROOT" ] && [ -d "$LEGACY_INSTALL_ROOT" ]; then
+    INSTALL_ROOT="$LEGACY_INSTALL_ROOT"
+fi
+if [ ! -d "$MOBILE_INSTALL_ROOT" ] && [ -d "$LEGACY_MOBILE_INSTALL_ROOT" ]; then
+    MOBILE_INSTALL_ROOT="$LEGACY_MOBILE_INSTALL_ROOT"
+fi
+
+GITHUB_TOKEN=$(sed -n 's/^GITHUB_TOKEN=//p' "$INSTALL_ROOT/docker/.env" 2>/dev/null | tail -n1 || true)
 
 log_alert() {
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] ALERT: $1" | tee -a "$ALERT_FILE"
@@ -129,8 +141,8 @@ else
 fi
 
 # Check 3: Check latest cron run result robustly
-main_log="/opt/translate-java-property-files/logs/cron_job.log"
-mobile_log="/opt/translate-java-property-files-mobile-app/logs/cron_job.log"
+main_log="$INSTALL_ROOT/logs/cron_job.log"
+mobile_log="$MOBILE_INSTALL_ROOT/logs/cron_job.log"
 check_cron_log "Main service" "$main_log"
 check_cron_log "Mobile app service" "$mobile_log"
 

--- a/scripts/check-translation-services.sh
+++ b/scripts/check-translation-services.sh
@@ -18,7 +18,12 @@ if [ ! -d "$MOBILE_INSTALL_ROOT" ] && [ -d "$LEGACY_MOBILE_INSTALL_ROOT" ]; then
     MOBILE_INSTALL_ROOT="$LEGACY_MOBILE_INSTALL_ROOT"
 fi
 
-GITHUB_TOKEN=$(sed -n 's/^GITHUB_TOKEN=//p' "$INSTALL_ROOT/docker/.env" 2>/dev/null | tail -n1 || true)
+GITHUB_TOKEN=""
+for env_file in "$INSTALL_ROOT/docker/.env" "$MOBILE_INSTALL_ROOT/docker/.env"; do
+    if [ -z "$GITHUB_TOKEN" ] && [ -f "$env_file" ]; then
+        GITHUB_TOKEN=$(sed -n 's/^GITHUB_TOKEN=//p' "$env_file" 2>/dev/null | tail -n1 || true)
+    fi
+done
 
 log_alert() {
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] ALERT: $1" | tee -a "$ALERT_FILE"

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -63,7 +63,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     assert config["supported_locales"] == [{"code": "de", "name": "German"}]
 
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
-    assert "bisq-network/translate-java-property-files@v0.1.0" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.0" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -165,6 +165,70 @@ def test_cli_check_alias_runs_preflight_validation(tmp_path, capsys):
     assert "Preflight OK" in captured.out
 
 
+def test_cli_doctor_prints_redacted_effective_config(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-value")
+    repo = tmp_path / "repo"
+    i18n = repo / "i18n"
+    i18n.mkdir(parents=True)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({
+            "target_project_root": str(repo),
+            "input_folder": "i18n",
+            "translation_queue_folder": "translation_queue",
+            "translated_queue_folder": "translated_queue",
+            "model_provider": "aisuite",
+            "model_name": "gpt-4o-mini",
+            "review_model_name": "gpt-4o",
+            "semantic_review": {"enabled": True, "model": "gpt-4o"},
+            "dry_run": False,
+            "supported_locales": [{"code": "de", "name": "German"}],
+        }),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["doctor", "--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Localize Pipeline doctor" in captured.out
+    assert "profile: default" in captured.out
+    assert f"target_project_root: {repo}" in captured.out
+    assert f"input_folder: {i18n}" in captured.out
+    assert "model_provider: aisuite" in captured.out
+    assert "semantic_review: enabled" in captured.out
+    assert "OPENAI_API_KEY: set" in captured.out
+    assert "sk-secret-value" not in captured.out
+
+
+def test_cli_smoke_is_read_only_and_creates_missing_runtime_queue_dirs(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    i18n = repo / "i18n"
+    i18n.mkdir(parents=True)
+    config_path = tmp_path / "config.yaml"
+    queue = tmp_path / "scratch" / "translation_queue"
+    translated = tmp_path / "scratch" / "translated_queue"
+    config_path.write_text(
+        yaml.safe_dump({
+            "target_project_root": str(repo),
+            "input_folder": "i18n",
+            "translation_queue_folder": str(queue),
+            "translated_queue_folder": str(translated),
+            "dry_run": True,
+            "supported_locales": [{"code": "de", "name": "German"}],
+        }),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["smoke", "--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Smoke OK" in captured.out
+    assert queue.is_dir()
+    assert translated.is_dir()
+
+
 def test_cli_check_false_dry_run_env_does_not_override_config(tmp_path, monkeypatch, capsys):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("LOCALIZE_DRY_RUN", "false")
@@ -332,6 +396,45 @@ def test_cli_bootstrap_pr_delegates_to_onboarding_generator(capsys):
     assert "Created onboarding commit abc123" in captured.out
 
 
+def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
+    with patch("localize.cli.translation_quality_gate_main", return_value=0) as quality_main:
+        exit_code = cli.main([
+            "quality-gate",
+            "--repo-root",
+            "/repo",
+            "--input-folder",
+            "/repo/i18n",
+            "--config",
+            "/repo/config.yaml",
+            "--validation-summary",
+            "/repo/logs/summary.json",
+            "--output-json",
+            "/tmp/report.json",
+            "--output-markdown",
+            "/tmp/report.md",
+            "--changed-files",
+            "i18n/messages_de.properties",
+        ])
+
+    assert exit_code == 0
+    quality_main.assert_called_once_with([
+        "--repo-root",
+        "/repo",
+        "--input-folder",
+        "/repo/i18n",
+        "--config",
+        "/repo/config.yaml",
+        "--validation-summary",
+        "/repo/logs/summary.json",
+        "--output-json",
+        "/tmp/report.json",
+        "--output-markdown",
+        "/tmp/report.md",
+        "--changed-files",
+        "i18n/messages_de.properties",
+    ])
+
+
 def test_cli_memory_import_export_stats_and_suggest(tmp_path, capsys):
     source = tmp_path / "source-memory.json"
     destination = tmp_path / "destination-memory.json"
@@ -437,8 +540,9 @@ def test_pyproject_exposes_localize_console_script():
 
     assert pyproject["project"]["name"] == "localize-pipeline"
     assert pyproject["project"]["version"] == "0.1.0"
-    assert pyproject["project"]["urls"]["Repository"]
+    assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
+    assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"
     assert "Programming Language :: Python :: 3 :: Only" in pyproject["project"]["classifiers"]
     assert pyproject["project"]["scripts"]["localize"] == "localize.cli:main"
     assert pyproject["tool"]["setuptools"]["packages"]["find"]["include"] == ["localize*"]

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -9,6 +9,8 @@ import yaml
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 BISQ_PROFILE_CONFIG = PROJECT_ROOT / "profiles" / "bisq" / "config.yaml"
 BISQ_PROFILE_GLOSSARY = PROJECT_ROOT / "profiles" / "bisq" / "glossary.json"
+BISQ_MOBILE_PROFILE_CONFIG = PROJECT_ROOT / "profiles" / "bisq-mobile" / "config.yaml"
+BISQ_MOBILE_PROFILE_GLOSSARY = PROJECT_ROOT / "profiles" / "bisq-mobile" / "glossary.json"
 GENERIC_EXAMPLE_DIR = PROJECT_ROOT / "examples" / "generic-java-properties"
 
 
@@ -63,6 +65,52 @@ def test_docs_use_localize_init_as_stable_onboarding_surface():
 
     assert "localize init" in docs
     assert "./init.sh" not in docs
+
+
+def test_docs_and_metadata_use_localize_pipeline_repo_name():
+    paths = [
+        PROJECT_ROOT / "README.md",
+        PROJECT_ROOT / "pyproject.toml",
+        PROJECT_ROOT / "action.yml",
+        *sorted((PROJECT_ROOT / "docs").glob("*.md")),
+    ]
+    text = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+
+    assert "bisq-network/localize-pipeline" in text
+    assert "bisq-network/translate-java-property-files" not in text
+
+
+def test_llms_txt_guides_agents_to_stable_surfaces():
+    llms = (PROJECT_ROOT / "llms.txt").read_text(encoding="utf-8")
+
+    assert "# Localize Pipeline" in llms
+    assert "localize init" in llms
+    assert "localize doctor" in llms
+    assert "localize smoke" in llms
+    assert "localize.core" in llms
+    assert "localize.formats" in llms
+    assert "localize.providers" in llms
+    assert "profiles/bisq/" in llms
+    assert "profiles/bisq-mobile/" in llms
+    assert "docs/new-format-checklist.md" in llms
+    assert "Java properties" in llms
+    assert "JSON" in llms
+
+
+def test_core_public_modules_do_not_import_bisq_profile_assumptions():
+    public_modules = [
+        PROJECT_ROOT / "localize" / "core" / "__init__.py",
+        PROJECT_ROOT / "localize" / "formats" / "__init__.py",
+        PROJECT_ROOT / "localize" / "providers" / "__init__.py",
+        PROJECT_ROOT / "localize" / "pipeline_core.py",
+        PROJECT_ROOT / "localize" / "connectors.py",
+    ]
+
+    for path in public_modules:
+        text = path.read_text(encoding="utf-8")
+        assert "profiles/bisq" not in text
+        assert "i18n/src/main/resources" not in text
+        assert "Bisq" not in text
 
 
 def test_release_maturity_docs_are_packaged():
@@ -124,6 +172,37 @@ def test_bisq_profile_packages_config_and_glossary_assets():
     assert config["glossary_file_path"] == "glossary.json"
     assert isinstance(glossary, dict) and glossary
     assert "de" in glossary
+
+
+def test_bisq_mobile_profile_packages_sanitized_production_shape():
+    """Bisq mobile production behavior is a tracked profile fixture, not hidden state."""
+    assert BISQ_MOBILE_PROFILE_CONFIG.exists()
+    assert BISQ_MOBILE_PROFILE_GLOSSARY.exists()
+
+    config = yaml.safe_load(BISQ_MOBILE_PROFILE_CONFIG.read_text(encoding="utf-8"))
+    glossary = yaml.safe_load(BISQ_MOBILE_PROFILE_GLOSSARY.read_text(encoding="utf-8"))
+
+    assert config["localization_format"] == "java_properties"
+    assert config["translation_source"] == "git"
+    assert config["input_folder"] == "/target_repo/shared/domain/src/commonMain/resources/mobile"
+    assert "Bisq mobile" in config["project_context"]
+    assert config["semantic_review"]["enabled"] is True
+    assert config["semantic_review"]["auto_apply_error_suggestions"] is True
+    assert config["quality_gate"]["semantic_qa_audit_scope"] == "changed"
+    assert isinstance(glossary, dict) and {"de", "es", "fr"}.issubset(glossary)
+
+    supported_locale_codes = {
+        locale["code"]
+        for locale in config["supported_locales"]
+    }
+    semantic_rule_locale_codes = {
+        locale
+        for rule in config.get("semantic_quality_rules", [])
+        for locale in rule.get("locales", [])
+        if locale != "*"
+    }
+    assert {"de", "es", "fr", "id", "it", "vi"}.issubset(supported_locale_codes)
+    assert semantic_rule_locale_codes <= supported_locale_codes
 
 
 def test_docker_compose_mounts_the_selected_profile():

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -72,7 +72,7 @@ def test_docs_and_metadata_use_localize_pipeline_repo_name():
         PROJECT_ROOT / "README.md",
         PROJECT_ROOT / "pyproject.toml",
         PROJECT_ROOT / "action.yml",
-        *sorted((PROJECT_ROOT / "docs").glob("*.md")),
+        *sorted((PROJECT_ROOT / "docs").rglob("*.md")),
     ]
     text = "\n".join(path.read_text(encoding="utf-8") for path in paths)
 

--- a/tests/unit/test_semantic_remediation.py
+++ b/tests/unit/test_semantic_remediation.py
@@ -1,0 +1,100 @@
+import json
+
+from localize.localization_profiles import load_localization_profiles
+from localize.semantic_remediation import apply_semantic_review_suggestions
+
+
+def test_semantic_remediation_applies_properties_suggestion_with_placeholder_parity(tmp_path):
+    resources = tmp_path / "resources"
+    resources.mkdir()
+    (resources / "messages.properties").write_text("hello=Hello {0}\n", encoding="utf-8")
+    target_path = resources / "messages_de.properties"
+    target_path.write_text("hello=Hallo\n", encoding="utf-8")
+
+    result = apply_semantic_review_suggestions(
+        repo_root=str(tmp_path),
+        input_folder=str(resources),
+        findings=[
+            {
+                "file": "messages_de.properties",
+                "key": "hello",
+                "severity": "error",
+                "suggested_value": "Hallo {0}",
+            }
+        ],
+        locale_codes=["de"],
+        localization_profiles=load_localization_profiles({"localization_format": "java_properties"}),
+    )
+
+    assert result.applied_count == 1
+    assert result.skipped_count == 0
+    assert "hello=Hallo {0}" in target_path.read_text(encoding="utf-8")
+
+
+def test_semantic_remediation_skips_suggestions_that_break_placeholders(tmp_path):
+    resources = tmp_path / "resources"
+    resources.mkdir()
+    (resources / "messages.properties").write_text("hello=Hello {0}\n", encoding="utf-8")
+    target_path = resources / "messages_de.properties"
+    target_path.write_text("hello=Hallo\n", encoding="utf-8")
+
+    result = apply_semantic_review_suggestions(
+        repo_root=str(tmp_path),
+        input_folder=str(resources),
+        findings=[
+            {
+                "file": "messages_de.properties",
+                "key": "hello",
+                "severity": "error",
+                "suggested_value": "Hallo",
+            }
+        ],
+        locale_codes=["de"],
+        localization_profiles=load_localization_profiles({"localization_format": "java_properties"}),
+    )
+
+    assert result.applied_count == 0
+    assert result.skipped_count == 1
+    assert "hello=Hallo\n" in target_path.read_text(encoding="utf-8")
+
+
+def test_semantic_remediation_applies_json_locale_directory_suggestion(tmp_path):
+    resources = tmp_path / "resources"
+    source_dir = resources / "en"
+    target_dir = resources / "de"
+    source_dir.mkdir(parents=True)
+    target_dir.mkdir(parents=True)
+    (source_dir / "common.json").write_text(
+        json.dumps({"hello": "Hello {0}"}, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    target_path = target_dir / "common.json"
+    target_path.write_text(
+        json.dumps({"hello": "Hallo"}, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = apply_semantic_review_suggestions(
+        repo_root=str(tmp_path),
+        input_folder=str(resources),
+        findings=[
+            {
+                "file": "de/common.json",
+                "key": "/hello",
+                "severity": "error",
+                "suggested_value": "Hallo {0}",
+            }
+        ],
+        locale_codes=["de"],
+        localization_profiles=load_localization_profiles({
+            "localization_formats": [
+                {
+                    "id": "json",
+                    "layout": {"id": "locale_directory", "source_locale": "en"},
+                }
+            ]
+        }),
+    )
+
+    assert result.applied_count == 1
+    assert json.loads(target_path.read_text(encoding="utf-8"))["hello"] == "Hallo {0}"

--- a/tests/unit/test_semantic_remediation.py
+++ b/tests/unit/test_semantic_remediation.py
@@ -24,6 +24,7 @@ def test_semantic_remediation_applies_properties_suggestion_with_placeholder_par
         ],
         locale_codes=["de"],
         localization_profiles=load_localization_profiles({"localization_format": "java_properties"}),
+        changed_identities={("messages_de.properties", "hello")},
     )
 
     assert result.applied_count == 1
@@ -51,6 +52,7 @@ def test_semantic_remediation_skips_suggestions_that_break_placeholders(tmp_path
         ],
         locale_codes=["de"],
         localization_profiles=load_localization_profiles({"localization_format": "java_properties"}),
+        changed_identities={("messages_de.properties", "hello")},
     )
 
     assert result.applied_count == 0
@@ -94,7 +96,103 @@ def test_semantic_remediation_applies_json_locale_directory_suggestion(tmp_path)
                 }
             ]
         }),
+        changed_identities={("de/common.json", "/hello")},
     )
 
     assert result.applied_count == 1
     assert json.loads(target_path.read_text(encoding="utf-8"))["hello"] == "Hallo {0}"
+
+
+def test_semantic_remediation_rejects_unchanged_entries(tmp_path):
+    resources = tmp_path / "resources"
+    resources.mkdir()
+    (resources / "messages.properties").write_text("hello=Hello {0}\n", encoding="utf-8")
+    target_path = resources / "messages_de.properties"
+    target_path.write_text("hello=Hallo\n", encoding="utf-8")
+
+    result = apply_semantic_review_suggestions(
+        repo_root=str(tmp_path),
+        input_folder=str(resources),
+        findings=[
+            {
+                "file": "messages_de.properties",
+                "key": "hello",
+                "severity": "error",
+                "suggested_value": "Hallo {0}",
+            }
+        ],
+        locale_codes=["de"],
+        localization_profiles=load_localization_profiles({"localization_format": "java_properties"}),
+        changed_identities=set(),
+    )
+
+    assert result.applied_count == 0
+    assert result.skipped[0]["reason"] == "finding is not scoped to a changed entry"
+    assert "hello=Hallo\n" in target_path.read_text(encoding="utf-8")
+
+
+def test_semantic_remediation_rejects_out_of_tree_findings(tmp_path):
+    resources = tmp_path / "resources"
+    outside = tmp_path / "outside"
+    resources.mkdir()
+    outside.mkdir()
+    (resources / "messages.properties").write_text("hello=Hello {0}\n", encoding="utf-8")
+    target_path = outside / "messages_de.properties"
+    target_path.write_text("hello=Hallo\n", encoding="utf-8")
+
+    result = apply_semantic_review_suggestions(
+        repo_root=str(tmp_path),
+        input_folder=str(resources),
+        findings=[
+            {
+                "file": "../outside/messages_de.properties",
+                "key": "hello",
+                "severity": "error",
+                "suggested_value": "Hallo {0}",
+            }
+        ],
+        locale_codes=["de"],
+        localization_profiles=load_localization_profiles({"localization_format": "java_properties"}),
+        changed_identities={("../outside/messages_de.properties", "hello")},
+    )
+
+    assert result.applied_count == 0
+    assert result.skipped[0]["reason"] == "target file is outside input_folder"
+    assert "hello=Hallo\n" in target_path.read_text(encoding="utf-8")
+
+
+def test_semantic_remediation_skips_duplicate_changed_identity(tmp_path):
+    resources = tmp_path / "resources"
+    resources.mkdir()
+    (resources / "messages.properties").write_text("hello=Hello {0}\n", encoding="utf-8")
+    target_path = resources / "messages_de.properties"
+    target_path.write_text("hello=Hallo\n", encoding="utf-8")
+
+    result = apply_semantic_review_suggestions(
+        repo_root=str(tmp_path),
+        input_folder=str(resources),
+        findings=[
+            {
+                "file": "messages_de.properties",
+                "key": "hello",
+                "severity": "error",
+                "reason": "First suggestion.",
+                "suggested_value": "Hallo {0}",
+            },
+            {
+                "file": "messages_de.properties",
+                "key": "hello",
+                "severity": "error",
+                "reason": "Second suggestion.",
+                "suggested_value": "Guten Tag {0}",
+            },
+        ],
+        locale_codes=["de"],
+        localization_profiles=load_localization_profiles({"localization_format": "java_properties"}),
+        changed_identities={("messages_de.properties", "hello")},
+    )
+
+    assert result.applied_count == 1
+    assert result.skipped_count == 1
+    assert result.skipped[0]["reason"] == "duplicate finding for changed entry"
+    assert "hello=Hallo {0}" in target_path.read_text(encoding="utf-8")

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -330,6 +330,101 @@ async def test_semantic_reviewer_defaults_to_aisuite_provider(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_semantic_reviewer_auto_applies_safe_error_suggestions(tmp_path):
+    resources = tmp_path / "resources"
+    resources.mkdir()
+    source_path = resources / "messages.properties"
+    target_path = resources / "messages_de.properties"
+    source_path.write_text("hello=Hello {0}\n", encoding="utf-8")
+    target_path.write_text("hello=Hallo\n", encoding="utf-8")
+    config_path = tmp_path / "config.yaml"
+    validation_summary_path = tmp_path / "translation_validation_summary.json"
+    config_path.write_text(
+        "\n".join(
+            [
+                "dry_run: false",
+                "semantic_review:",
+                "  enabled: true",
+                "  auto_apply_error_suggestions: true",
+                "supported_locales:",
+                "  - code: de",
+                "    name: German",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    provider = MagicMock()
+    provider.client = object()
+    provider.create_chat_completion = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=json.dumps(
+                            {
+                                "findings": [
+                                    {
+                                        "file": "messages_de.properties",
+                                        "key": "hello",
+                                        "severity": "error",
+                                        "reason": "Placeholder missing.",
+                                        "suggested_value": "Hallo {0}",
+                                    }
+                                ]
+                            }
+                        )
+                    )
+                )
+            ]
+        )
+    )
+
+    with (
+        patch(
+            "localize.translation_semantic_reviewer.get_staged_diff",
+            return_value="fake diff",
+        ),
+        patch(
+            "localize.translation_semantic_reviewer.iter_translation_changes_from_diff",
+            return_value=[
+                TranslationChange(
+                    file="messages_de.properties",
+                    locale_code="de",
+                    key="hello",
+                    source_value="Hello {0}",
+                    old_value=None,
+                    new_value="Hallo",
+                )
+            ],
+        ),
+        patch(
+            "localize.translation_semantic_reviewer.create_model_provider",
+            return_value=provider,
+        ),
+    ):
+        exit_code = await _run(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--input-folder",
+                str(resources),
+                "--config",
+                str(config_path),
+                "--validation-summary",
+                str(validation_summary_path),
+                "--changed-files",
+                "resources/messages_de.properties",
+            ]
+        )
+
+    assert exit_code == 0
+    assert "hello=Hallo {0}" in target_path.read_text(encoding="utf-8")
+    summary = json.loads(validation_summary_path.read_text(encoding="utf-8"))
+    assert summary["semantic_review_findings"] == []
+    assert summary["semantic_review_remediations"][0]["key"] == "hello"
+
+
+@pytest.mark.asyncio
 async def test_semantic_reviewer_collects_changes_from_all_configured_profiles(tmp_path):
     config_path = tmp_path / "config.yaml"
     validation_summary_path = tmp_path / "translation_validation_summary.json"

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -369,6 +369,19 @@ async def test_semantic_reviewer_auto_applies_safe_error_suggestions(tmp_path):
                                         "severity": "error",
                                         "reason": "Placeholder missing.",
                                         "suggested_value": "Hallo {0}",
+                                    },
+                                    {
+                                        "file": "messages_de.properties",
+                                        "key": "hello",
+                                        "severity": "error",
+                                        "reason": "Conflicting duplicate.",
+                                        "suggested_value": "Guten Tag {0}",
+                                    },
+                                    {
+                                        "file": "messages_de.properties",
+                                        "key": "hello",
+                                        "severity": "warning",
+                                        "reason": "Tone is informal.",
                                     }
                                 ]
                             }
@@ -420,8 +433,12 @@ async def test_semantic_reviewer_auto_applies_safe_error_suggestions(tmp_path):
     assert exit_code == 0
     assert "hello=Hallo {0}" in target_path.read_text(encoding="utf-8")
     summary = json.loads(validation_summary_path.read_text(encoding="utf-8"))
-    assert summary["semantic_review_findings"] == []
+    assert [finding["reason"] for finding in summary["semantic_review_findings"]] == [
+        "Conflicting duplicate.",
+        "Tone is informal.",
+    ]
     assert summary["semantic_review_remediations"][0]["key"] == "hello"
+    assert summary["semantic_review_remediation_skips"][0]["reason"] == "duplicate finding for changed entry"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -71,7 +71,7 @@ def test_fork_repo_name_short_strips_git_suffix_before_status_api():
 def test_config_file_is_normalized_before_late_quality_gate_call():
     script = (REPO_ROOT / "update-translations.sh").read_text()
 
-    normalize_index = script.index("CONFIG_FILE=$(cd")
+    normalize_index = script.index("resolve_config_file")
     quality_gate_index = script.index("localize.translation_quality_gate")
 
     assert normalize_index < quality_gate_index
@@ -85,6 +85,41 @@ def test_validation_summary_is_reset_before_translation_script_runs():
 
     assert reset_index < python_index
     assert '{"files":{},"pipeline_warnings":[]}' in script
+
+
+def test_smoke_only_mode_runs_before_pending_pr_guard():
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    smoke_index = script.index("LOCALIZE_SMOKE_ONLY")
+    pending_guard_index = script.index("Checking for manually-blocked PRs")
+
+    assert "run_smoke_only_if_requested()" in script
+    assert "python3 -m localize.cli doctor" in script
+    assert "python3 -m localize.cli smoke" in script
+    assert smoke_index < pending_guard_index
+
+
+def test_script_emits_structured_pipeline_events_for_monitoring():
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    assert "record_pipeline_event()" in script
+    assert "PIPELINE_EVENT event=$event" in script
+    assert 'record_pipeline_event "pending_pr_guard"' in script
+    assert 'record_pipeline_event "source_files_detected"' in script
+    assert 'record_pipeline_event "translation_files_detected"' in script
+    assert 'record_pipeline_event "files_processed"' in script
+    assert 'record_pipeline_event "skipped_files"' in script
+    assert 'record_pipeline_event "pull_request_created"' in script
+
+
+def test_semantic_remediation_changes_are_restaged_before_quality_gate():
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    review_index = script.index("localize.translation_semantic_reviewer")
+    restage_index = script.index("Re-staging translation files after semantic review")
+    quality_gate_index = script.index("localize.translation_quality_gate")
+
+    assert review_index < restage_index < quality_gate_index
 
 
 def test_translation_source_is_read_and_defaults_to_transifex():

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -38,6 +38,13 @@ def test_env_example_documents_max_files_per_pr_override():
     assert "MAX_FILES_PER_PR=150" in env_example
 
 
+def test_health_check_reads_github_token_from_main_or_mobile_install():
+    script = (REPO_ROOT / "scripts" / "check-translation-services.sh").read_text()
+
+    assert 'for env_file in "$INSTALL_ROOT/docker/.env" "$MOBILE_INSTALL_ROOT/docker/.env"' in script
+    assert 'if [ -z "$GITHUB_TOKEN" ] && [ -f "$env_file" ]; then' in script
+
+
 def test_generated_prs_publish_translation_quality_gate_status():
     script = (REPO_ROOT / "update-translations.sh").read_text()
 
@@ -71,7 +78,7 @@ def test_fork_repo_name_short_strips_git_suffix_before_status_api():
 def test_config_file_is_normalized_before_late_quality_gate_call():
     script = (REPO_ROOT / "update-translations.sh").read_text()
 
-    normalize_index = script.index("resolve_config_file")
+    normalize_index = script.index('resolve_config_file\nlog "Using configuration file')
     quality_gate_index = script.index("localize.translation_quality_gate")
 
     assert normalize_index < quality_gate_index
@@ -90,7 +97,7 @@ def test_validation_summary_is_reset_before_translation_script_runs():
 def test_smoke_only_mode_runs_before_pending_pr_guard():
     script = (REPO_ROOT / "update-translations.sh").read_text()
 
-    smoke_index = script.index("LOCALIZE_SMOKE_ONLY")
+    smoke_index = script.index("\nrun_smoke_only_if_requested\n")
     pending_guard_index = script.index("Checking for manually-blocked PRs")
 
     assert "run_smoke_only_if_requested()" in script
@@ -103,7 +110,9 @@ def test_script_emits_structured_pipeline_events_for_monitoring():
     script = (REPO_ROOT / "update-translations.sh").read_text()
 
     assert "record_pipeline_event()" in script
-    assert "PIPELINE_EVENT event=$event" in script
+    assert 'payload="{\\"event\\":$(record_pipeline_event_field "$event")"' in script
+    assert 'log "PIPELINE_EVENT $payload"' in script
+    assert "record_pipeline_event_field()" in script
     assert 'record_pipeline_event "pending_pr_guard"' in script
     assert 'record_pipeline_event "source_files_detected"' in script
     assert 'record_pipeline_event "translation_files_detected"' in script

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -61,8 +61,51 @@ log_cmd() {
   "$@" 2>&1 | sed 's/^/| /' | tee -a "$LOG_FILE"
 }
 
+record_pipeline_event() {
+    local event="$1"
+    shift || true
+    log "PIPELINE_EVENT event=$event $*" "INFO"
+}
+
 command_exists() {
     command -v "$1" >/dev/null 2>&1
+}
+
+resolve_config_file() {
+    local requested_config="${TRANSLATOR_CONFIG_FILE:-config.yaml}"
+    local resolved_config="$requested_config"
+
+    if [ ! -f "$resolved_config" ]; then
+        log "Configuration file not found at '$resolved_config'." "ERROR"
+        # Attempt to find it in the script's directory as a fallback for local runs.
+        local script_dir_real
+        script_dir_real=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+        if [ -f "$script_dir_real/$resolved_config" ]; then
+            resolved_config="$script_dir_real/$resolved_config"
+            log "Found config file in script directory: $resolved_config" "INFO"
+        else
+            log "Also not found in script directory. Aborting." "ERROR"
+            return 1
+        fi
+    fi
+
+    resolved_config=$(cd "$(dirname "$resolved_config")" && pwd)/$(basename "$resolved_config")
+    CONFIG_FILE="$resolved_config"
+    export TRANSLATOR_CONFIG_FILE="$CONFIG_FILE"
+}
+
+run_smoke_only_if_requested() {
+    if [[ "${LOCALIZE_SMOKE_ONLY:-false}" != "true" ]]; then
+        return 0
+    fi
+
+    resolve_config_file
+    log "Running smoke-only deployment verification with configuration file: $CONFIG_FILE"
+    python3 -m localize.cli doctor --config "$CONFIG_FILE"
+    python3 -m localize.cli smoke --config "$CONFIG_FILE"
+    record_pipeline_event "smoke_only_ok" "config=$CONFIG_FILE"
+    send_heartbeat_if_configured "smoke_only_ok"
+    exit 0
 }
 
 normalize_translation_source() {
@@ -208,8 +251,9 @@ collect_changed_translation_files() {
 
 # Send a heartbeat ping to the health check URL if it is configured
 send_heartbeat_if_configured() {
+    local event="${1:-heartbeat}"
     if [ -n "${HEALTHCHECK_URL:-}" ]; then
-        log "Sending heartbeat to health check URL..."
+        log "Sending heartbeat to health check URL for event '$event'..."
         # Use curl with options to fail silently and handle connection timeouts
         curl -fsS --retry 3 --max-time 10 "$HEALTHCHECK_URL" > /dev/null || log "Warning: Health check ping failed."
     else
@@ -224,8 +268,9 @@ send_heartbeat_if_configured() {
 check_and_exit_if_blocked() {
     log "BLOCKING CONDITION DETECTED: $1" "ERROR"
     log "Aborting translation run. Please resolve the blocking issue." "ERROR"
+    record_pipeline_event "pending_pr_guard" "reason=$1"
     # Send heartbeat ping before exiting to indicate successful (expected) skip
-    send_heartbeat_if_configured
+    send_heartbeat_if_configured "pending_pr_guard"
     exit 0 # Exit cleanly to prevent cron from flagging it as a failure
 }
 
@@ -278,6 +323,8 @@ RANDOM_DELAY=$((RANDOM % 6))
 log "Adding random delay of ${RANDOM_DELAY}s to desynchronize concurrent starts..." "DEBUG"
 sleep "$RANDOM_DELAY"
 
+run_smoke_only_if_requested
+
 # --- Pull Request Gate ---
 # This gate prevents the script from running if there's already a pending PR.
 # It checks for two conditions:
@@ -318,22 +365,7 @@ fi
 log "Starting Git and Transifex validation..."
 # Load configuration from YAML file
 # Use the environment variable if it's set, otherwise default to config.yaml in the CWD.
-CONFIG_FILE="${TRANSLATOR_CONFIG_FILE:-config.yaml}"
-
-if [ ! -f "$CONFIG_FILE" ]; then
-    log "Configuration file not found at '$CONFIG_FILE'." "ERROR"
-    # Attempt to find it in the script's directory as a fallback for local runs.
-    SCRIPT_DIR_REAL=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-    if [ -f "$SCRIPT_DIR_REAL/$CONFIG_FILE" ]; then
-        CONFIG_FILE="$SCRIPT_DIR_REAL/$CONFIG_FILE"
-        log "Found config file in script directory: $CONFIG_FILE" "INFO"
-    else
-        log "Also not found in script directory. Aborting." "ERROR"
-        exit 1
-    fi
-fi
-CONFIG_FILE=$(cd "$(dirname "$CONFIG_FILE")" && pwd)/$(basename "$CONFIG_FILE")
-export TRANSLATOR_CONFIG_FILE="$CONFIG_FILE"
+resolve_config_file
 log "Using configuration file: $CONFIG_FILE"
 
 # Helper function to parse values from config.yaml robustly using yq
@@ -424,11 +456,14 @@ prepare_translation_source() {
             # Match translation files even when staged for deletion (D prefix) or renames (-> suffix)
             if ! git status --porcelain | grep -qE "$(translation_file_change_regex)"; then
                 log "Transifex pull completed successfully, but no translation files were modified. This is normal when there are no new translation keys." "INFO"
+                record_pipeline_event "source_files_detected" "count=0 source=transifex"
                 log "No further processing needed. Exiting gracefully."
-                send_heartbeat_if_configured
+                send_heartbeat_if_configured "no_source_changes"
                 exit 0
             fi
 
+            SOURCE_CHANGE_COUNT=$(git status --porcelain | grep -E "$(translation_file_change_regex)" | wc -l | tr -d '[:space:]')
+            record_pipeline_event "source_files_detected" "count=${SOURCE_CHANGE_COUNT:-0} source=transifex"
             log "Transifex pull successfully updated translation files. Starting AI translation processing..." "INFO"
 
         else
@@ -577,6 +612,8 @@ if [ $PY_EXIT -ne 0 ]; then
   log "Error: Localization CLI exited with code $PY_EXIT"
   exit $PY_EXIT
 fi
+PROCESSED_FILE_COUNT=$(jq -r '(.files // {}) | length' "$VALIDATION_SUMMARY" 2>/dev/null || echo 0)
+record_pipeline_event "files_processed" "count=${PROCESSED_FILE_COUNT:-0}"
 
 # Change back to the target project root for the final git operations.
 cd "$TARGET_PROJECT_ROOT"
@@ -660,6 +697,14 @@ stage_and_submit_batch() {
     if [ "$SEMANTIC_REVIEW_EXIT" -ne 0 ]; then
         log "Semantic AI review failed; continuing with deterministic quality gate only." "WARNING"
     fi
+    log "Re-staging translation files after semantic review"
+    for bf in "${BATCH_FILES[@]}"; do
+        if [ -f "$bf" ]; then
+            git add -- "$bf"
+        else
+            git rm -- "$bf" 2>/dev/null || true
+        fi
+    done
 
     local QUALITY_GATE_EXIT=0
     set +e
@@ -719,6 +764,12 @@ This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT
         log "Found skipped files report. Prepending to PR description."
         PR_BODY=$(printf "%s\n\n%s" "$(cat "$SKIPPED_FILES_REPORT")" "$PR_BODY")
     fi
+    if [ -s "$SKIPPED_FILES_REPORT" ]; then
+        SKIPPED_FILE_COUNT=$(grep -cve '^[[:space:]]*$' "$SKIPPED_FILES_REPORT" || true)
+        record_pipeline_event "skipped_files" "count=${SKIPPED_FILE_COUNT:-0}"
+    else
+        record_pipeline_event "skipped_files" "count=0"
+    fi
 
     # Append per-run token usage / estimated cost so reviewers see what the run cost.
     local TOKEN_USAGE_JSON="$report_dir/token_usage_summary.json"
@@ -747,6 +798,7 @@ This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT
         --base "$TARGET_BRANCH_FOR_PR" \
         --head "${FORK_OWNER}:$branch"); then
         log "Successfully created pull request: $PR_URL"
+        record_pipeline_event "pull_request_created" "url=$PR_URL branch=$branch files=${#BATCH_FILES[@]}"
     else
         log "Error: Failed to create pull request. Check gh cli auth and GITHUB_TOKEN." "ERROR"
         return 1
@@ -832,6 +884,7 @@ if [ -n "$TRANSLATION_CHANGES" ]; then
         mapfile -t ALL_FILES < <(collect_changed_translation_files "$REL_INPUT_FOLDER")
         TOTAL_FILES=${#ALL_FILES[@]}
         log "Total translation files to commit: $TOTAL_FILES (split threshold: $MAX_FILES_PER_PR)"
+        record_pipeline_event "translation_files_detected" "count=$TOTAL_FILES input_folder=$REL_INPUT_FOLDER"
 
         # Read the descriptive PR title from the Python-generated summary.
         TRANSLATION_SUMMARY="/app/logs/translation_summary.json"

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -64,7 +64,24 @@ log_cmd() {
 record_pipeline_event() {
     local event="$1"
     shift || true
-    log "PIPELINE_EVENT event=$event $*" "INFO"
+    local payload
+    payload="{\"event\":$(record_pipeline_event_field "$event")"
+    local field key value
+    for field in "$@"; do
+        key="${field%%=*}"
+        value="${field#*=}"
+        if [[ -z "$key" || "$key" == "$field" || "$key" =~ [^A-Za-z0-9_] ]]; then
+            key="value"
+            value="$field"
+        fi
+        payload="${payload},\"${key}\":$(record_pipeline_event_field "$value")"
+    done
+    payload="${payload}}"
+    log "PIPELINE_EVENT $payload" "INFO"
+}
+
+record_pipeline_event_field() {
+    python3 -c 'import json, sys; print(json.dumps(sys.argv[1], ensure_ascii=False))' "$1"
 }
 
 command_exists() {


### PR DESCRIPTION
## Summary
- rebrand docs/action/package metadata around localize-pipeline and add llms.txt for agent discovery
- add doctor/smoke/quality-gate CLI surfaces plus deploy smoke-only mode and structured pipeline events
- add adapter-based semantic remediation, a sanitized Bisq mobile profile fixture, and a new-format checklist

## Verification
- ./venv/bin/pytest
- ./venv/bin/ruff check .
- bash -n update-translations.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new CLI checks for diagnostics, smoke runs, and quality gating.
  * Enabled optional automatic application of safe semantic-review suggestions.
  * Added support for an additional mobile localization profile and glossary.

* **Bug Fixes**
  * Improved pipeline handling for empty-change runs, restarts, and validation tracking.
  * Updated workflow steps and release references to the latest action name.

* **Documentation**
  * Refreshed setup, workflow, and CLI docs with the latest commands and examples.
  * Added guidance for creating new localization formats and repository usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->