### PR TITLE
Track git source diff baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 - Git-source production installs now persist a last-processed upstream commit and
   use it as `TRANSLATION_DIFF_BASE`, so committed source-file changes are still
   detected after the wrapper resets the target repository to a clean checkout.
+- The Bisq Mobile production profile now uses Transifex as its translation
+  source again, matching the operational setup used by Bisq 2 and mobile.
 
 ## [0.1.3] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 - Translation service health checks now alert on stale completed cron runs and
   continue to inspect the latest run after log rotation.
+- Git-source production installs now persist a last-processed upstream commit and
+  use it as `TRANSLATION_DIFF_BASE`, so committed source-file changes are still
+  detected after the wrapper resets the target repository to a clean checkout.
 
 ## [0.1.3] - 2026-07-01
 

--- a/profiles/bisq-mobile/config.yaml
+++ b/profiles/bisq-mobile/config.yaml
@@ -2,7 +2,7 @@ target_project_root: "/target_repo"
 input_folder: "/target_repo/shared/domain/src/commonMain/resources/mobile"
 glossary_file_path: "glossary.json"
 localization_format: "java_properties"
-translation_source: "git"
+translation_source: "transifex"
 project_context: >
   Translate for Bisq mobile, the Kotlin Multiplatform mobile companion for the
   Bisq peer-to-peer bitcoin trading ecosystem. Keep navigation labels concise,

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -187,7 +187,7 @@ def test_bisq_mobile_profile_packages_sanitized_production_shape():
     glossary = yaml.safe_load(BISQ_MOBILE_PROFILE_GLOSSARY.read_text(encoding="utf-8"))
 
     assert config["localization_format"] == "java_properties"
-    assert config["translation_source"] == "git"
+    assert config.get("translation_source", "transifex") == "transifex"
     assert config["input_folder"] == "/target_repo/shared/domain/src/commonMain/resources/mobile"
     assert "Bisq mobile" in config["project_context"]
     assert config["semantic_review"]["enabled"] is True

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -187,7 +187,7 @@ def test_bisq_mobile_profile_packages_sanitized_production_shape():
     glossary = yaml.safe_load(BISQ_MOBILE_PROFILE_GLOSSARY.read_text(encoding="utf-8"))
 
     assert config["localization_format"] == "java_properties"
-    assert config.get("translation_source", "transifex") == "transifex"
+    assert config["translation_source"] == "transifex"
     assert config["input_folder"] == "/target_repo/shared/domain/src/commonMain/resources/mobile"
     assert "Bisq mobile" in config["project_context"]
     assert config["semantic_review"]["enabled"] is True

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -190,6 +190,52 @@ def test_transifex_pull_is_skipped_when_source_is_git():
     assert guard_index < tx_pull_index
 
 
+def test_git_source_prepares_diff_baseline_before_pipeline():
+    """Git-source cron runs must diff against the last processed upstream commit."""
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    assert "prepare_git_source_diff_base()" in script
+    assert 'prepare_git_source_diff_base "$TRANSLATION_SOURCE"' in script
+    assert 'export TRANSLATION_DIFF_BASE="$baseline_sha"' in script
+    assert 'git merge-base --is-ancestor "$baseline_sha" HEAD' in script
+
+    checkout_index = script.index('git checkout -B "${DEFAULT_BRANCH}"')
+    baseline_index = script.index('prepare_git_source_diff_base "$TRANSLATION_SOURCE"')
+    prepare_index = script.index('prepare_translation_source "$TRANSLATION_SOURCE"')
+    python_index = script.index('python3 -u -m localize.cli run --config "$CONFIG_FILE"')
+
+    assert checkout_index < baseline_index < prepare_index < python_index
+
+
+def test_git_source_baseline_uses_persistent_logs_state():
+    """The baseline survives container restarts by living under the logs mount."""
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    assert "sanitize_state_component()" in script
+    assert 'state_dir="${LOCALIZE_STATE_DIR:-$LOG_DIR/state}"' in script
+    assert "git-source-baseline" in script
+    assert "GIT_SOURCE_BASELINE_FILE=" in script
+    assert "GIT_SOURCE_CURRENT_HEAD=" in script
+
+
+def test_git_source_baseline_advances_only_after_no_change_success():
+    """Do not advance the baseline while a generated translation PR is pending."""
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    assert "update_git_source_baseline_if_safe()" in script
+    assert "TRANSLATION_CHANGES_CREATED=false" in script
+    assert "TRANSLATION_CHANGES_CREATED=true" in script
+    assert '"${DRY_RUN:-false}" == "true"' in script
+    assert '"${TRANSLATION_CHANGES_CREATED:-false}" == "true"' in script
+    assert "Not advancing git-source baseline because translation changes were produced" in script
+
+    publish_index = script.index("\npublish_translation_changes\n")
+    update_index = script.index('update_git_source_baseline_if_safe "$TRANSLATION_SOURCE"')
+    return_branch_index = script.index("# Go back to original branch")
+
+    assert publish_index < update_index < return_branch_index
+
+
 def test_translation_source_read_before_transifex_step():
     script = (REPO_ROOT / "update-translations.sh").read_text()
 

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -213,6 +213,7 @@ def test_git_source_baseline_uses_persistent_logs_state():
 
     assert "sanitize_state_component()" in script
     assert 'state_dir="${LOCALIZE_STATE_DIR:-$LOG_DIR/state}"' in script
