### PR TITLE
Ignore blank action env overrides

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,12 +102,22 @@ runs:
         PYTHONPATH: ${{ github.action_path }}
         TRANSLATOR_CONFIG_FILE: ${{ github.workspace }}/${{ inputs.config-file }}
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
-        OPENAI_BASE_URL: ${{ inputs.api-base-url }}
-        REVIEW_MODEL_NAME: ${{ inputs.review-model }}
+        LOCALIZE_API_BASE_URL_INPUT: ${{ inputs.api-base-url }}
+        LOCALIZE_REVIEW_MODEL_INPUT: ${{ inputs.review-model }}
         LOCALIZE_DRY_RUN: ${{ inputs.dry-run }}
         LOCALIZE_PLUGIN_MODULES: ${{ inputs.plugin-modules }}
       run: |
         set -euo pipefail
+        if [ -n "${LOCALIZE_API_BASE_URL_INPUT:-}" ]; then
+          export OPENAI_BASE_URL="$LOCALIZE_API_BASE_URL_INPUT"
+        else
+          unset OPENAI_BASE_URL
+        fi
+        if [ -n "${LOCALIZE_REVIEW_MODEL_INPUT:-}" ]; then
+          export REVIEW_MODEL_NAME="$LOCALIZE_REVIEW_MODEL_INPUT"
+        else
+          unset REVIEW_MODEL_NAME
+        fi
         python -m localize.cli check --config "$TRANSLATOR_CONFIG_FILE"
 
     - name: Translate changed strings
@@ -117,14 +127,24 @@ runs:
         PYTHONPATH: ${{ github.action_path }}
         TRANSLATOR_CONFIG_FILE: ${{ github.workspace }}/${{ inputs.config-file }}
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
-        OPENAI_BASE_URL: ${{ inputs.api-base-url }}
-        REVIEW_MODEL_NAME: ${{ inputs.review-model }}
+        LOCALIZE_API_BASE_URL_INPUT: ${{ inputs.api-base-url }}
+        LOCALIZE_REVIEW_MODEL_INPUT: ${{ inputs.review-model }}
         PROCESS_ALL_FILES: ${{ inputs.process-all-files }}
         DIFF_BASE_INPUT: ${{ inputs.diff-base }}
         LOCALIZE_DRY_RUN: ${{ inputs.dry-run }}
         LOCALIZE_PLUGIN_MODULES: ${{ inputs.plugin-modules }}
       run: |
         set -euo pipefail
+        if [ -n "${LOCALIZE_API_BASE_URL_INPUT:-}" ]; then
+          export OPENAI_BASE_URL="$LOCALIZE_API_BASE_URL_INPUT"
+        else
+          unset OPENAI_BASE_URL
+        fi
+        if [ -n "${LOCALIZE_REVIEW_MODEL_INPUT:-}" ]; then
+          export REVIEW_MODEL_NAME="$LOCALIZE_REVIEW_MODEL_INPUT"
+        else
+          unset REVIEW_MODEL_NAME
+        fi
         # An all-zero SHA (first push to a branch) is not a valid diff base; fall back
         # to working-tree detection rather than failing the run.
         if [[ "${DIFF_BASE_INPUT:-}" =~ ^0*$ ]]; then

--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -406,12 +406,29 @@ def _resolve_dry_run(config: Dict[str, Any]) -> bool:
     return _as_bool(config.get('dry_run', False), default=False)
 
 
