### PR TITLE
Prepare runtime queues before appuser

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -86,6 +86,52 @@ ensure_logs_dir() {
   chmod "$mode" /app/logs || log "Warning: Could not set permissions on /app/logs. Continuing..." "WARNING"
 }
 
+resolve_app_runtime_dir() {
+  local configured_path="${1:-}"
+  if [ -z "$configured_path" ] || [ "$configured_path" = "null" ]; then
+    return 1
+  fi
+
+  case "$configured_path" in
+    /*) printf '%s\n' "$configured_path" ;;
+    *) printf '/app/%s\n' "$configured_path" ;;
+  esac
+}
+
+ensure_configured_runtime_dirs() {
+  local config_file="${TRANSLATOR_CONFIG_FILE:-/app/config.yaml}"
+  local runtime_dirs=("/app/translation_queue" "/app/translated_queue")
+  local key configured_path runtime_dir
+
+  if command -v yq >/dev/null 2>&1 && [ -r "$config_file" ]; then
+    for key in translation_queue_folder translated_queue_folder; do
+      configured_path="$(yq -r ".$key // \"\"" "$config_file" 2>/dev/null || true)"
+      if runtime_dir="$(resolve_app_runtime_dir "$configured_path")"; then
+        runtime_dirs+=("$runtime_dir")
+      fi
+    done
+  else
+    log "Config file unavailable for runtime directory discovery; using default queue folders." "WARNING"
+  fi
+
+  for runtime_dir in "${runtime_dirs[@]}"; do
+    case "$runtime_dir" in
+      /app/*)
+        mkdir -p "$runtime_dir"
+        if [ "$(id -u)" -eq 0 ]; then
+          chown "${APPUSER_UID}:${APPUSER_GID}" "$runtime_dir" \
+            || log "Warning: unable to chown runtime directory $runtime_dir; continuing" "WARNING"
+        fi
+        chmod "${APP_RUNTIME_DIR_MODE:-0755}" "$runtime_dir" \
+          || log "Warning: unable to chmod runtime directory $runtime_dir; continuing" "WARNING"
+        ;;
+      *)
+        log "Skipping configured runtime directory outside /app: $runtime_dir" "WARNING"
+        ;;
+    esac
+  done
+}
+
 # --- Main Execution Logic ---
 # The script acts as a gate:
 # 1. If run as root, it fixes permissions and then re-executes itself as appuser.
@@ -355,6 +401,7 @@ else
 
     # Ensure log directory exists and has correct permissions.
     ensure_logs_dir
+    ensure_configured_runtime_dirs
 
     # Fix permissions on the target repository if it's a mounted volume
     if [ -d "/target_repo" ]; then

--- a/tests/unit/test_docker_entrypoint.py
+++ b/tests/unit/test_docker_entrypoint.py
@@ -1,0 +1,37 @@
+"""Static checks for the Docker entrypoint runtime setup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = PROJECT_ROOT / "docker" / "docker-entrypoint.sh"
+
+
+def _entrypoint_script() -> str:
+    return ENTRYPOINT.read_text(encoding="utf-8")
+
+
+def test_entrypoint_prepares_configured_app_runtime_dirs_before_privilege_drop():
+    script = _entrypoint_script()
+
+    assert "ensure_configured_runtime_dirs()" in script
+    assert 'local config_file="${TRANSLATOR_CONFIG_FILE:-/app/config.yaml}"' in script
+    assert "translation_queue_folder translated_queue_folder" in script
+    assert 'runtime_dir="$(resolve_app_runtime_dir "$configured_path")"' in script
+    assert 'case "$runtime_dir" in' in script
+    assert "/app/*)" in script
+    assert 'chown "${APPUSER_UID}:${APPUSER_GID}" "$runtime_dir"' in script
+
+    root_block_index = script.index("# --- Root Execution Block ---")
+    runtime_dir_index = script.index("ensure_configured_runtime_dirs", root_block_index)
+    privilege_drop_index = script.index("exec gosu appuser", root_block_index)
+
+    assert runtime_dir_index < privilege_drop_index
+
+
+def test_entrypoint_keeps_arbitrary_configured_runtime_paths_out_of_root_setup():
+    script = _entrypoint_script()
+
+    assert 'Skipping configured runtime directory outside /app: $runtime_dir' in script


### PR DESCRIPTION
## Summary
- prepare configured /app runtime queue directories in the Docker entrypoint root phase
- keep root setup restricted to /app runtime paths from config
- add regression tests for entrypoint runtime directory setup before the appuser privilege drop

## Why
Production smoke-only verification now reaches localize smoke, but appuser cannot create /app/translation_queue in the root-owned image filesystem. Normal translation runs need the same queue directories, so the entrypoint must prepare them before dropping privileges.

## Validation
- ./venv/bin/pytest
- ./venv/bin/ruff check .
- bash -n update-translations.sh docker/docker-entrypoint.sh scripts/check-translation-services.sh