### PR TITLE
Fix Marketplace action description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Localize Pipeline are documented here.
 This project follows semantic versioning once tagged releases begin. Until a
 stable `1.0.0`, minor releases may still refine public APIs with migration notes.
 
+## [0.1.3] - 2026-07-01
+
+### Fixed
+
+- Shortened the GitHub Action description so the action can be published to the
+  GitHub Marketplace.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.3`.
+
 ## [0.1.2] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.2
+      - uses: bisq-network/localize-pipeline@v0.1.3
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -208,7 +208,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.2
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.3
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -228,7 +228,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.2
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.3
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -310,7 +310,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.2
+- uses: bisq-network/localize-pipeline@v0.1.3
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,7 @@
 name: "Localize Pipeline"
 description: >-
-  Agent-friendly AI localization pipeline that translates changed Java
-  .properties or JSON files with AISuite, OpenAI-compatible endpoints, or local
-  models, then opens a reviewable pull request.
+  AI localization for Java .properties and JSON files, with reviewable GitHub
+  pull requests.
 
 branding:
   icon: globe

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.2
+      - uses: bisq-network/localize-pipeline@v0.1.3
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -94,7 +94,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.2
+      - uses: bisq-network/localize-pipeline@v0.1.3
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -149,7 +149,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.2
+      - uses: bisq-network/localize-pipeline@v0.1.3
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -168,7 +168,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.2
+      - uses: bisq-network/localize-pipeline@v0.1.3
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.2
+      - uses: bisq-network/localize-pipeline@v0.1.3
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.2
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.3
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -105,7 +105,7 @@ you are ready to let the pipeline write translations.
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.2
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.3
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -127,7 +127,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.2 \
+  --action-ref v0.1.3 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.2"
+    action_ref: str = "v0.1.3"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -511,7 +511,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.2", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.3", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.2"
+version = "0.1.3"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -39,7 +39,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
         BootstrapPrOptions(
             target_project_root=repo,
             branch_name="localize/onboarding",
-            action_ref="v0.1.2",
+            action_ref="v0.1.3",
             push=False,
             open_pr=False,
         )
@@ -63,7 +63,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     assert config["supported_locales"] == [{"code": "de", "name": "German"}]
 
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
-    assert "bisq-network/localize-pipeline@v0.1.2" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.3" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -378,7 +378,7 @@ def test_cli_bootstrap_pr_delegates_to_onboarding_generator(capsys):
             "--input-folder",
             "i18n",
             "--action-ref",
-            "v0.1.2",
+            "v0.1.3",
             "--plugin-module",
             "target_repo.localize_adapter",
             "--plugin-install-command",
@@ -390,7 +390,7 @@ def test_cli_bootstrap_pr_delegates_to_onboarding_generator(capsys):
     options = create.call_args.args[0]
     assert options.target_project_root == "/repo"
     assert options.input_folder == "i18n"
-    assert options.action_ref == "v0.1.2"
+    assert options.action_ref == "v0.1.3"
     assert options.plugin_modules == ("target_repo.localize_adapter",)
     assert options.plugin_install_command == "python -m pip install ."
     assert "Created onboarding commit abc123" in captured.out
@@ -539,7 +539,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.2"
+    assert pyproject["project"]["version"] == "0.1.3"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -119,6 +119,7 @@ def test_release_maturity_docs_are_packaged():
 
     assert changelog.exists()
     changelog_text = changelog.read_text(encoding="utf-8")
+    assert "## [0.1.3]" in changelog_text
     assert "## [0.1.2]" in changelog_text
     assert "## [0.1.1]" in changelog_text
     assert "## [0.1.0]" in changelog_text

--- a/tests/unit/test_github_action.py
+++ b/tests/unit/test_github_action.py
@@ -18,6 +18,10 @@ def test_action_exists_and_is_composite(action):
     assert action["runs"]["using"] == "composite"
 
 
+def test_action_description_is_marketplace_publishable(action):
+    assert len(action["description"]) < 125
+
+
 def test_supports_byo_key_and_local_endpoint(action):
     inputs = action["inputs"]
     assert "openai-api-key" in inputs


### PR DESCRIPTION
## Summary
- shorten action.yml description below the GitHub Marketplace 125-character limit
- bump package/docs/bootstrap defaults to v0.1.3
- add a static action test for the Marketplace description limit

## Tests
- venv/bin/pytest -q