+def _non_empty_env(name: str) -> Optional[str]:
+    """Return a stripped environment value, treating blanks as unset.
+
+    Some CI systems export optional inputs as empty environment variables. The
+    OpenAI SDK reads OPENAI_BASE_URL directly from the environment, so leaving a
+    blank value in place can override the SDK default endpoint with an empty URL.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    if stripped:
+        return stripped
+    os.environ.pop(name, None)
+    return None
+
+
 def _resolve_api_base_url(config: Dict[str, Any]) -> Optional[str]:
     """Resolve the OpenAI-compatible endpoint, env (OPENAI_BASE_URL) over config.
 
     Returns None for the default OpenAI API.
     """
-    for candidate in (os.environ.get('OPENAI_BASE_URL'), config.get('api_base_url')):
+    for candidate in (_non_empty_env('OPENAI_BASE_URL'), config.get('api_base_url')):
         if candidate is not None:
             stripped = str(candidate).strip()
             if stripped:
@@ -438,7 +455,7 @@ def _create_model_provider(
         logger.info("Running in dry-run mode, model provider will not be initialized")
         return None
 
-    api_key_from_env = os.environ.get('OPENAI_API_KEY')
+    api_key_from_env = _non_empty_env('OPENAI_API_KEY')
 
     try:
         return create_model_provider(
@@ -517,7 +534,7 @@ def load_app_config() -> AppConfig:
         default=False,
     )
     model_name = config.get('model_name', 'gpt-4')
-    review_model_name = os.environ.get('REVIEW_MODEL_NAME', config.get('review_model_name', model_name))
+    review_model_name = _non_empty_env('REVIEW_MODEL_NAME') or config.get('review_model_name', model_name)
     model_provider_name = normalize_model_provider_name(
         str(config.get('model_provider', DEFAULT_MODEL_PROVIDER) or DEFAULT_MODEL_PROVIDER)
     )

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, mock_open, MagicMock
 import pytest
 import yaml
 
-from localize.app_config import AppConfig, load_app_config, validate_config
+from localize.app_config import AppConfig, _non_empty_env, load_app_config, validate_config
 from localize.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
 from localize.localization_layouts import SUFFIX_LAYOUT
 
@@ -808,6 +808,36 @@ class TestProviderAbstraction:
         assert config.api_base_url == "http://env-host/v1"
         _, kwargs = mock_openai.call_args
         assert kwargs["base_url"] == "http://env-host/v1"
+
+    def test_empty_base_url_env_is_ignored(self):
+        """A blank OPENAI_BASE_URL must not shadow the SDK default endpoint."""
+        config, mock_openai = self._load(
+            {
+                "dry_run": False,
+                "model_provider": "openai_compatible",
+            },
+            {"OPENAI_API_KEY": "sk-test-key", "OPENAI_BASE_URL": ""},
+        )
+        assert config.api_base_url is None
+        _, kwargs = mock_openai.call_args
+        assert "base_url" not in kwargs
+
+    def test_empty_env_value_is_removed_before_sdk_initialization(self):
+        with patch.dict(os.environ, {"OPENAI_BASE_URL": "   "}, clear=True):
+            assert _non_empty_env("OPENAI_BASE_URL") is None
+            assert "OPENAI_BASE_URL" not in os.environ
+
+    def test_empty_review_model_env_falls_back_to_config(self):
+        config, _ = self._load(
+            {
+                "dry_run": False,
+                "model_provider": "openai_compatible",
+                "model_name": "gpt-4o-mini",
+                "review_model_name": "gpt-4o-mini",
+            },
+            {"OPENAI_API_KEY": "sk-test-key", "REVIEW_MODEL_NAME": ""},
+        )
+        assert config.review_model_name == "gpt-4o-mini"
 
     def test_local_provider_without_key_uses_placeholder(self):
         """A custom endpoint (e.g. Ollama) needs no real key; we must not exit."""

--- a/tests/unit/test_github_action.py
+++ b/tests/unit/test_github_action.py
@@ -37,10 +37,15 @@ def test_translate_step_wires_provider_and_process_all_env(action):
     steps = action["runs"]["steps"]
     translate = next(s for s in steps if s["name"] == "Translate changed strings")
     env = translate["env"]
-    assert env["OPENAI_BASE_URL"] == "${{ inputs.api-base-url }}"
+    assert "OPENAI_BASE_URL" not in env
+    assert "REVIEW_MODEL_NAME" not in env
+    assert env["LOCALIZE_API_BASE_URL_INPUT"] == "${{ inputs.api-base-url }}"
+    assert env["LOCALIZE_REVIEW_MODEL_INPUT"] == "${{ inputs.review-model }}"
     assert env["PROCESS_ALL_FILES"] == "${{ inputs.process-all-files }}"
     assert env["LOCALIZE_DRY_RUN"] == "${{ inputs.dry-run }}"
     assert env["LOCALIZE_PLUGIN_MODULES"] == "${{ inputs.plugin-modules }}"
+    assert 'unset OPENAI_BASE_URL' in translate["run"]
+    assert 'unset REVIEW_MODEL_NAME' in translate["run"]
     assert 'python -m localize.cli run --config "$TRANSLATOR_CONFIG_FILE"' in translate["run"]
 
 
@@ -49,9 +54,13 @@ def test_action_runs_preflight_check_before_translation(action):
     preflight_index = next(i for i, step in enumerate(steps) if step["name"] == "Check localization setup")
     translate_index = next(i for i, step in enumerate(steps) if step["name"] == "Translate changed strings")
     assert preflight_index < translate_index
-    assert steps[preflight_index]["env"]["OPENAI_BASE_URL"] == "${{ inputs.api-base-url }}"
-    assert steps[preflight_index]["env"]["REVIEW_MODEL_NAME"] == "${{ inputs.review-model }}"
+    assert "OPENAI_BASE_URL" not in steps[preflight_index]["env"]
+    assert "REVIEW_MODEL_NAME" not in steps[preflight_index]["env"]
+    assert steps[preflight_index]["env"]["LOCALIZE_API_BASE_URL_INPUT"] == "${{ inputs.api-base-url }}"
+    assert steps[preflight_index]["env"]["LOCALIZE_REVIEW_MODEL_INPUT"] == "${{ inputs.review-model }}"
     assert steps[preflight_index]["env"]["LOCALIZE_PLUGIN_MODULES"] == "${{ inputs.plugin-modules }}"
+    assert 'unset OPENAI_BASE_URL' in steps[preflight_index]["run"]
+    assert 'unset REVIEW_MODEL_NAME' in steps[preflight_index]["run"]
     assert 'python -m localize.cli check --config "$TRANSLATOR_CONFIG_FILE"' in steps[preflight_index]["run"]
 
 


### PR DESCRIPTION
## Summary
- avoid exporting empty optional action inputs as OPENAI_BASE_URL or REVIEW_MODEL_NAME
- treat blank environment overrides as unset before SDK initialization
- add regression coverage for blank action/config environment values

## Test
- venv/bin/pytest -q

Found during the PR Guardian end-to-end localization pipeline test: GitHub Actions exported OPENAI_BASE_URL as an empty string, causing OpenAI SDK chat requests to use an empty base URL while curl to /v1/models still succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of blank environment settings so empty values no longer override configured defaults.
  * Made localization checks and translation runs more reliable by only using provider settings when they are actually provided.
  * Updated test coverage to verify the new environment handling behavior and action setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->