### PR TITLE
Update external onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ model provider and your credentials.
 
 Repository: <https://github.com/bisq-network/localize-pipeline>
 
+Rendered docs: <https://bisq-network.github.io/localize-pipeline/>
+
 ## Why Use It
 
 - **Runs in your infrastructure.** Use GitHub Actions, local CLI runs, or a Docker
@@ -109,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.1
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -119,13 +121,22 @@ The action translates only files changed since the configured diff base. Use
 `process-all-files: true` once for an initial backfill, then return to
 incremental runs.
 
+Before enabling live PR creation in a target repo, add the `OPENAI_API_KEY`
+repository secret and set the repository's Actions workflow permissions to
+allow write tokens and workflow-created pull requests. The workflow-level
+`contents: write` and `pull-requests: write` permissions are necessary but not
+sufficient if repository or organization settings keep the default token
+read-only.
+
 Full guide: [docs/github-action.md](docs/github-action.md).
 
 ## Documentation
 
-Start with the agent-readable index in [llms.txt](llms.txt), then use the
-developer guide in [docs/index.html](docs/index.html) for setup, configuration,
-CLI commands, and supported localization formats.
+Start with the rendered developer guide at
+<https://bisq-network.github.io/localize-pipeline/>. The source lives in
+[docs/index.html](docs/index.html). Agents should start with the
+agent-readable index in [llms.txt](llms.txt), then use the developer guide for
+setup, configuration, CLI commands, and supported localization formats.
 
 ## Configuration Model
 
@@ -195,7 +206,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.1
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -215,7 +226,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.1
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -297,7 +308,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.0
+- uses: bisq-network/localize-pipeline@v0.1.1
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.
@@ -336,6 +347,12 @@ Server guide: [docs/new-project-deployment.md](docs/new-project-deployment.md).
 - **Quality gate failed:** inspect the PR report. The pipeline reports skipped
   files, placeholder errors, semantic findings, and suspicious source-identical
   values.
+- **Action pushed a branch but failed to create a PR:** enable repository
+  Actions workflow write permissions and allow workflow-created pull requests
+  in the target repository settings.
+- **Unexpected archive files in a generated PR:** ignore the pipeline archive
+  folder under your localization input folder, for example
+  `/src/main/resources/archive/` for Java `.properties` suffix layouts.
 - **Model parameter errors:** completion-token caps are normalized at the provider
   boundary. Use `model_provider: aisuite` unless you need the direct
   `openai_compatible` fallback.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.1
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -36,6 +36,33 @@ The default run is incremental. It compares the working tree against
 For a no-cost setup preview, add `dry-run: true`. The action still validates the
 config and discovery path, but the runtime skips model calls and translation
 writes.
+
+## Target Repository Settings
+
+Before live runs can open translation PRs, configure the target repository:
+
+- Add `OPENAI_API_KEY` as an Actions repository secret for OpenAI-backed runs.
+- Set repository Actions workflow permissions to read and write.
+- Enable workflow-created pull requests in repository or organization Actions
+  settings.
+- Keep workflow-level permissions:
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+If the repo setting leaves the workflow token read-only, the action can still
+complete translation and push a branch in some configurations, but `gh pr
+create` fails with a `createPullRequest` permission error.
+
+For Java `.properties` suffix layouts, ignore the runtime archive folder created
+under the localization input folder, for example:
+
+```gitignore
+/src/main/resources/archive/
+```
 
 ## First Run
 
@@ -88,7 +115,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.1
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -107,7 +134,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.1
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -135,7 +162,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.0
+      - uses: bisq-network/localize-pipeline@v0.1.1
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.1
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -105,7 +105,7 @@ you are ready to let the pipeline write translations.
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.0
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.1
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -127,7 +127,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.0 \
+  --action-ref v0.1.1 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.0"
+    action_ref: str = "v0.1.1"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -511,7 +511,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.0", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.1", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -39,7 +39,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
         BootstrapPrOptions(
             target_project_root=repo,
             branch_name="localize/onboarding",
-            action_ref="v0.1.0",
+            action_ref="v0.1.1",
             push=False,
             open_pr=False,
         )
@@ -63,7 +63,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     assert config["supported_locales"] == [{"code": "de", "name": "German"}]
 
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
-    assert "bisq-network/localize-pipeline@v0.1.0" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.1" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -378,7 +378,7 @@ def test_cli_bootstrap_pr_delegates_to_onboarding_generator(capsys):
             "--input-folder",
             "i18n",
             "--action-ref",
-            "v0.1.0",
+            "v0.1.1",
             "--plugin-module",
             "target_repo.localize_adapter",
             "--plugin-install-command",
@@ -390,7 +390,7 @@ def test_cli_bootstrap_pr_delegates_to_onboarding_generator(capsys):
     options = create.call_args.args[0]
     assert options.target_project_root == "/repo"
     assert options.input_folder == "i18n"
-    assert options.action_ref == "v0.1.0"
+    assert options.action_ref == "v0.1.1"
     assert options.plugin_modules == ("target_repo.localize_adapter",)
     assert options.plugin_install_command == "python -m pip install ."
     assert "Created onboarding commit abc123" in captured.out


### PR DESCRIPTION
## Summary
- update public examples and bootstrap defaults to the patched v0.1.1 action release
- link the rendered GitHub Pages docs from the README
- document target-repo Actions settings and archive-folder guidance discovered during the PR Guardian integration test

## Test
- venv/bin/pytest -q

Note: the GitHub Pages site is already built from main:/docs at https://bisq-network.github.io/localize-pipeline/. Updating the repository About/homepage metadata requires admin permission; this token has maintain permission only.