+    assert 'input_component=$(sanitize_state_component "${INPUT_FOLDER:-default}")' in script
     assert "git-source-baseline" in script
     assert "GIT_SOURCE_BASELINE_FILE=" in script
     assert "GIT_SOURCE_CURRENT_HEAD=" in script

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -139,6 +139,96 @@ is_supported_translation_source() {
     [[ "$source" == "git" || "$source" == "transifex" ]]
 }
 
+sanitize_state_component() {
+    local value="${1:-unknown}"
+    printf '%s' "$value" | tr -c 'A-Za-z0-9_.-' '_'
+}
+
+git_source_baseline_path() {
+    local state_dir="$1"
+    local repo_component
+    local branch_component
+    repo_component=$(sanitize_state_component "$UPSTREAM_REPO_NAME")
+    branch_component=$(sanitize_state_component "$DEFAULT_BRANCH")
+    printf '%s/git-source-baseline-%s-%s.sha\n' "$state_dir" "$repo_component" "$branch_component"
+}
+
+prepare_git_source_diff_base() {
+    local translation_source="$1"
+    if [[ "$translation_source" != "git" ]]; then
+        return 0
+    fi
+
+    GIT_SOURCE_CURRENT_HEAD=$(git rev-parse HEAD)
+    export GIT_SOURCE_CURRENT_HEAD
+
+    local state_dir
+    state_dir="${LOCALIZE_STATE_DIR:-$LOG_DIR/state}"
+    mkdir -p "$state_dir"
+    GIT_SOURCE_BASELINE_FILE=$(git_source_baseline_path "$state_dir")
+    export GIT_SOURCE_BASELINE_FILE
+
+    if [ -n "${TRANSLATION_DIFF_BASE:-}" ]; then
+        log "Using explicit TRANSLATION_DIFF_BASE='$TRANSLATION_DIFF_BASE' for git-source change detection." "INFO"
+        return 0
+    fi
+
+    if [ ! -s "$GIT_SOURCE_BASELINE_FILE" ]; then
+        log "No git-source baseline found at '$GIT_SOURCE_BASELINE_FILE'. This run will seed the baseline after a successful no-change run." "INFO"
+        return 0
+    fi
+
+    local baseline_sha
+    IFS= read -r baseline_sha < "$GIT_SOURCE_BASELINE_FILE" || baseline_sha=""
+    baseline_sha="${baseline_sha%%[[:space:]]*}"
+    if ! git rev-parse --verify --quiet "${baseline_sha}^{commit}" >/dev/null; then
+        log "Ignoring invalid git-source baseline '$baseline_sha' in '$GIT_SOURCE_BASELINE_FILE'." "WARNING"
+        return 0
+    fi
+    if ! git merge-base --is-ancestor "$baseline_sha" HEAD; then
+        log "Ignoring git-source baseline '$baseline_sha' because it is not an ancestor of HEAD." "WARNING"
+        return 0
+    fi
+
+    export TRANSLATION_DIFF_BASE="$baseline_sha"
+    log "Using git-source baseline '$baseline_sha' for change detection against HEAD '$GIT_SOURCE_CURRENT_HEAD'." "INFO"
+    record_pipeline_event "git_source_diff_base" "base=$baseline_sha" "head=$GIT_SOURCE_CURRENT_HEAD"
+}
+
+update_git_source_baseline_if_safe() {
+    local translation_source="$1"
+    if [[ "$translation_source" != "git" ]]; then
+        return 0
+    fi
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+        log "Dry run is enabled. Not advancing git-source baseline." "INFO"
+        return 0
+    fi
+    if [[ "${TRANSLATION_CHANGES_CREATED:-false}" == "true" ]]; then
+        log "Not advancing git-source baseline because translation changes were produced and need PR review." "INFO"
+        return 0
+    fi
+    if [ -z "${GIT_SOURCE_CURRENT_HEAD:-}" ]; then
+        log "Git-source baseline was not prepared; skipping baseline update." "WARNING"
+        return 0
+    fi
+
+    local state_dir
+    state_dir="${LOCALIZE_STATE_DIR:-$LOG_DIR/state}"
+    mkdir -p "$state_dir"
+    if [ -z "${GIT_SOURCE_BASELINE_FILE:-}" ]; then
+        GIT_SOURCE_BASELINE_FILE=$(git_source_baseline_path "$state_dir")
+        export GIT_SOURCE_BASELINE_FILE
+    fi
+
+    local tmp_file
+    tmp_file="${GIT_SOURCE_BASELINE_FILE}.$$"
+    printf '%s\n' "$GIT_SOURCE_CURRENT_HEAD" > "$tmp_file"
+    mv "$tmp_file" "$GIT_SOURCE_BASELINE_FILE"
+    log "Advanced git-source baseline to '$GIT_SOURCE_CURRENT_HEAD'." "INFO"
+    record_pipeline_event "git_source_baseline_updated" "head=$GIT_SOURCE_CURRENT_HEAD"
+}
+
 translation_file_change_regex() {
     printf '\\.(%s)([[:space:]]|$|->)' "$(translation_file_extension_regex)"
 }
