### PR TITLE
Add ignored key patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Localize Pipeline are documented here.
 This project follows semantic versioning once tagged releases begin. Until a
 stable `1.0.0`, minor releases may still refine public APIs with migration notes.
 
+## Unreleased
+
+### Added
+
+- `ignore_key_patterns` config to keep matching localization keys copied from
+  the source locale while excluding them from model calls, validation accounting,
+  quality gates, and cost estimates.
+
 ## [0.1.3] - 2026-07-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Key settings:
 | `supported_locales` | Target locales. |
 | `project_context` | Product/domain context injected into prompts. |
 | `brand_technical_glossary` | Terms that must not be translated. |
+| `ignore_key_patterns` | Python regexes matched against adapter keys; matching keys are copied from source and never translated. |
 | `style_rules` | Locale-specific writing rules. |
 
 Examples:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -90,6 +90,13 @@ brand_technical_glossary:
   - Bitcoin
   - GitHub
 
+# Optional key exclusions. Patterns are Python regular expressions matched with
+# re.search against the adapter key: JSON uses JSON Pointer keys such as "/#1"
+# and "/nav/settings"; Java properties use the dotted property key. Matching
+# keys are never sent to the model and are copied from the source locale.
+# ignore_key_patterns:
+#   - "^/#\\d+$"  # RoboSats-style JSON pseudo-comments: "#1", "#2", ...
+
 # If true, the script logs actions without calling the API or writing files.
 dry_run: false
 

--- a/llms.txt
+++ b/llms.txt
@@ -47,6 +47,11 @@ Treat `profiles/bisq/` as one production profile, not as a product default.
 Treat `profiles/bisq-mobile/` the same way. Core modules must stay reusable and
 must not depend on Bisq paths, terms, or Transifex behavior.
 
+Config `ignore_key_patterns` is a format-agnostic list of Python regexes matched
+against adapter keys with `re.search`. JSON uses JSON Pointer keys such as `/#1`
+and `/nav/settings`; Java properties use the dotted property key. Matching keys
+are copied verbatim from the source locale and never sent to the model.
+
 ## Supported Built-In Formats
 
 - Java properties (`localization_format: java_properties`)

--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -4,11 +4,12 @@ import os
 import sys
 import tempfile
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Pattern, Tuple
 
 import yaml
 from dotenv import load_dotenv
 
