### PR TITLE
Fix smoke-only app root

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ incremental runs.
 
 Full guide: [docs/github-action.md](docs/github-action.md).
 
-## Documentation Site
+## Documentation
 
-The polished docs entry point is [docs/index.html](docs/index.html). It is a
-static page that can be served by GitHub Pages from the `docs/` directory or
-opened directly in a browser.
+Start with the agent-readable index in [llms.txt](llms.txt), then use the
+developer guide in [docs/index.html](docs/index.html) for setup, configuration,
+CLI commands, and supported localization formats.
 
 ## Configuration Model
 

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,16 +1,17 @@
 :root {
   color-scheme: light;
-  --bg: #f7f5ef;
-  --panel: #ffffff;
-  --panel-muted: #f1efe7;
-  --ink: #1f2528;
-  --muted: #5f696d;
-  --line: #d8d3c7;
-  --accent: #0f766e;
-  --accent-strong: #0b4f49;
-  --accent-soft: #d9f0ec;
-  --gold: #ad7c1b;
-  --shadow: 0 16px 40px rgb(31 37 40 / 10%);
+  --paper: #fbfbfa;
+  --white: #fffffe;
+  --soft: #f3f3f3;
+  --soft-green: #eef8ef;
+  --ink: #191919;
+  --muted: #626a64;
+  --line: #d9ddd8;
+  --green: #25b135;
+  --green-dark: #12871d;
+  --code: #111513;
+  --code-line: #2a312d;
+  --shadow: 0 22px 60px rgb(25 25 25 / 10%);
 }
 
 * {
@@ -23,11 +24,14 @@ html {
 
 body {
   margin: 0;
-  background: var(--bg);
+  background: var(--paper);
   color: var(--ink);
   font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+    "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  font-size: 16px;
+  font-weight: 300;
+  letter-spacing: 0;
   line-height: 1.55;
 }
 
@@ -36,10 +40,34 @@ a {
   text-decoration: none;
 }
 
+a:focus-visible,
+button:focus-visible {
+  outline: 3px solid rgb(37 177 53 / 35%);
+  outline-offset: 4px;
+}
+
 code,
 pre {
   font-family:
-    "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    "IBM Plex Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
+    monospace;
+}
+
+.skip-link {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 20;
+  transform: translateY(-150%);
+  padding: 10px 14px;
+  background: var(--ink);
+  color: var(--white);
+  font-weight: 500;
+  transition: transform 180ms ease-out;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
 }
 
 .site-header {
@@ -49,74 +77,123 @@ pre {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
-  padding: 18px clamp(20px, 5vw, 72px);
-  border-bottom: 1px solid rgb(216 211 199 / 70%);
-  background: rgb(247 245 239 / 92%);
-  backdrop-filter: blur(16px);
+  gap: 32px;
+  min-height: 70px;
+  padding: 0 max(24px, calc((100vw - 1180px) / 2));
+  border-bottom: 1px solid var(--line);
+  background: rgb(251 251 250 / 94%);
+  backdrop-filter: blur(12px);
 }
 
 .brand,
 .top-nav,
 .hero-actions,
+.agent-links,
+.tag-row,
 .site-footer {
   display: flex;
   align-items: center;
 }
 
 .brand {
-  gap: 10px;
-  font-weight: 720;
+  gap: 12px;
+  min-width: 0;
 }
 
 .brand-mark {
-  display: inline-grid;
-  width: 32px;
-  height: 32px;
-  place-items: center;
-  border: 1px solid var(--accent);
-  background: var(--accent);
-  color: #ffffff;
+  display: grid;
+  grid-template-columns: repeat(3, 4px);
+  gap: 4px;
+  align-items: end;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  background: var(--green);
+}
+
+.brand-mark span {
+  display: block;
+  width: 4px;
+  background: var(--white);
+}
+
+.brand-mark span:nth-child(1) {
+  height: 13px;
+}
+
+.brand-mark span:nth-child(2) {
+  height: 22px;
+}
+
+.brand-mark span:nth-child(3) {
+  height: 17px;
+}
+
+.brand-copy {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
+.brand-copy strong {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.brand-copy small {
+  color: var(--muted);
   font-size: 12px;
-  letter-spacing: 0;
 }
 
 .top-nav {
-  gap: 22px;
+  gap: 28px;
   color: var(--muted);
   font-size: 14px;
+  font-weight: 500;
+}
+
+.top-nav a,
+.site-footer a,
+.doc-list a,
+.text-link {
+  transition:
+    color 160ms ease-out,
+    background-color 160ms ease-out,
+    border-color 160ms ease-out,
+    transform 160ms ease-out;
 }
 
 .top-nav a:hover,
 .site-footer a:hover,
-.doc-list a:hover {
-  color: var(--accent-strong);
+.doc-list a:hover,
+.text-link:hover {
+  color: var(--green-dark);
 }
 
 main {
-  width: min(1180px, calc(100% - 40px));
+  width: min(1180px, calc(100% - 48px));
   margin: 0 auto;
 }
 
 .hero {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(360px, 0.9fr);
-  gap: clamp(32px, 7vw, 86px);
+  grid-template-columns: minmax(0, 0.95fr) minmax(390px, 0.78fr);
+  gap: 76px;
   align-items: center;
-  min-height: calc(100svh - 76px);
-  padding: 64px 0 40px;
+  min-height: calc(100svh - 70px);
+  padding: 84px 0 58px;
 }
 
 .hero-copy {
-  max-width: 680px;
+  max-width: 730px;
 }
 
-.eyebrow,
-.card-kicker {
-  margin: 0 0 12px;
-  color: var(--accent-strong);
+.eyebrow {
+  margin: 0 0 14px;
+  color: var(--green-dark);
   font-size: 12px;
-  font-weight: 760;
+  font-weight: 700;
   letter-spacing: 0;
   text-transform: uppercase;
 }
@@ -128,209 +205,332 @@ p {
   margin-top: 0;
 }
 
-h1 {
-  max-width: 780px;
-  margin-bottom: 22px;
-  font-size: clamp(46px, 7vw, 84px);
-  line-height: 0.95;
+h1,
+h2,
+h3 {
+  font-weight: 500;
   letter-spacing: 0;
+}
+
+h1 {
+  max-width: 820px;
+  margin-bottom: 24px;
+  font-size: 76px;
+  line-height: 0.96;
 }
 
 h2 {
-  margin-bottom: 14px;
-  font-size: clamp(30px, 4vw, 48px);
-  line-height: 1.05;
-  letter-spacing: 0;
+  max-width: 760px;
+  margin-bottom: 16px;
+  font-size: 44px;
+  line-height: 1.06;
 }
 
 h3 {
-  margin-bottom: 8px;
-  font-size: 18px;
-  letter-spacing: 0;
+  margin-bottom: 6px;
+  font-size: 19px;
+  line-height: 1.25;
 }
 
 .lede {
-  max-width: 620px;
+  max-width: 660px;
   color: var(--muted);
-  font-size: clamp(18px, 2.1vw, 22px);
+  font-size: 22px;
+  line-height: 1.48;
 }
 
 .hero-actions {
   flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 30px;
+  gap: 12px 18px;
+  margin-top: 34px;
 }
 
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 44px;
+  min-height: 46px;
   padding: 0 18px;
   border: 1px solid var(--ink);
-  border-radius: 8px;
-  font-weight: 700;
+  border-radius: 4px;
+  font-weight: 600;
 }
 
 .button.primary {
   background: var(--ink);
-  color: #ffffff;
+  color: var(--white);
 }
 
-.button.secondary {
-  background: transparent;
+.button.primary:hover {
+  border-color: var(--green);
+  background: var(--green);
+  color: var(--white);
 }
 
-.workflow-visual {
+.button.secondary:hover {
+  border-color: var(--green);
+  color: var(--green-dark);
+}
+
+.button:active,
+.route-item:active,
+.doc-list a:active {
+  transform: translateY(1px);
+}
+
+.text-link {
+  color: var(--green-dark);
+  font-weight: 600;
+}
+
+.run-panel {
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--panel);
+  background: var(--white);
   box-shadow: var(--shadow);
+}
+
+.panel-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 46px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--soft);
+}
+
+.panel-bar span {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #b7bdb8;
+}
+
+.panel-bar span:first-child {
+  background: var(--green);
+}
+
+.panel-bar strong {
+  margin-left: 6px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.status-ledger {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border-bottom: 1px solid var(--line);
+}
+
+.status-ledger div {
+  min-height: 92px;
+  padding: 18px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.status-ledger div:nth-child(2n) {
+  border-right: 0;
+}
+
+.status-ledger div:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.status-ledger span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.status-ledger strong {
+  font-weight: 600;
+}
+
+.run-panel pre,
+.command-panel {
+  overflow-x: auto;
+  margin: 0;
+  background: var(--code);
+  color: #ecf2ed;
+}
+
+.run-panel pre {
   padding: 20px;
 }
 
-.workflow-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 16px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--panel-muted);
-}
-
-.workflow-row.active {
-  border-color: var(--accent);
-  background: var(--accent-soft);
-}
-
-.step-label {
-  font-weight: 760;
-}
-
-.step-state {
-  color: var(--muted);
-  text-align: right;
-}
-
-.workflow-line {
-  width: 1px;
-  height: 22px;
-  margin: 0 auto;
-  background: var(--line);
-}
-
-.workflow-visual pre,
-.command-panel {
-  overflow-x: auto;
-  margin: 20px 0 0;
-  border: 1px solid #273035;
-  border-radius: 8px;
-  background: #151a1d;
-  color: #e9eee9;
-}
-
-.workflow-visual pre {
-  padding: 18px;
-}
-
-.workflow-visual code {
+.run-panel code {
   white-space: pre;
 }
 
-.quick-grid {
+.agent-strip {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
-  margin-top: -28px;
-  padding-bottom: 90px;
+  grid-template-columns: minmax(220px, 0.7fr) minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: center;
+  margin-bottom: 76px;
+  padding: 26px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
 }
 
-.guide-card {
-  display: grid;
-  gap: 8px;
-  min-height: 190px;
-  padding: 22px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--panel);
+.agent-strip h2 {
+  margin-bottom: 0;
+  font-size: 28px;
 }
 
-.guide-card strong {
-  font-size: 22px;
-}
-
-.guide-card span:last-child,
-.section p,
-.timeline p {
+.agent-strip p {
+  margin-bottom: 0;
   color: var(--muted);
 }
 
+.agent-links {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.agent-links a,
+.tag-row span {
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  background: var(--white);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.agent-links a:hover {
+  border-color: var(--green);
+  color: var(--green-dark);
+}
+
+.route-section,
 .section {
-  padding: 86px 0;
+  padding: 82px 0;
   border-top: 1px solid var(--line);
 }
 
 .section-heading {
-  max-width: 760px;
-  margin-bottom: 28px;
+  max-width: 780px;
+  margin-bottom: 34px;
 }
 
-.timeline {
+.route-list {
+  display: grid;
+  border-top: 1px solid var(--line);
+}
+
+.route-item {
+  display: grid;
+  grid-template-columns: 70px minmax(180px, 0.38fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: baseline;
+  padding: 24px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.route-item:hover {
+  color: var(--green-dark);
+}
+
+.route-item span,
+.process-list > li > span {
+  color: var(--green);
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 500;
+}
+
+.route-item strong {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.route-item p,
+.section p,
+.process-list p {
+  color: var(--muted);
+}
+
+.route-item p {
+  margin-bottom: 0;
+}
+
+.process {
+  background: var(--soft);
+  box-shadow:
+    50vw 0 0 var(--soft),
+    -50vw 0 0 var(--soft);
+}
+
+.process-list {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
-}
-
-.timeline > div {
-  padding: 22px;
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background: var(--line);
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--panel);
 }
 
-.number {
-  display: inline-grid;
-  width: 30px;
-  height: 30px;
-  place-items: center;
-  margin-bottom: 18px;
-  border-radius: 50%;
-  background: var(--accent);
-  color: #ffffff;
-  font-weight: 800;
+.process-list li {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 18px;
+  min-height: 190px;
+  padding: 24px;
+  background: var(--white);
+}
+
+.process-list p {
+  margin-bottom: 0;
 }
 
 .split {
   display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.7fr);
-  gap: 44px;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.56fr);
+  gap: 64px;
   align-items: start;
+}
+
+.tag-row {
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 26px;
+}
+
+.tag-row span {
+  background: var(--soft-green);
+  border-color: rgb(37 177 53 / 24%);
 }
 
 .doc-list {
   display: grid;
-  gap: 10px;
+  border-top: 1px solid var(--line);
 }
 
 .doc-list a {
-  padding: 14px 16px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--panel);
-  font-weight: 700;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--line);
+  font-weight: 600;
+}
+
+.operations {
+  padding-bottom: 110px;
 }
 
 .command-panel {
   display: grid;
-  gap: 0;
-  padding: 8px;
+  border: 1px solid var(--code-line);
 }
 
 .command-panel code {
   display: block;
-  padding: 12px 14px;
-  border-bottom: 1px solid rgb(255 255 255 / 10%);
+  padding: 15px 18px;
+  border-bottom: 1px solid var(--code-line);
   white-space: nowrap;
 }
 
@@ -340,8 +540,8 @@ h3 {
 
 .site-footer {
   justify-content: center;
-  gap: 18px;
-  padding: 38px 20px;
+  gap: 20px;
+  padding: 36px 24px;
   border-top: 1px solid var(--line);
   color: var(--muted);
   font-size: 14px;
@@ -349,35 +549,112 @@ h3 {
 
 .site-footer span {
   color: var(--ink);
-  font-weight: 760;
+  font-weight: 700;
 }
 
-@media (max-width: 900px) {
-  .site-header,
-  .top-nav,
-  .site-footer {
-    align-items: flex-start;
-    flex-direction: column;
+@media (max-width: 1040px) {
+  h1 {
+    font-size: 60px;
   }
 
-  .top-nav {
-    gap: 10px;
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+    padding-top: 64px;
   }
 
-  .hero,
-  .quick-grid,
-  .timeline,
+  .run-panel {
+    max-width: 720px;
+  }
+
+  .agent-strip,
   .split {
     grid-template-columns: 1fr;
   }
 
-  .hero {
-    min-height: auto;
-    padding-top: 48px;
+  .agent-links {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 760px) {
+  main {
+    width: min(100% - 32px, 1180px);
   }
 
-  .quick-grid {
-    margin-top: 0;
-    padding-bottom: 48px;
+  .site-header {
+    position: static;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 14px;
+    padding: 16px;
+  }
+
+  .top-nav {
+    flex-wrap: wrap;
+    gap: 12px 18px;
+  }
+
+  h1 {
+    font-size: 44px;
+  }
+
+  h2 {
+    font-size: 32px;
+  }
+
+  .lede {
+    font-size: 18px;
+  }
+
+  .hero,
+  .route-section,
+  .section {
+    padding-top: 54px;
+    padding-bottom: 54px;
+  }
+
+  .agent-strip {
+    margin-bottom: 42px;
+  }
+
+  .status-ledger,
+  .process-list {
+    grid-template-columns: 1fr;
+  }
+
+  .status-ledger div,
+  .status-ledger div:nth-child(2n),
+  .status-ledger div:nth-last-child(-n + 2) {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .status-ledger div:last-child {
+    border-bottom: 0;
+  }
+
+  .route-item {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,129 +6,202 @@
     <title>Localize Pipeline - AI localization as pull requests</title>
     <meta
       name="description"
-      content="Localize Pipeline translates Java .properties and JSON localization files with model-provider abstraction, review gates, translation memory, and pull-request workflows."
+      content="Localize Pipeline translates Java .properties and JSON localization files with provider abstraction, review gates, translation memory, and pull-request workflows."
     >
+    <meta name="robots" content="index,follow">
+    <link rel="canonical" href="https://bisq-network.github.io/localize-pipeline/">
+    <meta property="og:title" content="Localize Pipeline">
+    <meta
+      property="og:description"
+      content="AI localization automation for maintainers: changed strings in, reviewable translation pull requests out."
+    >
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://bisq-network.github.io/localize-pipeline/">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Localize Pipeline">
+    <meta
+      name="twitter:description"
+      content="Translate localization files through a reviewable, provider-neutral PR pipeline."
+    >
+    <link rel="preconnect" href="https://bisq.network">
+    <link href="https://bisq.network/css/fonts.css" rel="stylesheet">
     <link rel="stylesheet" href="assets/site.css">
   </head>
   <body>
+    <a class="skip-link" href="#content">Skip to content</a>
+
     <header class="site-header">
       <a class="brand" href="index.html" aria-label="Localize Pipeline docs homepage">
-        <span class="brand-mark" aria-hidden="true">LP</span>
-        <span>Localize Pipeline</span>
+        <span class="brand-mark" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+        <span class="brand-copy">
+          <strong>Localize Pipeline</strong>
+          <small>Bisq Network tooling</small>
+        </span>
       </a>
       <nav class="top-nav" aria-label="Primary">
         <a href="localization-cli.md">CLI</a>
         <a href="github-action.md">GitHub Action</a>
-        <a href="new-project-deployment.md">Server</a>
-        <a href="repository-structure.md">Structure</a>
+        <a href="#formats">Formats</a>
+        <a href="new-project-deployment.md">Runbook</a>
       </nav>
     </header>
 
-    <main>
-      <section class="hero">
+    <main id="content">
+      <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="eyebrow">AI localization for maintainers</p>
-          <h1>Ship translations as normal pull requests.</h1>
+          <p class="eyebrow">Open-source localization automation</p>
+          <h1 id="hero-title">Review translations like code.</h1>
           <p class="lede">
-            Localize Pipeline detects changed source strings, translates Java .properties
-            and JSON files, runs quality checks, and opens reviewable PRs from your own
-            CI or server.
+            Localize Pipeline watches changed source strings, translates Java .properties
+            and JSON files, validates the result, and opens normal pull requests that
+            maintainers can review, amend, and merge.
           </p>
           <div class="hero-actions" aria-label="Quick links">
             <a class="button primary" href="localization-cli.md">Start with the CLI</a>
-            <a class="button secondary" href="github-action.md">Use the Action</a>
+            <a class="button secondary" href="github-action.md">Use the GitHub Action</a>
+            <a
+              class="text-link"
+              href="https://github.com/bisq-network/localize-pipeline/blob/main/llms.txt"
+            >Agent index</a>
           </div>
         </div>
 
-        <div class="workflow-visual" aria-label="Localization workflow overview">
-          <div class="workflow-row">
-            <span class="step-label">Source repo</span>
-            <span class="step-state">Changed strings</span>
+        <aside class="run-panel" aria-label="Production run snapshot">
+          <div class="panel-bar">
+            <span></span>
+            <span></span>
+            <span></span>
+            <strong>localize run</strong>
           </div>
-          <div class="workflow-line" aria-hidden="true"></div>
-          <div class="workflow-row active">
-            <span class="step-label">Localize Pipeline</span>
-            <span class="step-state">AISuite provider, glossary, review</span>
+          <div class="status-ledger">
+            <div>
+              <span>source keys</span>
+              <strong>changed</strong>
+            </div>
+            <div>
+              <span>formats</span>
+              <strong>.properties + JSON</strong>
+            </div>
+            <div>
+              <span>quality gate</span>
+              <strong>reviewed</strong>
+            </div>
+            <div>
+              <span>output</span>
+              <strong>pull request</strong>
+            </div>
           </div>
-          <div class="workflow-line" aria-hidden="true"></div>
-          <div class="workflow-row">
-            <span class="step-label">Translation PR</span>
-            <span class="step-state">Diff, checks, memory update</span>
-          </div>
-          <pre><code>localize bootstrap-pr --target-project-root repo
-localize check --config config.yaml
+          <pre><code>localize doctor --config config.yaml
+localize smoke --config config.yaml
 localize run --dry-run --config config.yaml
-localize memory stats --memory-file logs/translation_memory.json</code></pre>
+localize quality-gate --repo-root . --changed-files ...</code></pre>
+        </aside>
+      </section>
+
+      <section class="agent-strip" aria-labelledby="agent-title">
+        <div>
+          <p class="eyebrow">Agent entry points</p>
+          <h2 id="agent-title">Start with the map, then run checks.</h2>
+        </div>
+        <p>
+          Agents should read the repository index first, inspect the target profile,
+          then use the CLI preflight commands before changing translations.
+        </p>
+        <div class="agent-links" aria-label="Agent references">
+          <a href="https://github.com/bisq-network/localize-pipeline/blob/main/llms.txt">llms.txt</a>
+          <a href="repository-structure.md">Repository structure</a>
+          <a href="localization-cli.md">CLI commands</a>
         </div>
       </section>
 
-      <section class="quick-grid" aria-label="Primary paths">
-        <a class="guide-card" href="localization-cli.md">
-          <span class="card-kicker">Local development</span>
-          <strong>CLI guide</strong>
-          <span>Scaffold config, validate setup, run dry checks, and manage memory.</span>
-        </a>
-        <a class="guide-card" href="github-action.md">
-          <span class="card-kicker">CI workflow</span>
-          <strong>GitHub Action</strong>
-          <span>Translate changed strings and open pull requests from normal CI.</span>
-        </a>
-        <a class="guide-card" href="new-project-deployment.md">
-          <span class="card-kicker">Scheduled service</span>
-          <strong>Server deployment</strong>
-          <span>Run Docker Compose plus cron for Transifex-backed production jobs.</span>
-        </a>
-      </section>
-
-      <section class="section">
+      <section class="route-section" aria-labelledby="route-title">
         <div class="section-heading">
-          <p class="eyebrow">Adoption path</p>
-          <h2>Onboard a repository in one reviewable PR.</h2>
+          <p class="eyebrow">Choose the path</p>
+          <h2 id="route-title">Adopt it without changing how maintainers review code.</h2>
         </div>
-        <div class="timeline">
-          <div>
-            <span class="number">1</span>
-            <h3>Generate</h3>
-            <p>Run <code>localize bootstrap-pr</code> to create config, glossary, workflow, and a target-repo guide.</p>
-          </div>
-          <div>
-            <span class="number">2</span>
-            <h3>Validate</h3>
-            <p>Keep <code>dry-run: true</code>, add credentials or a local endpoint, and run preflight checks.</p>
-          </div>
-          <div>
-            <span class="number">3</span>
-            <h3>Translate</h3>
-            <p>Enable writes, run an initial backfill, and review translations through normal PR review.</p>
-          </div>
+        <div class="route-list">
+          <a class="route-item" href="localization-cli.md">
+            <span>01</span>
+            <strong>Local project setup</strong>
+            <p>Scaffold config, validate credentials, run smoke checks, and test dry runs.</p>
+          </a>
+          <a class="route-item" href="github-action.md">
+            <span>02</span>
+            <strong>GitHub Action workflow</strong>
+            <p>Translate changed strings from CI and open reviewable pull requests.</p>
+          </a>
+          <a class="route-item" href="new-project-deployment.md">
+            <span>03</span>
+            <strong>Scheduled production service</strong>
+            <p>Run Docker Compose plus cron for repositories backed by external sources.</p>
+          </a>
         </div>
       </section>
 
-      <section class="section split">
+      <section class="section process" aria-labelledby="process-title">
+        <div class="section-heading">
+          <p class="eyebrow">Adoption flow</p>
+          <h2 id="process-title">One onboarding PR, then normal translation PRs.</h2>
+        </div>
+        <ol class="process-list">
+          <li>
+            <span>1</span>
+            <div>
+              <h3>Bootstrap</h3>
+              <p>Run <code>localize bootstrap-pr</code> to add config, glossary, workflow, and target-repo notes.</p>
+            </div>
+          </li>
+          <li>
+            <span>2</span>
+            <div>
+              <h3>Verify</h3>
+              <p>Keep dry-run mode on while <code>localize doctor</code>, <code>localize smoke</code>, and validation pass.</p>
+            </div>
+          </li>
+          <li>
+            <span>3</span>
+            <div>
+              <h3>Publish</h3>
+              <p>Enable writes, review the generated PR, and let translation memory improve future runs.</p>
+            </div>
+          </li>
+        </ol>
+      </section>
+
+      <section id="formats" class="section split" aria-labelledby="formats-title">
         <div>
           <p class="eyebrow">Formats and providers</p>
-          <h2>Built for extension without rewriting the pipeline.</h2>
+          <h2 id="formats-title">Modular by contract, not by convention.</h2>
           <p>
-            Java .properties and JSON are built in. Custom adapters can be loaded
-            through CLI plugins, Action plugin inputs, or Python entry points.
-            AISuite is the default model-provider abstraction, with an explicit
-            OpenAI-compatible fallback for local endpoints.
+            Java .properties and JSON are built in. Additional formats plug into the
+            same adapter contract, so parsing, changed-key detection, placeholder
+            validation, quality gates, and publishing stay reusable across projects.
           </p>
+          <div class="tag-row" aria-label="Supported surfaces">
+            <span>Java .properties</span>
+            <span>JSON</span>
+            <span>AISuite</span>
+            <span>GitHub PRs</span>
+          </div>
         </div>
         <div class="doc-list" aria-label="Implementation references">
           <a href="repository-structure.md">Repository structure</a>
-          <a href="localization-cli.md">CLI commands</a>
+          <a href="new-format-checklist.md">New format checklist</a>
           <a href="how-to-run-locally.md">Local runs</a>
           <a href="adding-new-locales.md">Adding locales</a>
         </div>
       </section>
 
-      <section class="section">
+      <section class="section operations" aria-labelledby="operations-title">
         <div class="section-heading">
           <p class="eyebrow">Operational surface</p>
-          <h2>Keep translation state visible and portable.</h2>
+          <h2 id="operations-title">Keep state visible and portable.</h2>
         </div>
-        <div class="command-panel">
+        <div class="command-panel" aria-label="Translation memory commands">
           <code>localize memory stats --memory-file logs/translation_memory.json</code>
           <code>localize memory export --memory-file logs/translation_memory.json --output shared-memory.json</code>
           <code>localize memory import --memory-file logs/translation_memory.json --input shared-memory.json</code>
@@ -139,9 +212,10 @@ localize memory stats --memory-file logs/translation_memory.json</code></pre>
 
     <footer class="site-footer">
       <span>Localize Pipeline</span>
-      <a href="repository-structure.md">Repository structure</a>
+      <a href="repository-structure.md">Structure</a>
       <a href="how-to-run-locally.md">Run locally</a>
       <a href="maintenance/disk-space-management.md">Maintenance</a>
+      <a href="https://github.com/bisq-network/localize-pipeline">GitHub</a>
     </footer>
   </body>
 </html>

--- a/tests/unit/test_docs_site.py
+++ b/tests/unit/test_docs_site.py
@@ -43,13 +43,24 @@ def test_docs_homepage_is_packaged_for_github_pages():
     css = stylesheet.read_text(encoding="utf-8")
 
     assert "<title>Localize Pipeline" in html
+    assert '<meta property="og:title"' in html
+    assert 'href="https://bisq.network/css/fonts.css"' in html
     assert 'href="assets/site.css"' in html
+    assert 'href="#content"' in html
+    assert 'id="content"' in html
+    assert "Agent entry points" in html
     assert "localize bootstrap-pr" in html
     assert "localize memory stats" in html
     assert "GitHub Action" in html
     assert "Java .properties" in html
     assert "JSON" in html
+    assert ">LP<" not in html
+    assert "served by GitHub Pages" not in html
     assert ".hero" in css
+    assert ".skip-link:focus" in css
+    assert "#25b135" in css
+    assert "IBM Plex Sans" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css
     assert "@media" in css
     assert "[docs/index.html](docs/index.html)" in readme.read_text(encoding="utf-8")
 

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -101,6 +101,9 @@ def test_smoke_only_mode_runs_before_pending_pr_guard():
     pending_guard_index = script.index("Checking for manually-blocked PRs")
 
     assert "run_smoke_only_if_requested()" in script
+    assert 'local app_root="${APP_ROOT:-/app}"' in script
+    assert '( cd "$app_root" && python3 -m localize.cli doctor --config "$CONFIG_FILE" )' in script
+    assert '( cd "$app_root" && python3 -m localize.cli smoke --config "$CONFIG_FILE" )' in script
     assert "python3 -m localize.cli doctor" in script
     assert "python3 -m localize.cli smoke" in script
     assert smoke_index < pending_guard_index

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -117,9 +117,13 @@ run_smoke_only_if_requested() {
     fi
 
     resolve_config_file
+    local app_root="${APP_ROOT:-/app}"
+    if [ ! -d "$app_root" ]; then
+        app_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    fi
     log "Running smoke-only deployment verification with configuration file: $CONFIG_FILE"
-    python3 -m localize.cli doctor --config "$CONFIG_FILE"
-    python3 -m localize.cli smoke --config "$CONFIG_FILE"
+    ( cd "$app_root" && python3 -m localize.cli doctor --config "$CONFIG_FILE" )
+    ( cd "$app_root" && python3 -m localize.cli smoke --config "$CONFIG_FILE" )
     record_pipeline_event "smoke_only_ok" "config=$CONFIG_FILE"
     send_heartbeat_if_configured "smoke_only_ok"
     exit 0


### PR DESCRIPTION
## Summary
- run smoke-only doctor/smoke commands from the app root before normal script setup
- keep a local checkout fallback for non-container smoke-only runs
- adjust the README docs pointer so maintainer-only GitHub Pages setup is not presented as developer guidance

## Why
Production smoke-only verification executes before the entrypoint changes into /app, so python3 -m localize.cli could not resolve the local package in the container. This preserves smoke-only verification even when a generated translation PR is open.

## Validation
- ./venv/bin/pytest
- ./venv/bin/ruff check .
- bash -n update-translations.sh