### PR TITLE
Harden translation health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
   the source locale while excluding them from model calls, validation accounting,
   quality gates, and cost estimates.
 
+### Fixed
+
+- Translation service health checks now alert on stale completed cron runs and
+  continue to inspect the latest run after log rotation.
+
 ## [0.1.3] - 2026-07-01
 
 ### Fixed

--- a/scripts/check-translation-services.sh
+++ b/scripts/check-translation-services.sh
@@ -10,6 +10,8 @@ INSTALL_ROOT="${LOCALIZE_PIPELINE_ROOT:-/opt/localize-pipeline}"
 MOBILE_INSTALL_ROOT="${LOCALIZE_PIPELINE_MOBILE_ROOT:-/opt/localize-pipeline-mobile}"
 LEGACY_INSTALL_ROOT="/opt/translate-java-property-files"
 LEGACY_MOBILE_INSTALL_ROOT="/opt/translate-java-property-files-mobile-app"
+MAX_CRON_SUCCESS_AGE_SECONDS="${MAX_CRON_SUCCESS_AGE_SECONDS:-93600}"
+MAX_RUNNING_AGE_SECONDS="${MAX_RUNNING_AGE_SECONDS:-10800}"
 
 if [ ! -d "$INSTALL_ROOT" ] && [ -d "$LEGACY_INSTALL_ROOT" ]; then
     INSTALL_ROOT="$LEGACY_INSTALL_ROOT"
@@ -81,31 +83,93 @@ count_open_translation_prs() {
     echo "$total"
 }
 