+from localize.ignore_keys import compile_ignore_key_patterns
 from localize.logging_config import setup_logger
 from localize.localization_formats import (
     JAVA_PROPERTIES_FORMAT,
@@ -72,6 +73,7 @@ class AppConfig:
     style_rules: Dict[str, List[str]]
     precomputed_style_rules_text: Dict[str, str]
     brand_glossary: List[str]
+    ignore_key_patterns: List[Pattern[str]]
 
     # Queue settings
     translation_queue_folder: str
@@ -544,6 +546,7 @@ def load_app_config() -> AppConfig:
         logger.critical("CRITICAL: %s", exc)
         sys.exit(1)
     retranslate_identical_source_strings = bool(config.get('retranslate_identical_source_strings', False))
+    ignore_key_patterns = compile_ignore_key_patterns(config.get('ignore_key_patterns', []))
     quality_gate_config = config.get('quality_gate', {}) or {}
     quality_gate = QualityGateConfig(
         source_identical_min_block_count=int(quality_gate_config.get('source_identical_min_block_count', 5)),
@@ -642,6 +645,7 @@ def load_app_config() -> AppConfig:
         style_rules=style_rules,
         precomputed_style_rules_text=precomputed_style_rules_text,
         brand_glossary=[str(term) for term in (config.get('brand_technical_glossary') or [])],
+        ignore_key_patterns=ignore_key_patterns,
         translation_queue_folder=translation_queue_folder,
         translated_queue_folder=translated_queue_folder,
         translation_key_ledger_file_path=translation_key_ledger_file_path,

--- a/localize/ignore_keys.py
+++ b/localize/ignore_keys.py
@@ -1,0 +1,38 @@
+"""Helpers for configured translation-key exclusion patterns."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Pattern, Sequence
+
+
+def compile_ignore_key_patterns(raw_patterns: Iterable[str] | None) -> list[Pattern[str]]:
+    """Compile configured ignore-key regexes once at config load.
+
+    Patterns are matched against adapter-produced translation keys. JSON adapters
+    produce JSON Pointer keys such as ``/#1`` or ``/nav/settings``; Java
+    properties adapters produce the dotted property key.
+    """
+    if raw_patterns is None:
+        return []
+
+    compiled: list[Pattern[str]] = []
+    for raw_pattern in raw_patterns:
+        if not isinstance(raw_pattern, str):
+            raise ValueError(
+                "ignore_key_patterns entries must be strings; "
+                f"got {type(raw_pattern).__name__}."
+            )
+        try:
+            compiled.append(re.compile(raw_pattern))
+        except re.error as exc:
+            raise ValueError(
+                f"Invalid ignore_key_patterns regex {raw_pattern!r}: {exc}. "
+                "Fix or remove this pattern from config.yaml."
+            ) from exc
+    return compiled
+
+
+def is_ignored_key(key: str, patterns: Sequence[Pattern[str]]) -> bool:
+    """Return true when ``key`` matches at least one ignore pattern."""
+    return any(pattern.search(key) for pattern in patterns)

--- a/localize/ignore_keys.py
+++ b/localize/ignore_keys.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import re
-from typing import Iterable, Pattern, Sequence
+from re import Pattern
+from typing import Iterable, Sequence
 
 
-def compile_ignore_key_patterns(raw_patterns: Iterable[str] | None) -> list[Pattern[str]]:
+def compile_ignore_key_patterns(raw_patterns: Iterable[str | Pattern[str]] | None) -> list[Pattern[str]]:
     """Compile configured ignore-key regexes once at config load.
 
     Patterns are matched against adapter-produced translation keys. JSON adapters
@@ -18,9 +19,12 @@ def compile_ignore_key_patterns(raw_patterns: Iterable[str] | None) -> list[Patt
 
     compiled: list[Pattern[str]] = []
     for raw_pattern in raw_patterns:
+        if isinstance(raw_pattern, Pattern):
+            compiled.append(raw_pattern)
+            continue
         if not isinstance(raw_pattern, str):
             raise ValueError(
-                "ignore_key_patterns entries must be strings; "
+                "ignore_key_patterns entries must be strings or compiled regex patterns; "
                 f"got {type(raw_pattern).__name__}."
             )
         try:

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from email.utils import parsedate_to_datetime
-from typing import Dict, List, Tuple, Optional, Set
+from typing import Dict, List, Optional, Pattern, Set, Tuple
 
 # --- Python Version Check ---
 # This script requires Python 3.11 or newer for features like modern asyncio.
@@ -32,6 +32,7 @@ from openai.types.chat import (
 from tqdm.asyncio import tqdm
 
 from localize.app_config import load_app_config
+from localize.ignore_keys import is_ignored_key
 from localize.localization_adapters import (
     get_localization_adapter,
     lint_properties_file as lint_properties_file,
@@ -98,6 +99,7 @@ RETRANSLATE_IDENTICAL_SOURCE_STRINGS = config.retranslate_identical_source_strin
 STYLE_RULES = config.style_rules
 PRECOMPUTED_STYLE_RULES_TEXT = config.precomputed_style_rules_text
 BRAND_GLOSSARY = config.brand_glossary
+IGNORE_KEY_PATTERNS = config.ignore_key_patterns
 PROJECT_CONTEXT = config.project_context
 LOCALIZATION_FORMAT = config.localization_format
 LOCALIZATION_LAYOUT = config.localization_layout
@@ -340,7 +342,8 @@ def extract_texts_to_translate(
         target_translations: Dict[str, str],
         newly_added_keys: Optional[Set[str]] = None,
         file_ledger_entries: Optional[Dict[str, Dict[str, str]]] = None,
-        retranslate_identical_existing: bool = False
+        retranslate_identical_existing: bool = False,
+        ignore_key_patterns: Optional[List[Pattern[str]]] = None,
 ) -> Tuple[List[str], List[int], List[str]]:
     """
     Identifies which texts need to be translated. A text needs translation if:
@@ -358,6 +361,7 @@ def extract_texts_to_translate(
         newly_added_keys: Keys that were added by key synchronization in this run.
         file_ledger_entries: Persisted hash data for keys in this translation file.
         retranslate_identical_existing: Whether to retranslate pre-existing source-identical keys.
+        ignore_key_patterns: Compiled key regexes that are never model-translated.
 
     Returns:
         A tuple containing the list of texts to translate, their corresponding indices, and their keys.
@@ -367,6 +371,7 @@ def extract_texts_to_translate(
     keys_to_translate = []
     newly_added_keys = newly_added_keys or set()
     file_ledger_entries = file_ledger_entries or {}
+    ignore_key_patterns = ignore_key_patterns or []
 
     existing_keys_in_target = {line['key'] for line in parsed_lines if line['type'] == 'entry'}
 
@@ -374,6 +379,8 @@ def extract_texts_to_translate(
     for i, line in enumerate(parsed_lines):
         if line['type'] == 'entry':
             key = line['key']
+            if is_ignored_key(key, ignore_key_patterns):
+                continue
             target_value = line.get('value', '')
             source_value = source_translations.get(key)
 
@@ -439,6 +446,8 @@ def extract_texts_to_translate(
     next_new_key_index = len(parsed_lines)
 
     for key in sorted(list(new_keys)):  # Sort for deterministic order
+        if is_ignored_key(key, ignore_key_patterns):
+            continue
         source_value = source_translations[key]
         texts_to_translate.append(source_value)
         indices.append(next_new_key_index)
@@ -446,6 +455,33 @@ def extract_texts_to_translate(
         next_new_key_index += 1
 
     return texts_to_translate, indices, keys_to_translate
+
+
+def apply_ignored_source_values(
+        parsed_lines: List[Dict],
+        target_translations: Dict[str, str],
+        source_translations: Dict[str, str],
+        ignore_key_patterns: List[Pattern[str]],
+) -> Set[str]:
+    """Force ignored keys in the target draft to the source value verbatim."""
+    if not ignore_key_patterns:
+        return set()
+
+    updated_keys: Set[str] = set()
+    for line in parsed_lines:
+        if line.get('type') != 'entry':
+            continue
+        key = line.get('key')
+        if not key or not is_ignored_key(key, ignore_key_patterns):
+            continue
+        if key not in source_translations:
+            continue
+        source_value = source_translations[key]
+        if line.get('value', '') != source_value:
+            updated_keys.add(key)
+        line['value'] = source_value
+        target_translations[key] = source_value
+    return updated_keys
 
 
 def filter_git_changed_keys_by_source(
@@ -744,6 +780,7 @@ def run_pre_translation_validation(
         localization_format: Optional[LocalizationFormat] = None,
         git_changed_keys: Optional[Set[str]] = None,
         file_ledger_entries: Optional[Dict[str, Dict[str, str]]] = None,
+        ignore_key_patterns: Optional[List[Pattern[str]]] = None,
 ) -> Tuple[List[str], Set[str]]:
     """
     Runs validation and preparation checks on a target localization file.
@@ -763,6 +800,7 @@ def run_pre_translation_validation(
     newly_added_keys: Set[str] = set()
     filename = os.path.basename(target_file_path)
     adapter = get_localization_adapter(localization_format or LOCALIZATION_FORMAT)
+    ignore_key_patterns = ignore_key_patterns or []
     logger.info(f"Running pre-translation validation for '{filename}'...")
 
     # 1. Synchronize keys (add missing, remove extra)
@@ -804,6 +842,8 @@ def run_pre_translation_validation(
     # 3. Check placeholder parity
     common_keys = set(source_translations.keys()).intersection(set(target_translations.keys()))
     for key in common_keys:
+        if is_ignored_key(key, ignore_key_patterns):
+            continue
         source_value = source_translations.get(key, "")
         target_value = target_translations.get(key, "")
         if not check_placeholder_parity(source_value, target_value):
@@ -825,6 +865,7 @@ def run_post_translation_validation(
         source_translations: Dict[str, str],
         filename: str,
         localization_format: Optional[LocalizationFormat] = None,
+        ignore_key_patterns: Optional[List[Pattern[str]]] = None,
 ) -> bool:
     """
     Runs a series of validation checks on the final translated file content.
@@ -843,6 +884,7 @@ def run_post_translation_validation(
     temp_file_path = None
     effective_format = localization_format or LOCALIZATION_FORMAT
     adapter = get_localization_adapter(effective_format)
+    ignore_key_patterns = ignore_key_patterns or []
     try:
         # Create a temporary file with delete=False to control its lifecycle.
         with tempfile.NamedTemporaryFile(
@@ -869,6 +911,8 @@ def run_post_translation_validation(
             _, final_translations = adapter.parse_file(temp_file_path)
             common_keys = set(source_translations.keys()).intersection(set(final_translations.keys()))
             for key in common_keys:
+                if is_ignored_key(key, ignore_key_patterns):
+                    continue
                 source_value = source_translations.get(key, "")
                 target_value = final_translations.get(key, "")
                 if not check_placeholder_parity(source_value, target_value):
@@ -906,7 +950,8 @@ def run_post_translation_validation(
 def run_per_key_validation_with_summary(
         final_translations: Dict[str, str],
         source_translations: Dict[str, str],
-        filename: str
+        filename: str,
+        ignore_key_patterns: Optional[List[Pattern[str]]] = None,
 ) -> Tuple[Dict[str, str], Dict[str, object]]:
     """
     Validates each translation key individually and selectively reverts failed keys.
@@ -930,9 +975,13 @@ def run_per_key_validation_with_summary(
     failed_keys = []
     control_character_keys = []
     placeholder_mismatch_keys = []
+    ignore_key_patterns = ignore_key_patterns or []
 
     for key, target_value in final_translations.items():
         source_value = source_translations.get(key, "")
+        if is_ignored_key(key, ignore_key_patterns):
+            valid_translations[key] = source_value
+            continue
         control_character_findings = find_disallowed_control_characters(target_value)
 
         if control_character_findings:
@@ -998,7 +1047,8 @@ def run_per_key_validation_with_summary(
 def run_per_key_validation(
         final_translations: Dict[str, str],
         source_translations: Dict[str, str],
-        filename: str
+        filename: str,
+        ignore_key_patterns: Optional[List[Pattern[str]]] = None,
 ) -> Tuple[Dict[str, str], List[str]]:
     """
     Backward-compatible wrapper returning only the failed key list.
@@ -1006,7 +1056,8 @@ def run_per_key_validation(
     valid_translations, summary = run_per_key_validation_with_summary(
         final_translations,
         source_translations,
-        filename
+        filename,
+        ignore_key_patterns=ignore_key_patterns,
     )
     return valid_translations, list(summary["failed_keys"])
 
@@ -1966,6 +2017,7 @@ async def process_translation_queue(
             localization_format,
             git_changed_keys=raw_git_changed_keys,
             file_ledger_entries=file_ledger_entries,
+            ignore_key_patterns=IGNORE_KEY_PATTERNS,
         )
         if validation_errors:
             logger.error(f"Skipping translation for '{translation_file}' due to pre-translation validation errors.")
@@ -1989,6 +2041,15 @@ async def process_translation_queue(
         # Load files
         parsed_lines, target_translations = adapter.parse_file(translation_file_path)
         _, source_translations = adapter.parse_file(source_file_path)
+        ignored_keys_updated = apply_ignored_source_values(
+            parsed_lines,
+            target_translations,
+            source_translations,
+            IGNORE_KEY_PATTERNS,
+        )
+        ignored_keys_requiring_output = ignored_keys_updated.union(
+            key for key in newly_added_keys if is_ignored_key(key, IGNORE_KEY_PATTERNS)
+        )
 
         # Extract texts to translate
         git_changed_keys = raw_git_changed_keys
@@ -2014,12 +2075,30 @@ async def process_translation_queue(
             target_translations,
             newly_added_keys=newly_synchronized_keys,
             file_ledger_entries=file_ledger_entries,
-            retranslate_identical_existing=RETRANSLATE_IDENTICAL_SOURCE_STRINGS
+            retranslate_identical_existing=RETRANSLATE_IDENTICAL_SOURCE_STRINGS,
+            ignore_key_patterns=IGNORE_KEY_PATTERNS,
         )
         if not texts_to_translate:
             # Refresh ledger baseline even when no translation was required.
             key_ledger[translation_file] = build_file_key_ledger(source_translations, target_translations)
             save_translation_key_ledger(TRANSLATION_KEY_LEDGER_FILE_PATH, key_ledger)
+            if ignored_keys_requiring_output:
+                translated_file_path = os.path.join(translated_queue_folder, translation_file)
+                new_file_content = adapter.reassemble_file(parsed_lines)
+                if DRY_RUN:
+                    logger.info(f"[Dry Run] Would write ignored-key passthrough content to '{translated_file_path}'.")
+                else:
+                    os.makedirs(os.path.dirname(translated_file_path), exist_ok=True)
+                    with open(translated_file_path, 'w', encoding='utf-8') as file:
+                        file.write(new_file_content)
+                processed_files_count += 1
+                processed_filenames.append(translation_file)
+                logger.info(
+                    "Updated %d ignored key(s) from source in '%s'.",
+                    len(ignored_keys_requiring_output),
+                    translation_file,
+                )
+                continue
             logger.info(f"No texts to translate in file '{translation_file}'.")
             continue
 
@@ -2223,7 +2302,8 @@ async def process_translation_queue(
         valid_translations, per_key_summary = run_per_key_validation_with_summary(
             changed_final_translations,
             source_translations,
-            translation_file
+            translation_file,
+            ignore_key_patterns=IGNORE_KEY_PATTERNS,
         )
         failed_keys = list(per_key_summary["failed_keys"])
         if validation_summary is not None:

--- a/localize/translation_quality_gate.py
+++ b/localize/translation_quality_gate.py
@@ -9,10 +9,11 @@ import re
 import subprocess
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Pattern, Sequence, Tuple
 
 import yaml
 
+from localize.ignore_keys import compile_ignore_key_patterns, is_ignored_key
 from localize.localization_formats import JAVA_PROPERTIES_FORMAT, LocalizationFormat, load_localization_format
 from localize.localization_layouts import SUFFIX_LAYOUT, LocalizationLayout, load_localization_layout
 from localize.localization_profiles import LocalizationProfile, load_localization_profiles
@@ -43,6 +44,22 @@ class QualityGateConfig:
     block_on_semantic_qa_warnings: bool = False
     semantic_qa_audit_scope: str = "changed"
     retained_source_word_allowlist: Dict[str, Tuple[str, ...]] = field(default_factory=dict)
+    ignore_key_patterns: List[Pattern[str]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source_identical_min_block_count": self.source_identical_min_block_count,
+            "source_identical_max_count": self.source_identical_max_count,
+            "source_identical_max_ratio": self.source_identical_max_ratio,
+            "block_on_pipeline_warnings": self.block_on_pipeline_warnings,
+            "block_on_semantic_qa_findings": self.block_on_semantic_qa_findings,
+            "block_on_semantic_qa_warnings": self.block_on_semantic_qa_warnings,
+            "semantic_qa_audit_scope": self.semantic_qa_audit_scope,
+            "retained_source_word_allowlist": self.retained_source_word_allowlist,
+            "ignore_key_patterns": [
+                pattern.pattern for pattern in self.ignore_key_patterns
+            ],
+        }
 
 
 @dataclass
@@ -107,6 +124,7 @@ def analyze_source_identical_changes(
     examples_limit: int = 10,
     localization_format: LocalizationFormat = JAVA_PROPERTIES_FORMAT,
     localization_layout: LocalizationLayout = SUFFIX_LAYOUT,
+    ignore_key_patterns: Sequence[Pattern[str] | str] = (),
 ) -> SourceIdenticalStats:
     """Analyze staged translation changes for suspicious English-source fallbacks."""
     changes = iter_translation_changes_from_diff(
@@ -122,17 +140,39 @@ def analyze_source_identical_changes(
         changes=changes,
         brand_glossary=brand_glossary,
         examples_limit=examples_limit,
+        ignore_key_patterns=_ensure_ignore_key_patterns(ignore_key_patterns),
     )
+
+
+def _ensure_ignore_key_patterns(
+    patterns: Sequence[Pattern[str] | str],
+) -> List[Pattern[str]]:
+    if not patterns:
+        return []
+    if all(hasattr(pattern, "search") for pattern in patterns):
+        return list(patterns)  # type: ignore[list-item]
+    return compile_ignore_key_patterns(patterns)  # type: ignore[arg-type]
+
+
+def _filter_ignored_changes(
+    changes: Iterable[TranslationChange],
+    ignore_key_patterns: Sequence[Pattern[str]],
+) -> Iterable[TranslationChange]:
+    for change in changes:
+        if is_ignored_key(change.key, ignore_key_patterns):
+            continue
+        yield change
 
 
 def _analyze_source_identical_translation_changes(
     changes: Iterable[TranslationChange],
     brand_glossary: Iterable[str],
     examples_limit: int,
+    ignore_key_patterns: Sequence[Pattern[str]] = (),
 ) -> SourceIdenticalStats:
     stats = SourceIdenticalStats()
 
-    for change in changes:
+    for change in _filter_ignored_changes(changes, ignore_key_patterns):
         if change.source_value is None:
             continue
 
@@ -232,6 +272,7 @@ def analyze_source_identical_changes_for_profiles(
     brand_glossary: Iterable[str],
     localization_profiles: Sequence[LocalizationProfile],
     examples_limit: int = 10,
+    ignore_key_patterns: Sequence[Pattern[str]] = (),
 ) -> SourceIdenticalStats:
     """Analyze suspicious source-identical changes across configured profiles."""
     return _analyze_source_identical_translation_changes(
@@ -246,6 +287,7 @@ def analyze_source_identical_changes_for_profiles(
         ),
         brand_glossary=brand_glossary,
         examples_limit=examples_limit,
+        ignore_key_patterns=ignore_key_patterns,
     )
 
 
@@ -260,6 +302,7 @@ def analyze_semantic_qa_changes(
     examples_limit: int = 10,
     localization_format: LocalizationFormat = JAVA_PROPERTIES_FORMAT,
     localization_layout: LocalizationLayout = SUFFIX_LAYOUT,
+    ignore_key_patterns: Sequence[Pattern[str] | str] = (),
 ) -> SemanticQAStats:
     """Scan changed translations for configured semantic regressions."""
     changes = list(
@@ -272,8 +315,9 @@ def analyze_semantic_qa_changes(
             localization_layout=localization_layout,
         )
     )
+    compiled_ignore_key_patterns = _ensure_ignore_key_patterns(ignore_key_patterns)
     return analyze_translation_changes(
-        changes=changes,
+        changes=list(_filter_ignored_changes(changes, compiled_ignore_key_patterns)),
         semantic_rules=semantic_rules,
         brand_glossary=brand_glossary,
         retained_source_word_allowlist=retained_source_word_allowlist,
@@ -291,6 +335,7 @@ def analyze_semantic_qa_changes_for_profiles(
     retained_source_word_allowlist: Optional[Mapping[str, Iterable[str]]] = None,
     localization_profiles: Sequence[LocalizationProfile] = (),
     examples_limit: int = 10,
+    ignore_key_patterns: Sequence[Pattern[str]] = (),
 ) -> SemanticQAStats:
     """Scan changed translations across all configured format/layout profiles."""
     changes = _deduplicate_translation_changes(
@@ -303,7 +348,7 @@ def analyze_semantic_qa_changes_for_profiles(
         )
     )
     return analyze_translation_changes(
-        changes=changes,
+        changes=list(_filter_ignored_changes(changes, ignore_key_patterns)),
         semantic_rules=semantic_rules,
         brand_glossary=brand_glossary,
         retained_source_word_allowlist=retained_source_word_allowlist,
@@ -320,6 +365,7 @@ def analyze_all_translation_entries_for_profiles(
     retained_source_word_allowlist: Optional[Mapping[str, Iterable[str]]] = None,
     localization_profiles: Sequence[LocalizationProfile] = (),
     examples_limit: int = 10,
+    ignore_key_patterns: Sequence[Pattern[str]] = (),
 ) -> SemanticQAStats:
     """Scan all translations across all configured format/layout profiles."""
     changes = _deduplicate_translation_changes(
@@ -331,7 +377,7 @@ def analyze_all_translation_entries_for_profiles(
         )
     )
     return analyze_translation_changes(
-        changes=changes,
+        changes=list(_filter_ignored_changes(changes, ignore_key_patterns)),
         semantic_rules=semantic_rules,
         brand_glossary=brand_glossary,
         retained_source_word_allowlist=retained_source_word_allowlist,
@@ -371,6 +417,9 @@ def load_quality_gate_config(
             ),
             retained_source_word_allowlist=normalize_retained_source_word_allowlist(
                 quality_gate.get("retained_source_word_allowlist", {})
+            ),
+            ignore_key_patterns=compile_ignore_key_patterns(
+                raw_config.get("ignore_key_patterns", [])
             ),
         ),
         locales,
@@ -582,7 +631,7 @@ def build_quality_gate_report(
         "validation": validation_totals,
         "pipeline_warnings_count": len(pipeline_warnings),
         "pipeline_warnings": pipeline_warnings,
-        "thresholds": asdict(config),
+        "thresholds": config.to_dict(),
     }
 
 
@@ -726,6 +775,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         locale_codes=locale_codes,
         brand_glossary=brand_glossary,
         localization_profiles=localization_profiles,
+        ignore_key_patterns=config.ignore_key_patterns,
     )
     audit_scope = args.audit_scope or config.semantic_qa_audit_scope
     if audit_scope == "all":
@@ -737,6 +787,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             semantic_rules=semantic_rules,
             retained_source_word_allowlist=config.retained_source_word_allowlist,
             localization_profiles=localization_profiles,
+            ignore_key_patterns=config.ignore_key_patterns,
         )
     else:
         semantic_stats = analyze_semantic_qa_changes_for_profiles(
@@ -748,6 +799,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             semantic_rules=semantic_rules,
             retained_source_word_allowlist=config.retained_source_word_allowlist,
             localization_profiles=localization_profiles,
+            ignore_key_patterns=config.ignore_key_patterns,
         )
     report = build_quality_gate_report(
         source_stats=source_stats,

--- a/localize/translation_quality_gate.py
+++ b/localize/translation_quality_gate.py
@@ -147,11 +147,7 @@ def analyze_source_identical_changes(
 def _ensure_ignore_key_patterns(
     patterns: Sequence[Pattern[str] | str],
 ) -> List[Pattern[str]]:
-    if not patterns:
-        return []
-    if all(hasattr(pattern, "search") for pattern in patterns):
-        return list(patterns)  # type: ignore[list-item]
-    return compile_ignore_key_patterns(patterns)  # type: ignore[arg-type]
+    return compile_ignore_key_patterns(patterns)
 
 
 def _filter_ignored_changes(

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -373,9 +373,7 @@ async def test_process_translation_queue_preserves_ignored_json_comment_keys(int
         "welcome": "Welcome to RoboSats",
         "amount": "Amount {{amount}} sats",
     }
-    target_content = {
-        "welcome": "Willkommen",
-    }
+    target_content = {}
     source_file_path = os.path.join(env['input_folder'], 'en.json')
     target_file_path = os.path.join(env['translation_queue_folder'], 'de.json')
 
@@ -451,6 +449,64 @@ async def test_process_translation_queue_preserves_ignored_json_comment_keys(int
     assert all('"#1"' not in prompt for prompt in seen_prompt_texts)
     assert all('"#2"' not in prompt for prompt in seen_prompt_texts)
     assert all("Phrases in basic" not in prompt for prompt in seen_prompt_texts)
+
+
+@pytest.mark.asyncio
+async def test_process_translation_queue_writes_only_ignored_json_keys(integration_test_environment):
+    env = integration_test_environment
+    layout = LocalizationLayout(id="locale_filename", source_locale="en")
+    source_content = {
+        "#1": "Phrases in basic/Main.tsx",
+        "#2": "Phrases in basic/BookPage/index.tsx",
+    }
+    source_file_path = os.path.join(env['input_folder'], 'en.json')
+    target_file_path = os.path.join(env['translation_queue_folder'], 'de.json')
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        json.dump(source_content, f, ensure_ascii=False, indent=2)
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        json.dump({}, f, ensure_ascii=False, indent=2)
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(
+        side_effect=AssertionError("Ignored keys must not call the model")
+    )
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+
+    profiles = (
+        LocalizationProfile(JSON_FORMAT, layout),
+    )
+    with patch('localize.translate_localization_files.LOCALIZATION_FORMAT', JSON_FORMAT), \
+         patch('localize.translate_localization_files.LOCALIZATION_LAYOUT', layout), \
+         patch('localize.translate_localization_files.LOCALIZATION_PROFILES', profiles), \
+         patch('localize.translate_localization_files.LANGUAGE_CODES', {'de': 'German'}), \
+         patch('localize.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('localize.translate_localization_files.IGNORE_KEY_PATTERNS',
+               compile_ignore_key_patterns([r"^/#\d+$"])), \
+         patch('localize.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH',
+               os.path.join(env['input_folder'], 'ledger.json')), \
+         patch('localize.translate_localization_files.get_working_tree_changed_keys', return_value=set()):
+        processed_count, processed_files, skipped_files, total_keys = (
+            await localize.translate_localization_files.process_translation_queue(
+                translation_queue_folder=env['translation_queue_folder'],
+                translated_queue_folder=env['translated_queue_folder'],
+                glossary_file_path=env['mock_glossary_path_resolved']
+            )
+        )
+
+    output_file_path = os.path.join(env['translated_queue_folder'], 'de.json')
+    assert os.path.exists(output_file_path)
+    with open(output_file_path, 'r', encoding='utf-8') as f:
+        final_payload = json.load(f)
+
+    assert processed_count == 1
+    assert processed_files == ['de.json']
+    assert skipped_files == {}
+    assert total_keys == 0
+    assert final_payload == source_content
+    provider.create_chat_completion.assert_not_awaited()
+    provider.estimate_run_cost.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from types import SimpleNamespace
 import pytest
 import localize.translate_localization_files
+from localize.ignore_keys import compile_ignore_key_patterns
 from localize.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
 from localize.localization_layouts import LocalizationLayout
 from localize.localization_profiles import LocalizationProfile
@@ -360,6 +361,96 @@ async def test_process_translation_queue_translates_json_locale_directory_layout
             {"title": "Details prüfen"},
         ],
     }
+
+
+@pytest.mark.asyncio
+async def test_process_translation_queue_preserves_ignored_json_comment_keys(integration_test_environment):
+    env = integration_test_environment
+    layout = LocalizationLayout(id="locale_filename", source_locale="en")
+    source_content = {
+        "#1": "Phrases in basic/Main.tsx",
+        "#2": "Phrases in basic/BookPage/index.tsx",
+        "welcome": "Welcome to RoboSats",
+        "amount": "Amount {{amount}} sats",
+    }
+    target_content = {
+        "welcome": "Willkommen",
+    }
+    source_file_path = os.path.join(env['input_folder'], 'en.json')
+    target_file_path = os.path.join(env['translation_queue_folder'], 'de.json')
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        json.dump(source_content, f, ensure_ascii=False, indent=2)
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        json.dump(target_content, f, ensure_ascii=False, indent=2)
+
+    seen_prompt_texts = []
+
+    async def fake_completion(**kwargs):
+        prompt_text = "\n".join(message["content"] for message in kwargs["messages"])
+        seen_prompt_texts.append(prompt_text)
+        if kwargs.get("response_format"):
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
+                content=json.dumps({
+                    "/amount": "Betrag {{amount}} sats",
+                    "/welcome": "Willkommen bei RoboSats",
+                })
+            ))])
+        if "Key: /amount" in prompt_text:
+            content = "Betrag {{amount}} sats"
+        elif "Key: /welcome" in prompt_text:
+            content = "Willkommen bei RoboSats"
+        else:
+            raise AssertionError(f"Unexpected model prompt: {prompt_text}")
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(side_effect=fake_completion)
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
+
+    profiles = (
+        LocalizationProfile(JSON_FORMAT, layout),
+    )
+    with patch('localize.translate_localization_files.LOCALIZATION_FORMAT', JSON_FORMAT), \
+         patch('localize.translate_localization_files.LOCALIZATION_LAYOUT', layout), \
+         patch('localize.translate_localization_files.LOCALIZATION_PROFILES', profiles), \
+         patch('localize.translate_localization_files.LANGUAGE_CODES', {'de': 'German'}), \
+         patch('localize.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('localize.translate_localization_files.IGNORE_KEY_PATTERNS',
+               compile_ignore_key_patterns([r"^/#\d+$"])), \
+         patch('localize.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH',
+               os.path.join(env['input_folder'], 'ledger.json')), \
+         patch('localize.translate_localization_files.get_working_tree_changed_keys', return_value=set()):
+        processed_count, processed_files, skipped_files, total_keys = (
+            await localize.translate_localization_files.process_translation_queue(
+                translation_queue_folder=env['translation_queue_folder'],
+                translated_queue_folder=env['translated_queue_folder'],
+                glossary_file_path=env['mock_glossary_path_resolved']
+            )
+        )
+
+    output_file_path = os.path.join(env['translated_queue_folder'], 'de.json')
+    assert os.path.exists(output_file_path)
+    with open(output_file_path, 'r', encoding='utf-8') as f:
+        final_payload = json.load(f)
+
+    assert processed_count == 1
+    assert processed_files == ['de.json']
+    assert skipped_files == {}
+    assert total_keys == 2
+    assert final_payload == {
+        "#1": "Phrases in basic/Main.tsx",
+        "#2": "Phrases in basic/BookPage/index.tsx",
+        "welcome": "Willkommen bei RoboSats",
+        "amount": "Betrag {{amount}} sats",
+    }
+    assert provider.estimate_run_cost.call_args.kwargs["num_keys"] == 2
+    assert all('"#1"' not in prompt for prompt in seen_prompt_texts)
+    assert all('"#2"' not in prompt for prompt in seen_prompt_texts)
+    assert all("Phrases in basic" not in prompt for prompt in seen_prompt_texts)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -33,6 +33,7 @@ class TestAppConfig:
             style_rules={},
             precomputed_style_rules_text={},
             brand_glossary=["Bisq"],
+            ignore_key_patterns=[],
             project_context="A desktop trading app.",
             localization_format=JAVA_PROPERTIES_FORMAT,
             localization_layout=SUFFIX_LAYOUT,
@@ -122,6 +123,7 @@ class TestLoadAppConfig:
         }
         assert config.language_codes == {"de": "German", "es": "Spanish"}
         assert config.name_to_code == {"german": "de", "spanish": "es"}
+        assert config.ignore_key_patterns == []
 
     def test_load_config_with_missing_file_uses_defaults(self):
         """Test that missing config file results in default values."""
@@ -151,6 +153,7 @@ class TestLoadAppConfig:
         assert config.quality_gate.semantic_qa_audit_scope == "changed"
         assert config.quality_gate.retained_source_word_allowlist == {}
         assert config.brand_glossary == []
+        assert config.ignore_key_patterns == []
         assert config.project_context == ""
         assert config.localization_format == JAVA_PROPERTIES_FORMAT
         assert config.localization_layout == SUFFIX_LAYOUT
@@ -210,6 +213,38 @@ class TestLoadAppConfig:
         assert config.localization_layout.id == "locale_directory"
         assert config.localization_layout.source_locale == "en"
         assert config.localization_profiles[0].localization_format.id == "custom_json"
+
+    def test_load_config_compiles_ignore_key_patterns(self):
+        mock_config = {
+            "dry_run": True,
+            "ignore_key_patterns": [r"^/#\d+$", r"^debug\."],
+        }
+
+        with patch("localize.app_config._load_yaml_config", return_value=mock_config):
+            with patch("os.path.exists", return_value=False):
+                with patch("localize.app_config.setup_logger") as mock_logger:
+                    mock_logger.return_value = MagicMock()
+                    with patch.dict(os.environ, {}, clear=True):
+                        config = load_app_config()
+
+        assert [pattern.pattern for pattern in config.ignore_key_patterns] == [
+            r"^/#\d+$",
+            r"^debug\.",
+        ]
+
+    def test_load_config_rejects_invalid_ignore_key_pattern(self):
+        mock_config = {
+            "dry_run": True,
+            "ignore_key_patterns": ["["],
+        }
+
+        with patch("localize.app_config._load_yaml_config", return_value=mock_config):
+            with patch("os.path.exists", return_value=False):
+                with patch("localize.app_config.setup_logger") as mock_logger:
+                    mock_logger.return_value = MagicMock()
+                    with patch.dict(os.environ, {}, clear=True):
+                        with pytest.raises(ValueError, match=r"Invalid ignore_key_patterns regex '\['"):
+                            load_app_config()
 
     def test_load_config_reads_multiple_localization_profiles(self):
         mock_config = {

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -13,6 +13,7 @@ os.environ['OPENAI_API_KEY'] = 'DUMMY_KEY_FOR_TESTING'
 # This might require adjusting the Python path if the test runner doesn't handle it.
 from localize.translate_localization_files import (
     build_context,
+    apply_ignored_source_values,
     normalize_value,
     compute_ledger_hash,
     extract_texts_to_translate,
@@ -391,6 +392,36 @@ class TestCoreLogic(unittest.TestCase):
 
         self.assertEqual(baseline, explicit_empty)
         self.assertEqual(baseline[2], ['/#1', '/welcome'])
+
+    def test_empty_ignore_patterns_do_not_rewrite_content(self):
+        """Empty ignore_key_patterns should be byte-for-byte inert."""
+        content = textwrap.dedent("""\
+            # Existing target file
+            comment.1=Phrases in basic/Main.tsx
+            welcome=Willkommen
+        """)
+        with tempfile.NamedTemporaryFile('w', delete=False, encoding='utf-8') as temp_file:
+            temp_file.write(content)
+            temp_file_path = temp_file.name
+
+        try:
+            parsed_lines, target_translations = parse_properties_file(temp_file_path)
+            before = reassemble_file(parsed_lines)
+
+            updated_keys = apply_ignored_source_values(
+                parsed_lines,
+                target_translations,
+                {
+                    'comment.1': 'Phrases in basic/Main.tsx',
+                    'welcome': 'Welcome',
+                },
+                [],
+            )
+
+            self.assertEqual(updated_keys, set())
+            self.assertEqual(reassemble_file(parsed_lines), before)
+        finally:
+            os.unlink(temp_file_path)
 
     def test_per_key_validation_excludes_ignored_keys_from_failures(self):
         valid_translations, summary = run_per_key_validation_with_summary(

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -20,9 +20,11 @@ from localize.translate_localization_files import (
     get_working_tree_changed_keys,
     extract_language_from_filename,
     run_post_translation_validation,
+    run_per_key_validation_with_summary,
     run_pre_translation_validation,
     validate_paths,
 )
+from localize.ignore_keys import compile_ignore_key_patterns
 from localize.properties_parser import parse_properties_file, reassemble_file
 
 
@@ -106,6 +108,25 @@ class TestCoreLogic(unittest.TestCase):
                 source_path,
                 git_changed_keys={'new.key'},
                 file_ledger_entries={},
+            )
+
+            self.assertEqual(errors, ['Placeholder mismatch for key `new.key`.'])
+
+    def test_pre_validation_ignores_placeholder_mismatch_for_ignored_key(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = os.path.join(temp_dir, 'mobile.properties')
+            target_path = os.path.join(temp_dir, 'mobile_de.properties')
+            with open(source_path, 'w', encoding='utf-8') as file:
+                file.write('comment.key=Path {0}\nnew.key=New {0}\n')
+            with open(target_path, 'w', encoding='utf-8') as file:
+                file.write('comment.key=Path\nnew.key=Neu\n')
+
+            errors, _newly_added_keys = run_pre_translation_validation(
+                target_path,
+                source_path,
+                git_changed_keys={'comment.key', 'new.key'},
+                file_ledger_entries={},
+                ignore_key_patterns=compile_ignore_key_patterns([r'^comment\.']),
             )
 
             self.assertEqual(errors, ['Placeholder mismatch for key `new.key`.'])
@@ -311,6 +332,87 @@ class TestCoreLogic(unittest.TestCase):
         self.assertEqual(texts, ['Source New'])
         self.assertEqual(indices, [1])
         self.assertEqual(keys, ['key_newly_added'])
+
+    def test_extract_texts_to_translate_skips_ignored_keys(self):
+        """Ignored keys should never be selected for model translation."""
+        parsed_lines = [
+            {'type': 'entry', 'key': '/#1', 'value': 'Phrases in basic/Main.tsx', 'line_number': 0},
+            {'type': 'entry', 'key': '/welcome', 'value': 'Welcome', 'line_number': 1},
+        ]
+        target_translations = {
+            '/#1': 'Phrases in basic/Main.tsx',
+            '/welcome': 'Welcome',
+        }
+        source_translations = {
+            '/#1': 'Phrases in basic/Main.tsx',
+            '/welcome': 'Welcome',
+        }
+
+        texts, indices, keys = extract_texts_to_translate(
+            parsed_lines,
+            source_translations,
+            target_translations,
+            newly_added_keys={'/#1', '/welcome'},
+            ignore_key_patterns=compile_ignore_key_patterns([r'^/#\d+$']),
+        )
+
+        self.assertEqual(texts, ['Welcome'])
+        self.assertEqual(indices, [1])
+        self.assertEqual(keys, ['/welcome'])
+
+    def test_extract_texts_to_translate_is_unchanged_without_ignore_patterns(self):
+        """Unset ignore_key_patterns should preserve existing selection behavior."""
+        parsed_lines = [
+            {'type': 'entry', 'key': '/#1', 'value': 'Phrases in basic/Main.tsx', 'line_number': 0},
+            {'type': 'entry', 'key': '/welcome', 'value': 'Welcome', 'line_number': 1},
+        ]
+        target_translations = {
+            '/#1': 'Phrases in basic/Main.tsx',
+            '/welcome': 'Welcome',
+        }
+        source_translations = {
+            '/#1': 'Phrases in basic/Main.tsx',
+            '/welcome': 'Welcome',
+        }
+
+        baseline = extract_texts_to_translate(
+            parsed_lines,
+            source_translations,
+            target_translations,
+            newly_added_keys={'/#1', '/welcome'},
+        )
+        explicit_empty = extract_texts_to_translate(
+            parsed_lines,
+            source_translations,
+            target_translations,
+            newly_added_keys={'/#1', '/welcome'},
+            ignore_key_patterns=[],
+        )
+
+        self.assertEqual(baseline, explicit_empty)
+        self.assertEqual(baseline[2], ['/#1', '/welcome'])
+
+    def test_per_key_validation_excludes_ignored_keys_from_failures(self):
+        valid_translations, summary = run_per_key_validation_with_summary(
+            {
+                '/#1': 'Phrases in basic/Main.tsx',
+                '/welcome': 'Willkommen',
+                '/broken': 'Hallo',
+            },
+            {
+                '/#1': 'Phrases in basic/Main.tsx {{name}}',
+                '/welcome': 'Welcome',
+                '/broken': 'Hello {{name}}',
+            },
+            'de.json',
+            ignore_key_patterns=compile_ignore_key_patterns([r'^/#\d+$']),
+        )
+
+        self.assertEqual(valid_translations['/#1'], 'Phrases in basic/Main.tsx {{name}}')
+        self.assertEqual(valid_translations['/welcome'], 'Willkommen')
+        self.assertEqual(valid_translations['/broken'], 'Hello {{name}}')
+        self.assertEqual(summary['failed_keys'], ['/broken'])
+        self.assertEqual(summary['placeholder_failures_count'], 1)
 
     def test_extract_texts_to_translate_can_opt_in_retranslate_identical_existing(self):
         """Legacy behavior can be enabled explicitly for source-identical existing keys."""

--- a/tests/unit/test_ignore_keys.py
+++ b/tests/unit/test_ignore_keys.py
@@ -1,5 +1,7 @@
 """Tests for configured translation-key ignore patterns."""
 
+import re
+
 import pytest
 
 from localize.ignore_keys import compile_ignore_key_patterns, is_ignored_key
@@ -33,6 +35,17 @@ def test_properties_keys_use_the_adapter_key_verbatim():
 def test_empty_patterns_are_noop():
     assert compile_ignore_key_patterns([]) == []
     assert not is_ignored_key("/#1", [])
+
+
+def test_compiled_patterns_are_passed_through():
+    compiled_pattern = re.compile(r"^/#\d+$")
+
+    patterns = compile_ignore_key_patterns([compiled_pattern, r"^/metadata$"])
+
+    assert patterns[0] is compiled_pattern
+    assert is_ignored_key("/#1", patterns)
+    assert is_ignored_key("/metadata", patterns)
+    assert not is_ignored_key("/title", patterns)
 
 
 def test_invalid_pattern_reports_the_pattern():

--- a/tests/unit/test_ignore_keys.py
+++ b/tests/unit/test_ignore_keys.py
@@ -1,0 +1,40 @@
+"""Tests for configured translation-key ignore patterns."""
+
+import pytest
+
+from localize.ignore_keys import compile_ignore_key_patterns, is_ignored_key
+
+
+def test_json_pointer_comment_keys_match_ignore_pattern():
+    patterns = compile_ignore_key_patterns([r"^/#\d+$"])
+
+    assert is_ignored_key("/#1", patterns)
+    assert is_ignored_key("/#52", patterns)
+    assert not is_ignored_key("/#abc", patterns)
+    assert not is_ignored_key("/nav/settings", patterns)
+
+
+def test_nested_json_pointer_keys_can_be_ignored():
+    patterns = compile_ignore_key_patterns([r"^/metadata/comments/"])
+
+    assert is_ignored_key("/metadata/comments/0", patterns)
+    assert is_ignored_key("/metadata/comments/source", patterns)
+    assert not is_ignored_key("/metadata/title", patterns)
+
+
+def test_properties_keys_use_the_adapter_key_verbatim():
+    patterns = compile_ignore_key_patterns([r"^debug\.", r"\.comment$"])
+
+    assert is_ignored_key("debug.section", patterns)
+    assert is_ignored_key("screen.comment", patterns)
+    assert not is_ignored_key("screen.title", patterns)
+
+
+def test_empty_patterns_are_noop():
+    assert compile_ignore_key_patterns([]) == []
+    assert not is_ignored_key("/#1", [])
+
+
+def test_invalid_pattern_reports_the_pattern():
+    with pytest.raises(ValueError, match=r"Invalid ignore_key_patterns regex '\['"):
+        compile_ignore_key_patterns(["["])

--- a/tests/unit/test_translation_quality_gate.py
+++ b/tests/unit/test_translation_quality_gate.py
@@ -177,6 +177,23 @@ def test_quality_gate_config_loads_ignore_key_patterns(tmp_path):
     config, _locale_codes, _brand_glossary, _rules = load_quality_gate_config(str(config_path))
 
     assert [pattern.pattern for pattern in config.ignore_key_patterns] == [r"^/#\d+$"]
+    report = build_quality_gate_report(
+        source_stats=analyze_source_identical_changes(
+            diff_text="",
+            repo_root=str(tmp_path),
+            input_folder=str(tmp_path),
+            locale_codes=["de"],
+            brand_glossary=[],
+            ignore_key_patterns=config.ignore_key_patterns,
+        ),
+        semantic_stats=None,
+        validation_summary={"files": {}, "pipeline_warnings": []},
+        changed_files=[],
+        input_folder=str(tmp_path),
+        config=config,
+    )
+    assert report["thresholds"]["ignore_key_patterns"] == [r"^/#\d+$"]
+    json.dumps(report["thresholds"])
 
 
 def test_quality_gate_localization_metadata_rejects_invalid_format(tmp_path):

--- a/tests/unit/test_translation_quality_gate.py
+++ b/tests/unit/test_translation_quality_gate.py
@@ -120,6 +120,65 @@ def test_source_identical_gate_supports_json_locale_directory_layout(tmp_path):
     ]
 
 
+def test_source_identical_gate_excludes_ignored_json_pointer_keys(tmp_path):
+    repo_root = tmp_path
+    input_folder = repo_root / "locales"
+    _write_json(
+        input_folder / "en.json",
+        {
+            "#1": "Phrases in basic/Main.tsx",
+            "title": "Open trades",
+        },
+    )
+    _write_json(
+        input_folder / "de.json",
+        {
+            "#1": "Phrases in basic/Main.tsx",
+            "title": "Open trades",
+        },
+    )
+    diff_text = """diff --git a/locales/de.json b/locales/de.json
++++ b/locales/de.json
++  "#1": "Phrases in basic/Main.tsx",
++  "title": "Open trades",
+"""
+
+    stats = analyze_source_identical_changes(
+        diff_text=diff_text,
+        repo_root=str(repo_root),
+        input_folder=str(input_folder),
+        locale_codes=["de"],
+        brand_glossary=[],
+        localization_format=JSON_FORMAT,
+        localization_layout=LocalizationLayout(id="locale_filename", source_locale="en"),
+        ignore_key_patterns=[r"^/#\d+$"],
+    )
+
+    assert stats.changed_entries_count == 1
+    assert stats.source_identical_count == 1
+    assert stats.unexpected_source_identical_count == 1
+    assert stats.examples == [
+        {"file": "de.json", "key": "/title", "value": "Open trades"},
+    ]
+
+
+def test_quality_gate_config_loads_ignore_key_patterns(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "ignore_key_patterns": [r"^/#\d+$"],
+                "supported_locales": [{"code": "de", "name": "German"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config, _locale_codes, _brand_glossary, _rules = load_quality_gate_config(str(config_path))
+
+    assert [pattern.pattern for pattern in config.ignore_key_patterns] == [r"^/#\d+$"]
+
+
 def test_quality_gate_localization_metadata_rejects_invalid_format(tmp_path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text("localization_format: unknown\n", encoding="utf-8")

--- a/tests/unit/test_translation_quality_gate.py
+++ b/tests/unit/test_translation_quality_gate.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import re
 
 import pytest
 import yaml
@@ -151,7 +152,7 @@ def test_source_identical_gate_excludes_ignored_json_pointer_keys(tmp_path):
         brand_glossary=[],
         localization_format=JSON_FORMAT,
         localization_layout=LocalizationLayout(id="locale_filename", source_locale="en"),
-        ignore_key_patterns=[r"^/#\d+$"],
+        ignore_key_patterns=[re.compile(r"^/#\d+$"), r"^/metadata$"],
     )
 
     assert stats.changed_entries_count == 1


### PR DESCRIPTION
## Summary
- add ignore_key_patterns config with compiled regex validation
- skip ignored keys in translation, review, validation, quality gates, and estimates
- document RoboSats-style JSON Pointer pseudo-comment usage

## Verification
- OPENAI_API_KEY=sk-test-key venv/bin/pytest tests/unit -q
- OPENAI_API_KEY=sk-test-key venv/bin/pytest tests/integration -q
- OPENAI_API_KEY=sk-test-key venv/bin/pytest -q
- OPENAI_API_KEY=sk-test-key venv/bin/ruff check .
- dry_run=true RoboSats-like fixture queued only /welcome and /amount, not /#1 or /#2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ignoring selected translation keys via configurable pattern matching.
  * Matching keys are now preserved from the source locale instead of being sent for translation.

* **Bug Fixes**
  * Improved handling so ignored keys are excluded from validation checks, quality checks, and cost/usage reporting.
  * Updated output flow to keep ignored content consistent even when no translation work is needed.

* **Documentation**
  * Documented the new configuration option in the changelog, README, and sample config.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->