### PR TITLE
Support signed action PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,11 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-The action translates only files changed since the configured diff base. Use
-`process-all-files: true` once for an initial backfill, then return to
-incremental runs.
+The action translates only files changed since the configured diff base. For a
+new locale, create and review the initial translation locally first, merge that
+baseline, then let the action maintain incremental source-string updates.
+`process-all-files: true` is still available for controlled full scans, but it
+should not be the default operating mode for normal CI.
 
 Before enabling live PR creation in a target repo, add the `OPENAI_API_KEY`
 repository secret and set the repository's Actions workflow permissions to
@@ -350,7 +352,11 @@ Server guide: [docs/new-project-deployment.md](docs/new-project-deployment.md).
 - **Action pushed a branch but failed to create a PR:** enable repository
   Actions workflow write permissions and allow workflow-created pull requests
   in the target repository settings.
-- **Unexpected archive files in a generated PR:** ignore the pipeline archive
+- **Strict signed-commit rules reject generated PRs:** configure SSH commit
+  signing in the action with a dedicated machine-user signing key. See
+  [docs/github-action.md](docs/github-action.md#signed-commits).
+- **Unexpected archive files in a generated PR:** recent action versions exclude
+  archive folders from staging, but you should also ignore the pipeline archive
   folder under your localization input folder, for example
   `/src/main/resources/archive/` for Java `.properties` suffix layouts.
 - **Model parameter errors:** completion-token caps are normalized at the provider

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
   process-all-files:
     description: >-
       Translate ALL locale files instead of only those changed since diff-base. Use
-      true for a one-time initial run; leave false for incremental CI.
+      sparingly for a controlled backfill; leave false for normal incremental CI.
     required: false
     default: "false"
   dry-run:
@@ -65,6 +65,22 @@ inputs:
     description: "Commit message for the translation changes."
     required: false
     default: "Update AI translations"
+  git-user-name:
+    description: "Git user.name used for generated translation commits."
+    required: false
+    default: "github-actions[bot]"
+  git-user-email:
+    description: "Git user.email used for generated translation commits."
+    required: false
+    default: "41898282+github-actions[bot]@users.noreply.github.com"
+  commit-signing-method:
+    description: "Commit signing method. Use 'ssh' with commit-signing-key, or 'none' for unsigned commits."
+    required: false
+    default: "none"
+  commit-signing-key:
+    description: "Private SSH signing key used when commit-signing-method is 'ssh'. Store this as a secret."
+    required: false
+    default: ""
   github-token:
     description: "Token used to push the branch and open the PR."
     required: false
@@ -165,22 +181,226 @@ runs:
         PR_BRANCH: ${{ inputs.pr-branch }}
         COMMIT_MSG: ${{ inputs.commit-message }}
         PR_TITLE: ${{ inputs.pr-title }}
+        GIT_USER_NAME: ${{ inputs.git-user-name }}
+        GIT_USER_EMAIL: ${{ inputs.git-user-email }}
+        COMMIT_SIGNING_METHOD: ${{ inputs.commit-signing-method }}
+        COMMIT_SIGNING_KEY: ${{ inputs.commit-signing-key }}
+        TRANSLATOR_CONFIG_FILE: ${{ github.workspace }}/${{ inputs.config-file }}
+        ACTION_LOG_DIR: ${{ github.action_path }}/logs
       run: |
         set -euo pipefail
         if git diff --quiet && git diff --cached --quiet && [ -z "$(git status --porcelain)" ]; then
           echo "No translation changes; nothing to open a PR for."
           exit 0
         fi
+
+        signing_key_file=""
+        cleanup_signing_key() {
+          if [ -n "${signing_key_file:-}" ]; then
+            rm -f "$signing_key_file"
+          fi
+        }
+        trap cleanup_signing_key EXIT
+
+        commit_args=(-m "$COMMIT_MSG")
+        case "${COMMIT_SIGNING_METHOD:-none}" in
+          ""|"none")
+            git config commit.gpgsign false
+            ;;
+          "ssh")
+            if [ -z "${COMMIT_SIGNING_KEY:-}" ]; then
+              echo "::error::commit-signing-method is 'ssh' but commit-signing-key is empty."
+              exit 1
+            fi
+            signing_key_file="${RUNNER_TEMP:-/tmp}/localize-commit-signing-key"
+            umask 077
+            printf '%s\n' "$COMMIT_SIGNING_KEY" > "$signing_key_file"
+            chmod 600 "$signing_key_file"
+            ssh-keygen -y -f "$signing_key_file" >/dev/null
+            git config gpg.format ssh
+            git config user.signingkey "$signing_key_file"
+            git config commit.gpgsign true
+            commit_args=(-S -m "$COMMIT_MSG")
+            ;;
+          *)
+            echo "::error::Unsupported commit-signing-method '${COMMIT_SIGNING_METHOD}'. Use 'none' or 'ssh'."
+            exit 1
+            ;;
+        esac
+
         branch="$PR_BRANCH"
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "$GIT_USER_NAME"
+        git config user.email "$GIT_USER_EMAIL"
         git checkout -B "$branch"