+cron_log_files() {
+    local log_file="$1"
+    local log_dir log_name
+    log_dir=$(dirname "$log_file")
+    log_name=$(basename "$log_file")
+
+    find "$log_dir" -maxdepth 1 -type f -name "${log_name}-*" 2>/dev/null | sort
+    if [ -f "$log_file" ]; then
+        printf '%s\n' "$log_file"
+    fi
+}
+
+combine_cron_logs() {
+    local log_file="$1"
+    local file
+
+    while IFS= read -r file; do
+        case "$file" in
+            *.gz)
+                gzip -cd -- "$file"
+                ;;
+            *)
+                cat -- "$file"
+                ;;
+        esac
+    done < <(cron_log_files "$log_file")
+}
+
 check_cron_log() {
     local label="$1"
     local log_file="$2"
+    local max_success_age_sec="$3"
 
     if [ ! -f "$log_file" ]; then
         log_alert "$label cron log not found: $log_file"
         return
     fi
 
+    local combined_log
+    combined_log=$(mktemp)
+    combine_cron_logs "$log_file" > "$combined_log"
+
     local start_line
-    start_line=$(grep -nE "Starting Git and Transifex validation" "$log_file" | tail -n1 | cut -d: -f1 || true)
+    start_line=$(grep -nE "Starting Git and Transifex validation" "$combined_log" | tail -n1 | cut -d: -f1 || true)
 
     if [ -z "$start_line" ]; then
         log_alert "$label cron job has no run markers - check $log_file"
+        rm -f "$combined_log"
         return
     fi
 
     local start_ts
-    start_ts=$(sed -n "${start_line}p" "$log_file" | sed -n 's/^\[\([^]]*\)\].*/\1/p')
+    start_ts=$(sed -n "${start_line}p" "$combined_log" | sed -n 's/^\[\([^]]*\)\].*/\1/p')
 
     local status_segment
-    status_segment=$(tail -n +"$start_line" "$log_file" | grep -E "Translation update script finished successfully|No further processing needed|BLOCKING CONDITION DETECTED" | tail -n1 || true)
+    status_segment=$(tail -n +"$start_line" "$combined_log" | grep -E "Translation update script finished successfully|No further processing needed|BLOCKING CONDITION DETECTED" | tail -n1 || true)
 
     if [ -n "$status_segment" ]; then
+        local status_ts status_epoch now_epoch status_age_sec
+        status_ts=$(sed -n 's/^\[\([^]]*\)\].*/\1/p' <<<"$status_segment")
+        status_epoch=$(date -d "$status_ts" +%s 2>/dev/null || echo 0)
+        now_epoch=$(date +%s)
+        status_age_sec=$((now_epoch - status_epoch))
+
+        if [ "$status_epoch" -le 0 ] || [ "$status_age_sec" -gt "$max_success_age_sec" ]; then
+            log_alert "$label cron job last completed run is too old - check $log_file"
+            rm -f "$combined_log"
+            return
+        fi
+
+        local heartbeat_failure heartbeat_segment
+        heartbeat_failure=$(tail -n +"$start_line" "$combined_log" | grep -E "Warning: Health check ping failed" | tail -n1 || true)
+        if [ -n "$heartbeat_failure" ]; then
+            log_alert "$label cron job heartbeat failed - check $log_file"
+            rm -f "$combined_log"
+            return
+        fi
+
+        heartbeat_segment=$(tail -n +"$start_line" "$combined_log" | grep -E "Sending heartbeat to health check URL" | tail -n1 || true)
+        if [ -z "$heartbeat_segment" ]; then
+            log_alert "$label cron job did not attempt a heartbeat - check $log_file"
+            rm -f "$combined_log"
+            return
+        fi
+
         log_ok "$label cron job completed successfully or blocked appropriately"
+        rm -f "$combined_log"
         return
     fi
 
@@ -114,11 +178,12 @@ check_cron_log() {
     start_epoch=$(date -d "$start_ts" +%s 2>/dev/null || echo 0)
     age_sec=$((now_epoch - start_epoch))
 
-    if [ "$start_epoch" -gt 0 ] && [ "$age_sec" -lt 10800 ]; then
+    if [ "$start_epoch" -gt 0 ] && [ "$age_sec" -lt "$MAX_RUNNING_AGE_SECONDS" ]; then
         log_ok "$label cron job appears to be still running (started ${age_sec}s ago)"
     else
         log_alert "$label cron job may have failed or stalled - check $log_file"
     fi
+    rm -f "$combined_log"
 }
 
 # Check 1: Ensure systemd service is NOT running
@@ -148,8 +213,8 @@ fi
 # Check 3: Check latest cron run result robustly
 main_log="$INSTALL_ROOT/logs/cron_job.log"
 mobile_log="$MOBILE_INSTALL_ROOT/logs/cron_job.log"
-check_cron_log "Main service" "$main_log"
-check_cron_log "Mobile app service" "$mobile_log"
+check_cron_log "Main service" "$main_log" "$MAX_CRON_SUCCESS_AGE_SECONDS"
+check_cron_log "Mobile app service" "$mobile_log" "$MAX_CRON_SUCCESS_AGE_SECONDS"
 
 # Check 4: Disk space for Docker volumes
 disk_usage=$(df -h /var/lib/docker | tail -1 | awk '{print $5}' | sed 's/%//' )

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -45,6 +45,27 @@ def test_health_check_reads_github_token_from_main_or_mobile_install():
     assert 'if [ -z "$GITHUB_TOKEN" ] && [ -f "$env_file" ]; then' in script
 
 
+def test_health_check_alerts_on_stale_completed_cron_runs():
+    script = (REPO_ROOT / "scripts" / "check-translation-services.sh").read_text()
+
+    assert "cron_log_files()" in script
+    assert "combine_cron_logs()" in script
+    assert 'gzip -cd -- "$file"' in script
+    assert 'MAX_CRON_SUCCESS_AGE_SECONDS="${MAX_CRON_SUCCESS_AGE_SECONDS:-93600}"' in script
+    assert 'local max_success_age_sec="$3"' in script
+    assert "last completed run is too old" in script
+    assert 'check_cron_log "Main service" "$main_log" "$MAX_CRON_SUCCESS_AGE_SECONDS"' in script
+    assert 'check_cron_log "Mobile app service" "$mobile_log" "$MAX_CRON_SUCCESS_AGE_SECONDS"' in script
+
+
+def test_health_check_verifies_job_heartbeat_attempts():
+    script = (REPO_ROOT / "scripts" / "check-translation-services.sh").read_text()
+
+    assert "Warning: Health check ping failed" in script
+    assert "did not attempt a heartbeat" in script
+    assert "Sending heartbeat to health check URL" in script
+
+
 def test_generated_prs_publish_translation_quality_gate_status():
     script = (REPO_ROOT / "update-translations.sh").read_text()
 


### PR DESCRIPTION
## Summary\n- alert when the latest completed translation cron run is stale\n- inspect rotated cron logs as well as the active log\n- fail health checks when the latest run skipped or failed its heartbeat attempt\n\n## Production note\n- hotfixed /opt/scripts/check-translation-services.sh on the production host\n- fixed the host logrotate owner from numeric 9999:9999 to root:root\n- forced log rotation and verified health checks still pass with empty active logs\n\n## Verification\n- OPENAI_API_KEY=sk-test-key venv/bin/pytest tests/unit/test_update_translations_script.py -q\n- OPENAI_API_KEY=sk-test-key venv/bin/ruff check tests/unit/test_update_translations_script.py\n- bash -n scripts/check-translation-services.sh\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation service health checks to better detect stale completed runs and heartbeat-related failures.
  * Now continues checking the latest available run even when logs are rotated or split across multiple files.
  * Added configurable timing thresholds so alerts can be tuned for completed and running cron jobs.

* **Tests**
  * Added coverage for stale run detection and heartbeat validation in translation health checks.

* **Documentation**
  * Updated the changelog with the latest fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->