@@ -307,6 +397,9 @@ done
 # Lock file to prevent concurrent executions for the same repository
 LOCK_FILE="/tmp/translation-${UPSTREAM_REPO_NAME//\//-}.lock"
 EXECUTION_LOG="${LOG_DIR}/translation-executions.log"
+GIT_SOURCE_BASELINE_FILE=""
+GIT_SOURCE_CURRENT_HEAD=""
+TRANSLATION_CHANGES_CREATED=false
 
 # Log execution start
 echo "$(date -Iseconds) START ${HOSTNAME:-unknown} REPO=${UPSTREAM_REPO_NAME} PID=$$" >> "$EXECUTION_LOG" 2>/dev/null || true
@@ -596,6 +689,7 @@ git clean -fde "venv/" -e ".idea/" -e "*.iml" -e "secrets/" -e "docker/.env"
 # No further git pull or submodule init/update should be necessary here before tx pull.
 log "Proceeding with Transifex operations. Current HEAD on ${DEFAULT_BRANCH}:"
 git log -1 --pretty=%H
+prepare_git_source_diff_base "$TRANSLATION_SOURCE"
 
 # Step 2: Use the configured source adapter to prepare translation files.
 prepare_translation_source "$TRANSLATION_SOURCE" "${DRY_RUN:-false}" "${PULL_SOURCE_FILES:-false}"
@@ -866,9 +960,11 @@ This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT
 }
 
 publish_translation_changes() {
+TRANSLATION_CHANGES_CREATED=false
 TRANSLATION_CHANGES=$(git status --porcelain | grep -E "$(translation_file_status_regex)" || true)
 
 if [ -n "$TRANSLATION_CHANGES" ]; then
+    TRANSLATION_CHANGES_CREATED=true
     if [[ "${DRY_RUN:-false}" == "true" ]]; then
         log "Dry run is enabled. Skipping commit and pull request creation." "WARNING"
         log "The following changes would have been committed:" "INFO"
@@ -961,6 +1057,7 @@ fi
 }
 
 publish_translation_changes
+update_git_source_baseline_if_safe "$TRANSLATION_SOURCE"
 
 # Go back to original branch
 if [ -n "$ORIGINAL_BRANCH" ] && [ "$ORIGINAL_BRANCH" != "$DEFAULT_BRANCH" ]; then

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -148,9 +148,11 @@ git_source_baseline_path() {
     local state_dir="$1"
     local repo_component
     local branch_component
+    local input_component
     repo_component=$(sanitize_state_component "$UPSTREAM_REPO_NAME")
     branch_component=$(sanitize_state_component "$DEFAULT_BRANCH")
-    printf '%s/git-source-baseline-%s-%s.sha\n' "$state_dir" "$repo_component" "$branch_component"
+    input_component=$(sanitize_state_component "${INPUT_FOLDER:-default}")
+    printf '%s/git-source-baseline-%s-%s-%s.sha\n' "$state_dir" "$repo_component" "$branch_component" "$input_component"
 }
 
 prepare_git_source_diff_base() {


### PR DESCRIPTION
## Summary

- persist the last processed upstream commit for git-source production installs
- export that commit as TRANSLATION_DIFF_BASE before the localization CLI runs
- avoid advancing the baseline when generated translation changes still need PR review

## Verification

- OPENAI_API_KEY=sk-test-key venv/bin/pytest tests/unit/test_update_translations_script.py -q
- bash -n update-translations.sh
- OPENAI_API_KEY=sk-test-key venv/bin/ruff check tests/unit/test_update_translations_script.py
- git diff --check
- OPENAI_API_KEY=sk-test-key venv/bin/pytest
- OPENAI_API_KEY=sk-test-key venv/bin/ruff check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git-based translation updates now remember the last checked baseline across runs, improving consistency in detecting source-file changes.

* **Bug Fixes**
  * Fixed translation change detection so committed source updates are less likely to be missed after resets.
  * Improved translation service health checks to better handle stale cron results and log rotation.
  * Bisq Mobile production now uses Transifex again for translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->