-        git add -A
-        git commit -m "$COMMIT_MSG"
+
+        stage_roots_file="${RUNNER_TEMP:-/tmp}/localize-stage-roots.txt"
+        python - <<'PY' > "$stage_roots_file"
+        import os
+        import sys
+        from pathlib import Path
+
+        import yaml
+
+        workspace = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
+        config_file = Path(os.environ["TRANSLATOR_CONFIG_FILE"]).resolve()
+        config = yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
+
+        target_root = Path(str(config.get("target_project_root") or "."))
+        if not target_root.is_absolute():
+            target_root = workspace / target_root
+        target_root = target_root.resolve()
+
+        input_folder = Path(str(config.get("input_folder") or "."))
+        if not input_folder.is_absolute():
+            input_folder = target_root / input_folder
+        input_folder = input_folder.resolve()
+
+        try:
+            relative = input_folder.relative_to(workspace)
+        except ValueError:
+            print(
+                f"Configured input_folder '{input_folder}' is outside the GitHub workspace '{workspace}'.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        relative_text = relative.as_posix() or "."
+        print(relative_text)
+        PY
+
+        git reset -q
+        while IFS= read -r stage_root; do
+          if [ -z "$stage_root" ]; then
+            continue
+          fi
+          if [ "$stage_root" = "." ]; then
+            git add -A -- . ":(exclude,glob)**/archive/**"
+          else
+            git add -A -- "$stage_root" \
+              ":(exclude)$stage_root/archive/**" \
+              ":(exclude,glob)$stage_root/**/archive/**"
+          fi
+        done < "$stage_roots_file"
+
+        if git diff --cached --quiet; then
+          echo "No stageable localization changes after excluding archive folders; nothing to open a PR for."
+          exit 0
+        fi
+
+        body_file="${RUNNER_TEMP:-/tmp}/localize-pr-body.md"
+        LOCALIZE_PR_BODY_FILE="$body_file" python - <<'PY'
+        import json
+        import os
+        from pathlib import Path
+
+        log_dir = Path(os.environ["ACTION_LOG_DIR"])
+        body_file = Path(os.environ["LOCALIZE_PR_BODY_FILE"])
+
+        def load_json(name):
+            path = log_dir / name
+            if not path.exists():
+                return None
+            with path.open("r", encoding="utf-8") as file:
+                return json.load(file)
+
+        translation = load_json("translation_summary.json") or {}
+        validation = load_json("translation_validation_summary.json") or {}
+        usage = load_json("token_usage_summary.json") or {}
+
+        files_count = translation.get("files_count")
+        if files_count is None:
+            files_count = len(translation.get("processed_files", []))
+        locales = translation.get("locales") or []
+        modules = translation.get("modules") or []
+        new_keys = int(translation.get("new_keys_count") or 0)
+        updated_keys = int(translation.get("updated_keys_count") or 0)
+
+        validation_files = validation.get("files") or {}
+        pipeline_warnings = validation.get("pipeline_warnings") or []
+        if isinstance(validation.get("skipped_files"), dict):
+            pipeline_warnings.extend(
+                {"file": name, "errors": errors}
+                for name, errors in validation["skipped_files"].items()
+            )
+        reverted_keys = sum(
+            int(summary.get("reverted_keys_count") or 0)
+            for summary in validation_files.values()
+            if isinstance(summary, dict)
+        )
+        placeholder_failures = sum(
+            int(summary.get("placeholder_failures_count") or 0)
+            for summary in validation_files.values()
+            if isinstance(summary, dict)
+        )
+        control_findings = sum(
+            int(summary.get("control_character_findings_count") or 0)
+            for summary in validation_files.values()
+            if isinstance(summary, dict)
+        )
+
+        totals = usage.get("totals") or {}
+        calls = totals.get("calls")
+        total_tokens = totals.get("total_tokens")
+        estimated_cost = totals.get("estimated_cost_usd")
+
+        lines = [
+            "Automated translation update from Localize Pipeline.",
+            "",
+            "## Run Summary",
+            f"- Files translated: {files_count}",
+            f"- Locales: {', '.join(f'`{locale}`' for locale in locales) if locales else 'n/a'}",
+            f"- Modules: {', '.join(f'`{module}`' for module in modules) if modules else 'n/a'}",
+            f"- New keys: {new_keys}",
+            f"- Updated keys: {updated_keys}",
+            "",
+            "## Validation",
+            f"- Files with validation summaries: {len(validation_files)}",
+            f"- Reverted keys: {reverted_keys}",
+            f"- Placeholder failures: {placeholder_failures}",
+            f"- Control-character findings: {control_findings}",
+            f"- Pipeline warnings: {len(pipeline_warnings)}",
+            "",
+            "## Token Usage",
+            f"- API calls: {calls if calls is not None else 'n/a'}",
+            f"- Total tokens: {total_tokens if total_tokens is not None else 'n/a'}",
+            f"- Estimated cost: ${estimated_cost:.4f}" if isinstance(estimated_cost, (int, float)) else "- Estimated cost: n/a",
+            "",
+            "Review the changed localization files before merging.",
+            "Detailed JSON summaries are attached to the workflow run when available.",
+        ]
+
+        if pipeline_warnings:
+            lines.extend(["", "## Warnings"])
+            for warning in pipeline_warnings[:10]:
+                if isinstance(warning, dict):
+                    filename = warning.get("file", "unknown")
+                    errors = warning.get("errors", [])
+                    lines.append(f"- `{filename}`: {len(errors)} issue(s)")
+                else:
+                    lines.append(f"- {warning}")
+            if len(pipeline_warnings) > 10:
+                lines.append(f"- ...and {len(pipeline_warnings) - 10} more warning(s)")
+
+        body_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        PY
+
+        git commit "${commit_args[@]}"
         git push --force-with-lease origin "$branch"
         if gh pr view "$branch" >/dev/null 2>&1; then
           echo "Pull request already exists for $branch; it now points at the latest push."
+          gh pr edit "$branch" --title "$PR_TITLE" --body-file "$body_file"
         else
-          gh pr create --head "$branch" --title "$PR_TITLE" \
-            --body "Automated translation update. Review the changed localization files before merging."
+          gh pr create --head "$branch" --title "$PR_TITLE" --body-file "$body_file"
         fi
+
+    - name: Upload run summaries
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: localize-pipeline-summaries
+        path: |
+          ${{ github.action_path }}/logs/translation_summary.json
+          ${{ github.action_path }}/logs/translation_validation_summary.json
+          ${{ github.action_path }}/logs/token_usage_summary.json
+          ${{ github.action_path }}/logs/skipped_files_report.log
+        if-no-files-found: ignore

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -37,6 +37,22 @@ For a no-cost setup preview, add `dry-run: true`. The action still validates the
 config and discovery path, but the runtime skips model calls and translation
 writes.
 
+## Recommended Rollout
+
+Use local runs for the initial locale baseline and use the GitHub Action for
+ongoing source-string updates:
+
+1. Generate or update `config.yaml` and `glossary.json` locally.
+2. Create the initial target locale files locally with `localize run`.
+3. Review and merge that baseline like a normal localization PR.
+4. Enable the action with the default `process-all-files: false`.
+5. Let future CI runs translate only changed strings.
+
+This keeps the largest and riskiest translation review out of unattended CI and
+gives the action a clean baseline for incremental maintenance. For small repos
+or controlled pilot runs, you can still trigger a manual full scan with
+`process-all-files: true`; switch it back to `false` after that run.
+
 ## Target Repository Settings
 
 Before live runs can open translation PRs, configure the target repository:
@@ -57,23 +73,41 @@ If the repo setting leaves the workflow token read-only, the action can still
 complete translation and push a branch in some configurations, but `gh pr
 create` fails with a `createPullRequest` permission error.
 
-For Java `.properties` suffix layouts, ignore the runtime archive folder created
-under the localization input folder, for example:
+Recent action versions stage only the configured localization input folder and
+exclude archive folders from generated PRs. Still ignore the runtime archive
+folder as defense in depth, especially for local runs:
 
 ```gitignore
 /src/main/resources/archive/
 ```
 
-## First Run
+## Signed Commits
 
-For a one-time backfill, run the workflow manually with:
+Repositories with strict signed-commit rules should use SSH commit signing from
+a dedicated machine user:
+
+1. Create a no-passphrase Ed25519 SSH key used only for commit signing.
+2. Add the public key to the machine user's GitHub account as an SSH signing key.
+3. Use a verified email address from that account for `git-user-email`.
+4. Store the private key as an Actions secret, for example
+   `LOCALIZE_COMMIT_SIGNING_KEY`.
+5. Pass the signing inputs to the action:
 
 ```yaml
-process-all-files: true
+      - uses: bisq-network/localize-pipeline@v0.1.1
+        with:
+          config-file: config.yaml
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          git-user-name: localize-bot
+          git-user-email: localize-bot@users.noreply.github.com
+          commit-signing-method: ssh
+          commit-signing-key: ${{ secrets.LOCALIZE_COMMIT_SIGNING_KEY }}
 ```
 
-After the first PR is merged, return to the default `false` value so future runs
-only translate changed strings.
+The action writes the private key to the runner temp directory, validates it
+with `ssh-keygen`, signs the generated translation commit with `git commit -S`,
+and deletes the key file when the step exits. Do not reuse deploy keys or human
+authentication keys for this.
 
 ## Config Examples
 
@@ -180,12 +214,16 @@ jobs:
 | `plugin-modules` | empty | Comma-separated plugin modules to load before check/run. |
 | `plugin-install-command` | empty | Shell command to install custom adapter packages before check/run. |
 | `diff-base` | `${{ github.event.before }}` | Ref used for changed-string detection. |
-| `process-all-files` | `false` | Translate all target files. Use for backfills. |
+| `process-all-files` | `false` | Translate all target files. Use only for controlled full scans/backfills. |
 | `dry-run` | `false` | Preview discovery and validation without model calls or translation writes. |
 | `open-pr` | `true` | Open a PR or leave changes in the workspace. |
 | `pr-branch` | `ai-translations` | Branch for translation changes. |
 | `pr-title` | `Update AI translations` | PR title. |
 | `commit-message` | `Update AI translations` | Commit message. |
+| `git-user-name` | `github-actions[bot]` | Committer name for generated translation commits. |
+| `git-user-email` | `41898282+github-actions[bot]@users.noreply.github.com` | Committer email for generated translation commits. |
+| `commit-signing-method` | `none` | Commit signing mode. Use `ssh` for strict signed-commit repos. |
+| `commit-signing-key` | empty | Private SSH signing key used when `commit-signing-method: ssh`. |
 | `github-token` | `${{ github.token }}` | Token for pushing and opening the PR. |
 | `python-version` | `3.11` | Python version used by the action. |
 
@@ -198,9 +236,13 @@ python -m localize.cli check --config "$TRANSLATOR_CONFIG_FILE"
 python -m localize.cli run --config "$TRANSLATOR_CONFIG_FILE"
 ```
 
-The PR step commits only when localization files changed. User-provided action
-inputs are passed through environment variables, not interpolated directly into
-shell scripts.
+The PR step commits only when localization files changed. It excludes archive
+folders from staging, signs the commit when configured, and writes a PR body
+from the JSON run summaries when available. Those summaries are also uploaded as
+the `localize-pipeline-summaries` workflow artifact on every run.
+
+User-provided action inputs are passed through environment variables, not
+interpolated directly into shell scripts.
 
 Pin a tagged release for production workflows. A workflow reference such as
 `bisq-network/localize-pipeline@main` follows unreleased changes;

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -258,10 +258,13 @@ python3 -m venv venv
 1. Add the `OPENAI_API_KEY` repository secret, or configure `api-base-url` for a
    local OpenAI-compatible endpoint.
 2. Merge this onboarding PR while the workflow still has `dry-run: true`.
-3. Trigger one manual workflow run with `process-all-files: true` for the first
-   backfill.
-4. Review the translation PR.
-5. Set `dry-run: false` for normal incremental translation runs.
+3. Create and review any initial locale backfill locally with
+   `./venv/bin/localize run --config {config_path}`.
+4. Set `dry-run: false` after the local baseline is merged.
+5. Leave `process-all-files` unset for normal incremental translation runs.
+
+Use `process-all-files: true` only for a controlled manual full scan or pilot
+backfill, then return to the default incremental mode.
 
 {plugin_section}## Maintenance
 

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -75,6 +75,8 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     assert "\nlocalize check --config config.yaml" not in guide
     assert "dry-run: true" in guide
     assert "OPENAI_API_KEY" in guide
+    assert "Create and review any initial locale backfill locally" in guide
+    assert "./venv/bin/localize run --config config.yaml" in guide
     assert "process-all-files: true" in guide
 
 

--- a/tests/unit/test_github_action.py
+++ b/tests/unit/test_github_action.py
@@ -108,3 +108,65 @@ def test_opens_pr_with_gh_cli(action):
     # The PR step is gated on the open-pr input.
     steps = action["runs"]["steps"]
     assert any("open-pr" in str(s.get("if", "")) for s in steps)
+
+
+def test_open_pr_step_supports_optional_ssh_commit_signing(action):
+    inputs = action["inputs"]
+    assert inputs["git-user-name"]["default"] == "github-actions[bot]"
+    assert inputs["git-user-email"]["default"] == "41898282+github-actions[bot]@users.noreply.github.com"
+    assert inputs["commit-signing-method"]["default"] == "none"
+    assert inputs["commit-signing-key"]["default"] == ""
+
+    pr_step = next(step for step in action["runs"]["steps"] if step["name"] == "Open pull request")
+    env = pr_step["env"]
+    assert env["GIT_USER_NAME"] == "${{ inputs.git-user-name }}"
+    assert env["GIT_USER_EMAIL"] == "${{ inputs.git-user-email }}"
+    assert env["COMMIT_SIGNING_METHOD"] == "${{ inputs.commit-signing-method }}"
+    assert env["COMMIT_SIGNING_KEY"] == "${{ inputs.commit-signing-key }}"
+
+    run = pr_step["run"]
+    assert 'case "${COMMIT_SIGNING_METHOD:-none}" in' in run
+    assert "ssh-keygen -y -f \"$signing_key_file\"" in run
+    assert "git config gpg.format ssh" in run
+    assert "git config user.signingkey \"$signing_key_file\"" in run
+    assert "git config commit.gpgsign true" in run
+    assert "commit_args=(-S -m \"$COMMIT_MSG\")" in run
+    assert "trap cleanup_signing_key EXIT" in run
+    assert "git config user.name \"$GIT_USER_NAME\"" in run
+    assert "git config user.email \"$GIT_USER_EMAIL\"" in run
+
+
+def test_open_pr_step_stages_localization_changes_without_archives(action):
+    pr_step = next(step for step in action["runs"]["steps"] if step["name"] == "Open pull request")
+    run = pr_step["run"]
+    assert "target_project_root" in run
+    assert "input_folder" in run
+    assert "stage_roots_file" in run
+    assert "git reset -q" in run
+    assert 'git add -A -- "$stage_root"' in run
+    assert '":(exclude)$stage_root/archive/**"' in run
+    assert '":(exclude,glob)$stage_root/**/archive/**"' in run
+    assert '":(exclude,glob)**/archive/**"' in run
+    assert "No stageable localization changes after excluding archive folders" in run
+
+
+def test_generated_pr_uses_summary_body_and_uploads_artifacts(action):
+    pr_step = next(step for step in action["runs"]["steps"] if step["name"] == "Open pull request")
+    run = pr_step["run"]
+    assert "translation_summary.json" in run
+    assert "translation_validation_summary.json" in run
+    assert "token_usage_summary.json" in run
+    assert "body_file=" in run
+    assert "gh pr create --head \"$branch\" --title \"$PR_TITLE\" --body-file \"$body_file\"" in run
+    assert "gh pr edit \"$branch\" --title \"$PR_TITLE\" --body-file \"$body_file\"" in run
+
+    upload = next(step for step in action["runs"]["steps"] if step["name"] == "Upload run summaries")
+    assert upload["if"] == "${{ always() }}"
+    assert upload["uses"] == "actions/upload-artifact@v4"
+    assert upload["with"]["name"] == "localize-pipeline-summaries"
+    paths = upload["with"]["path"]
+    assert "translation_summary.json" in paths
+    assert "translation_validation_summary.json" in paths
+    assert "token_usage_summary.json" in paths
+    assert "skipped_files_report.log" in paths
+    assert upload["with"]["if-no-files-found"] == "ignore"


### PR DESCRIPTION
## Summary
- add optional SSH commit signing for generated translation PR commits
- stage only configured localization files and exclude archive folders from generated PRs
- generate PR bodies from run summaries and upload summary artifacts
- document the recommended local initial-backfill and incremental CI process

## Tests
- venv/bin/pytest -q