### PR TITLE
Improve translation run reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ### Fixed
 
+- Generated translation PRs now report output values changed separately from
+  candidate keys, model calls, translation-memory reuse, and ledgerless
+  source-identical skips, so catch-up backlogs are visible in review.
 - Translation quality reports now separate AI semantic-review findings from
   rule/heuristic findings, show suggested AI-review values in PR examples, and
   exclude already auto-remediated AI findings from outstanding counts.

--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ Server guide: [docs/new-project-deployment.md](docs/new-project-deployment.md).
 - **Quality gate failed:** inspect the PR report. The pipeline reports skipped
   files, placeholder errors, semantic findings, and suspicious source-identical
   values.
+- **Generated PR title or counts look surprising:** inspect the "Translation run
+  summary" section. It separates output values changed from candidate keys,
+  model calls, translation-memory reuse, and source-identical keys skipped
+  because no ledger baseline exists yet.
 - **Action pushed a branch but failed to create a PR:** enable repository
   Actions workflow write permissions and allow workflow-created pull requests
   in the target repository settings.

--- a/localize/connectors.py
+++ b/localize/connectors.py
@@ -8,7 +8,7 @@ import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Awaitable, Callable, Dict, List, Protocol
+from typing import Awaitable, Callable, Dict, List, Mapping, Optional, Protocol
 
 from localize.pipeline_core import (
     ProcessQueueResult,
@@ -81,6 +81,7 @@ class PipelineReporterConnector(Protocol):
         processed_files: List[str],
         new_keys_count: int,
         updated_keys_count: int,
+        run_metrics: Optional[Mapping[str, int]] = None,
     ) -> None:
         """Write a machine-readable translation summary."""
 
@@ -279,14 +280,18 @@ class FileReporterConnector:
         processed_files: List[str],
         new_keys_count: int,
         updated_keys_count: int,
+        run_metrics: Optional[Mapping[str, int]] = None,
     ) -> None:
+        payload = {
+            "processed_files": processed_files,
+            "new_keys_count": new_keys_count,
+            "updated_keys_count": updated_keys_count,
+        }
+        if run_metrics:
+            payload.update({key: int(value) for key, value in run_metrics.items()})
         self._write_json(
             summary_path,
-            {
-                "processed_files": processed_files,
-                "new_keys_count": new_keys_count,
-                "updated_keys_count": updated_keys_count,
-            },
+            payload,
         )
 
     def write_translation_validation_summary(

--- a/localize/connectors.py
+++ b/localize/connectors.py
@@ -12,6 +12,7 @@ from typing import Awaitable, Callable, Dict, List, Mapping, Optional, Protocol
 
 from localize.pipeline_core import (
     ProcessQueueResult,
+    RUN_METRIC_KEYS,
     TranslationPipelineOptions,
     TranslationPipelinePaths,
     TranslationPipelineResult,
@@ -287,8 +288,8 @@ class FileReporterConnector:
             "new_keys_count": new_keys_count,
             "updated_keys_count": updated_keys_count,
         }
-        if run_metrics:
-            payload.update({key: int(value) for key, value in run_metrics.items()})
+        metrics = {key: int(value) for key, value in (run_metrics or {}).items()}
+        payload.update({key: metrics.get(key, 0) for key in RUN_METRIC_KEYS})
         self._write_json(
             summary_path,
             payload,

--- a/localize/pipeline_core.py
+++ b/localize/pipeline_core.py
@@ -11,10 +11,15 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Awaitable, Callable, Dict, List, Tuple
+from typing import Awaitable, Callable, Dict, List, Tuple, Union
 
 
-ProcessQueueResult = Tuple[int, List[str], Dict[str, List[str]], int]
+RunMetrics = Dict[str, int]
+LegacyProcessQueueResult = Tuple[int, List[str], Dict[str, List[str]], int]
+ProcessQueueResult = Union[
+    LegacyProcessQueueResult,
+    Tuple[int, List[str], Dict[str, List[str]], int, RunMetrics],
+]
 
 
 @dataclass(frozen=True)
@@ -91,6 +96,7 @@ class TranslationPipelineResult:
     processed_filenames: List[str] = field(default_factory=list)
     skipped_files: Dict[str, List[str]] = field(default_factory=dict)
     total_keys_translated: int = 0
+    run_metrics: RunMetrics = field(default_factory=dict)
 
 
 async def run_translation_pipeline(
@@ -130,17 +136,28 @@ async def run_translation_pipeline(
     logger.info("Copied changed files to '%s' for processing.", paths.translation_queue_folder)
 
     validation_files: Dict[str, Dict[str, object]] = {}
-    (
-        processed_files_count,
-        processed_filenames,
-        skipped_files,
-        total_keys_translated,
-    ) = await steps.process_translation_queue(
+    process_result = await steps.process_translation_queue(
         translation_queue_folder=paths.translation_queue_folder,
         translated_queue_folder=paths.translated_queue_folder,
         glossary_file_path=paths.glossary_file_path,
         validation_summary=validation_files,
     )
+    if len(process_result) == 5:
+        (
+            processed_files_count,
+            processed_filenames,
+            skipped_files,
+            total_keys_translated,
+            run_metrics,
+        ) = process_result
+    else:
+        (
+            processed_files_count,
+            processed_filenames,
+            skipped_files,
+            total_keys_translated,
+        ) = process_result
+        run_metrics = getattr(process_result, "run_metrics", {})
 
     if processed_files_count > 0:
         logger.info(
@@ -160,12 +177,23 @@ async def run_translation_pipeline(
     else:
         steps.remove_file_if_exists(paths.skipped_files_report_path)
 
-    steps.generate_translation_summary(
-        paths.translation_summary_path,
-        processed_files=processed_filenames,
-        new_keys_count=total_keys_translated,
-        updated_keys_count=0,
-    )
+    try:
+        steps.generate_translation_summary(
+            paths.translation_summary_path,
+            processed_files=processed_filenames,
+            new_keys_count=total_keys_translated,
+            updated_keys_count=0,
+            run_metrics=run_metrics,
+        )
+    except TypeError as exc:
+        if "run_metrics" not in str(exc):
+            raise
+        steps.generate_translation_summary(
+            paths.translation_summary_path,
+            processed_files=processed_filenames,
+            new_keys_count=total_keys_translated,
+            updated_keys_count=0,
+        )
     logger.info("Wrote translation summary to %s", paths.translation_summary_path)
 
     steps.write_translation_validation_summary(
@@ -194,4 +222,5 @@ async def run_translation_pipeline(
         processed_filenames=processed_filenames,
         skipped_files=skipped_files,
         total_keys_translated=total_keys_translated,
+        run_metrics=run_metrics,
     )

--- a/localize/pipeline_core.py
+++ b/localize/pipeline_core.py
@@ -8,18 +8,33 @@ shape without copying orchestration code.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Awaitable, Callable, Dict, List, Tuple, Union
+from typing import Awaitable, Callable, Dict, List, Tuple
 
+
+RUN_METRIC_KEYS = (
+    "candidate_keys_count",
+    "model_translation_keys_count",
+    "translation_memory_reused_count",
+    "source_identical_skipped_count",
+    "changed_values_count",
+)
 
 RunMetrics = Dict[str, int]
 LegacyProcessQueueResult = Tuple[int, List[str], Dict[str, List[str]], int]
-ProcessQueueResult = Union[
-    LegacyProcessQueueResult,
-    Tuple[int, List[str], Dict[str, List[str]], int, RunMetrics],
-]
+ProcessQueueResult = LegacyProcessQueueResult
+
+
+def supports_keyword_argument(callable_obj: Callable[..., object], keyword: str) -> bool:
+    """Return whether a callable accepts a named keyword argument."""
+    parameters = inspect.signature(callable_obj).parameters
+    return keyword in parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
 
 
 @dataclass(frozen=True)
@@ -142,22 +157,13 @@ async def run_translation_pipeline(
         glossary_file_path=paths.glossary_file_path,
         validation_summary=validation_files,
     )
-    if len(process_result) == 5:
-        (
-            processed_files_count,
-            processed_filenames,
-            skipped_files,
-            total_keys_translated,
-            run_metrics,
-        ) = process_result
-    else:
-        (
-            processed_files_count,
-            processed_filenames,
-            skipped_files,
-            total_keys_translated,
-        ) = process_result
-        run_metrics = getattr(process_result, "run_metrics", {})
+    (
+        processed_files_count,
+        processed_filenames,
+        skipped_files,
+        total_keys_translated,
+    ) = process_result
+    run_metrics = getattr(process_result, "run_metrics", {})
 
     if processed_files_count > 0:
         logger.info(
@@ -177,23 +183,14 @@ async def run_translation_pipeline(
     else:
         steps.remove_file_if_exists(paths.skipped_files_report_path)
 
-    try:
-        steps.generate_translation_summary(
-            paths.translation_summary_path,
-            processed_files=processed_filenames,
-            new_keys_count=total_keys_translated,
-            updated_keys_count=0,
-            run_metrics=run_metrics,
-        )
-    except TypeError as exc:
-        if "run_metrics" not in str(exc):
-            raise
-        steps.generate_translation_summary(
-            paths.translation_summary_path,
-            processed_files=processed_filenames,
-            new_keys_count=total_keys_translated,
-            updated_keys_count=0,
-        )
+    summary_kwargs = {
+        "processed_files": processed_filenames,
+        "new_keys_count": total_keys_translated,
+        "updated_keys_count": 0,
+    }
+    if supports_keyword_argument(steps.generate_translation_summary, "run_metrics"):
+        summary_kwargs["run_metrics"] = run_metrics
+    steps.generate_translation_summary(paths.translation_summary_path, **summary_kwargs)
     logger.info("Wrote translation summary to %s", paths.translation_summary_path)
 
     steps.write_translation_validation_summary(

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from email.utils import parsedate_to_datetime
-from typing import Dict, List, Optional, Pattern, Set, Tuple
+from typing import Dict, List, Mapping, Optional, Pattern, Set, Tuple
 
 # --- Python Version Check ---
 # This script requires Python 3.11 or newer for features like modern asyncio.
@@ -272,6 +272,62 @@ class TranslationMemoryPlan:
     pending_positions: List[int]
 
 
+RUN_METRIC_KEYS = (
+    "candidate_keys_count",
+    "model_translation_keys_count",
+    "translation_memory_reused_count",
+    "source_identical_skipped_count",
+    "changed_values_count",
+)
+
+
+def new_run_metrics() -> Dict[str, int]:
+    """Create a run-metrics map with stable keys for reporting."""
+    return {key: 0 for key in RUN_METRIC_KEYS}
+
+
+def increment_run_metric(metrics: Dict[str, int], key: str, amount: int = 1) -> None:
+    """Increment a named run metric in-place."""
+    metrics[key] = int(metrics.get(key, 0)) + amount
+
+
+def count_changed_translation_values(
+        before: Mapping[str, str],
+        after: Mapping[str, str],
+) -> int:
+    """Count target values that changed during this pipeline run."""
+    changed = 0
+    for key, value in after.items():
+        if before.get(key) != value:
+            changed += 1
+    return changed
+
+
+class ProcessTranslationQueueResult(tuple):
+    """Four-value process result with attached run metrics.
+
+    Existing direct callers can still unpack the legacy four fields, while the
+    generic pipeline core can read ``run_metrics`` for richer reporting.
+    """
+
+    run_metrics: Dict[str, int]
+
+    def __new__(
+            cls,
+            processed_files_count: int,
+            processed_filenames: List[str],
+            skipped_files: Dict[str, List[str]],
+            total_keys_translated: int,
+            run_metrics: Optional[Dict[str, int]] = None,
+    ):
+        obj = super().__new__(
+            cls,
+            (processed_files_count, processed_filenames, skipped_files, total_keys_translated),
+        )
+        obj.run_metrics = run_metrics or new_run_metrics()
+        return obj
+
+
 def apply_translation_memory(
         *,
         texts_to_translate: List[str],
@@ -344,6 +400,7 @@ def extract_texts_to_translate(
         file_ledger_entries: Optional[Dict[str, Dict[str, str]]] = None,
         retranslate_identical_existing: bool = False,
         ignore_key_patterns: Optional[List[Pattern[str]]] = None,
+        selection_metrics: Optional[Dict[str, int]] = None,
 ) -> Tuple[List[str], List[int], List[str]]:
     """
     Identifies which texts need to be translated. A text needs translation if:
@@ -362,6 +419,7 @@ def extract_texts_to_translate(
         file_ledger_entries: Persisted hash data for keys in this translation file.
         retranslate_identical_existing: Whether to retranslate pre-existing source-identical keys.
         ignore_key_patterns: Compiled key regexes that are never model-translated.
+        selection_metrics: Optional metrics map updated with selection decisions.
 
     Returns:
         A tuple containing the list of texts to translate, their corresponding indices, and their keys.
@@ -438,6 +496,8 @@ def extract_texts_to_translate(
                     "Enable 'retranslate_identical_source_strings' or seed the translation key ledger.",
                     key
                 )
+                if selection_metrics is not None:
+                    increment_run_metric(selection_metrics, "source_identical_skipped_count")
 
     # 2. Find new keys that are in the source but not in the target file.
     new_keys = source_translations.keys() - existing_keys_in_target
@@ -1917,7 +1977,7 @@ async def process_translation_queue(
         translated_queue_folder: str,
         glossary_file_path: str,
         validation_summary: Optional[Dict[str, Dict[str, object]]] = None
-) -> Tuple[int, List[str], Dict[str, List[str]], int]:
+) -> ProcessTranslationQueueResult:
     """
     Process all localization files in the translation queue folder.
 
@@ -1932,6 +1992,7 @@ async def process_translation_queue(
         - List of successfully processed filenames.
         - A dictionary of skipped files, mapping filename to a list of error strings.
         - Total number of keys translated across all files.
+        Run metrics are attached to the result as ``result.run_metrics``.
     """
     localization_files: List[Tuple[str, LocalizationProfile]] = []
     for root, dirs, files in os.walk(translation_queue_folder):
@@ -1967,6 +2028,7 @@ async def process_translation_queue(
     processed_files_count = 0
     processed_filenames: List[str] = []
     total_keys_translated = 0
+    run_metrics = new_run_metrics()
     skipped_files: Dict[str, List[str]] = {}
 
     for translation_file, localization_profile in localization_files:
@@ -2041,6 +2103,7 @@ async def process_translation_queue(
         # Load files
         parsed_lines, target_translations = adapter.parse_file(translation_file_path)
         _, source_translations = adapter.parse_file(source_file_path)
+        original_target_translations = dict(target_translations)
         ignored_keys_updated = apply_ignored_source_values(
             parsed_lines,
             target_translations,
@@ -2077,12 +2140,18 @@ async def process_translation_queue(
             file_ledger_entries=file_ledger_entries,
             retranslate_identical_existing=RETRANSLATE_IDENTICAL_SOURCE_STRINGS,
             ignore_key_patterns=IGNORE_KEY_PATTERNS,
+            selection_metrics=run_metrics,
         )
         if not texts_to_translate:
             # Refresh ledger baseline even when no translation was required.
             key_ledger[translation_file] = build_file_key_ledger(source_translations, target_translations)
             save_translation_key_ledger(TRANSLATION_KEY_LEDGER_FILE_PATH, key_ledger)
             if ignored_keys_requiring_output:
+                increment_run_metric(
+                    run_metrics,
+                    "changed_values_count",
+                    count_changed_translation_values(original_target_translations, target_translations),
+                )
                 translated_file_path = os.path.join(translated_queue_folder, translation_file)
                 new_file_content = adapter.reassemble_file(parsed_lines)
                 if DRY_RUN:
@@ -2102,6 +2171,8 @@ async def process_translation_queue(
             logger.info(f"No texts to translate in file '{translation_file}'.")
             continue
 
+        increment_run_metric(run_metrics, "candidate_keys_count", len(keys_to_translate))
+
         memory_plan = apply_translation_memory(
             texts_to_translate=texts_to_translate,
             indices=indices,
@@ -2110,6 +2181,8 @@ async def process_translation_queue(
             locale=language_code,
             format_id=localization_format.id,
         )
+        increment_run_metric(run_metrics, "translation_memory_reused_count", len(memory_plan.cached_results))
+        increment_run_metric(run_metrics, "model_translation_keys_count", len(memory_plan.pending_keys))
 
         # Pre-run scope/cost preview for this file (ballpark — actuals logged at the end).
         provider = MODEL_PROVIDER or _FALLBACK_PROVIDER
@@ -2319,6 +2392,16 @@ async def process_translation_queue(
         # Reassemble the final file content with validated translations
         updated_lines = draft_lines
         new_file_content = adapter.reassemble_file(updated_lines)
+        final_output_translations = {
+            line['key']: line.get('value', '')
+            for line in updated_lines
+            if line.get('type') == 'entry' and line.get('key')
+        }
+        increment_run_metric(
+            run_metrics,
+            "changed_values_count",
+            count_changed_translation_values(original_target_translations, final_output_translations),
+        )
         # --- End Per-Key Validation ---
 
         translated_file_path = os.path.join(translated_queue_folder, translation_file)
@@ -2355,7 +2438,13 @@ async def process_translation_queue(
         processed_filenames.append(translation_file)
         total_keys_translated += len(keys_to_translate)
 
-    return processed_files_count, processed_filenames, skipped_files, total_keys_translated
+    return ProcessTranslationQueueResult(
+        processed_files_count,
+        processed_filenames,
+        skipped_files,
+        total_keys_translated,
+        run_metrics,
+    )
 
 def archive_original_files(
         changed_files: List[str],
@@ -2387,6 +2476,7 @@ def generate_translation_summary(
     new_keys_count: int,
     updated_keys_count: int,
     supported_codes: Optional[List[str]] = None,
+    run_metrics: Optional[Mapping[str, int]] = None,
 ) -> None:
     """Write a JSON summary consumed by the shell script for PR title/body.
 
@@ -2397,6 +2487,7 @@ def generate_translation_summary(
         updated_keys_count: Total number of updated translation keys.
         supported_codes: Language codes for locale extraction. Defaults to
             ``LANGUAGE_CODES`` keys.
+        run_metrics: Optional explicit run counters for PR reporting.
     """
     if supported_codes is None:
         supported_codes = list(LANGUAGE_CODES.keys())
@@ -2432,7 +2523,15 @@ def generate_translation_summary(
     sorted_modules = sorted(modules)
     sorted_locales = sorted(locales)
 
-    title = _build_pr_title(sorted_modules, new_keys_count, updated_keys_count, len(sorted_locales))
+    metrics = {key: int(value) for key, value in (run_metrics or {}).items()}
+    changed_values_count = metrics.get("changed_values_count")
+    title = _build_pr_title(
+        sorted_modules,
+        new_keys_count,
+        updated_keys_count,
+        len(sorted_locales),
+        changed_values=changed_values_count,
+    )
 
     summary = {
         "title": title,
@@ -2442,6 +2541,8 @@ def generate_translation_summary(
         "new_keys_count": new_keys_count,
         "updated_keys_count": updated_keys_count,
     }
+    for key in RUN_METRIC_KEYS:
+        summary[key] = metrics.get(key, 0)
 
     os.makedirs(os.path.dirname(summary_path) or '.', exist_ok=True)
     with open(summary_path, 'w', encoding='utf-8') as f:
@@ -2519,18 +2620,21 @@ def _build_pr_title(
     new_keys: int,
     updated_keys: int,
     locale_count: int,
+    changed_values: Optional[int] = None,
 ) -> str:
     """Build a concise, descriptive PR title (max 72 chars)."""
-    if not modules and not new_keys and not updated_keys:
+    if changed_values is not None and changed_values > 0:
+        key_segment = f" ({changed_values} changed values)"
+    elif not modules and not new_keys and not updated_keys:
         return "Update translations"
-
-    parts: list[str] = []
-    if new_keys:
-        parts.append(f"{new_keys} new")
-    if updated_keys:
-        parts.append(f"{updated_keys} updated")
-    key_desc = ", ".join(parts)
-    key_segment = f" ({key_desc} keys)" if key_desc else ""
+    else:
+        parts: list[str] = []
+        if new_keys:
+            parts.append(f"{new_keys} new")
+        if updated_keys:
+            parts.append(f"{updated_keys} updated")
+        key_desc = ", ".join(parts)
+        key_segment = f" ({key_desc} keys)" if key_desc else ""
 
     if len(modules) == 1:
         mod_segment = f" in {modules[0]}"

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -47,6 +47,7 @@ from localize.placeholder_rules import (
     restore_placeholders as restore_protected_placeholders,
 )
 from localize.pipeline_core import (
+    RUN_METRIC_KEYS,
     TranslationPipelineOptions,
     TranslationPipelinePaths,
     TranslationPipelineSteps,
@@ -270,15 +271,6 @@ class TranslationMemoryPlan:
     pending_line_indices: List[int]
     pending_keys: List[str]
     pending_positions: List[int]
-
-
-RUN_METRIC_KEYS = (
-    "candidate_keys_count",
-    "model_translation_keys_count",
-    "translation_memory_reused_count",
-    "source_identical_skipped_count",
-    "changed_values_count",
-)
 
 
 def new_run_metrics() -> Dict[str, int]:
@@ -2623,8 +2615,10 @@ def _build_pr_title(
     changed_values: Optional[int] = None,
 ) -> str:
     """Build a concise, descriptive PR title (max 72 chars)."""
-    if changed_values is not None and changed_values > 0:
-        key_segment = f" ({changed_values} changed values)"
+    if changed_values is not None:
+        if not modules and changed_values == 0:
+            return "Update translations"
+        key_segment = f" ({changed_values} changed values)" if changed_values > 0 else ""
     elif not modules and not new_keys and not updated_keys:
         return "Update translations"
     else:

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -13,7 +13,11 @@ from localize.connectors import (
     PipelinePublisher,
     PipelinePublishRequest,
 )
-from localize.pipeline_core import TranslationPipelineOptions, TranslationPipelinePaths
+from localize.pipeline_core import (
+    RUN_METRIC_KEYS,
+    TranslationPipelineOptions,
+    TranslationPipelinePaths,
+)
 
 
 @dataclass
@@ -235,7 +239,10 @@ def test_file_reporter_connector_writes_machine_and_human_reports(tmp_path):
     )
 
     assert "placeholder mismatch" in skipped_report.read_text(encoding="utf-8")
-    assert json.loads(summary_path.read_text(encoding="utf-8"))["new_keys_count"] == 2
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["new_keys_count"] == 2
+    for key in RUN_METRIC_KEYS:
+        assert summary[key] == 0
     assert json.loads(validation_path.read_text(encoding="utf-8"))["files"]["messages_de.json"] == {
         "failed_keys": []
     }

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -547,6 +547,7 @@ class TestCoreLogic(unittest.TestCase):
         ]
         target_translations = {'key_existing': 'Source Existing'}
         source_translations = {'key_existing': 'Source Existing'}
+        selection_metrics = {}
 
         with self.assertLogs('translation_script', level='INFO') as captured_logs:
             texts, indices, keys = extract_texts_to_translate(
@@ -555,12 +556,14 @@ class TestCoreLogic(unittest.TestCase):
                 target_translations,
                 newly_added_keys=set(),
                 file_ledger_entries={},
-                retranslate_identical_existing=False
+                retranslate_identical_existing=False,
+                selection_metrics=selection_metrics,
             )
 
         self.assertEqual(texts, [])
         self.assertEqual(indices, [])
         self.assertEqual(keys, [])
+        self.assertEqual(selection_metrics["source_identical_skipped_count"], 1)
         joined_logs = "\n".join(captured_logs.output)
         self.assertIn("Skipping key 'key_existing' (source==target)", joined_logs)
         self.assertIn("retranslate_identical_source_strings", joined_logs)

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -112,6 +112,22 @@ class FakePipelineSteps:
         self.calls.append(f"cleanup:{translation_queue}:{translated_queue}")
 
 
+class MetricsAwareFakePipelineSteps(FakePipelineSteps):
+    def generate_translation_summary(
+        self,
+        summary_path,
+        *,
+        processed_files,
+        new_keys_count,
+        updated_keys_count,
+        run_metrics=None,
+    ):
+        self.calls.append(
+            "summary:"
+            f"{summary_path}:{processed_files}:{new_keys_count}:{updated_keys_count}:{run_metrics}"
+        )
+
+
 @pytest.fixture
 def pipeline_paths() -> TranslationPipelinePaths:
     return TranslationPipelinePaths(
@@ -184,6 +200,35 @@ async def test_pipeline_runs_core_steps_with_injected_adapters(pipeline_paths):
         "copy_back:/app/translated_queue:/repo/i18n",
         "cleanup:/app/translation_queue:/app/translated_queue",
     ]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_passes_run_metrics_to_summary(pipeline_paths):
+    run_metrics = {
+        "changed_values_count": 2,
+        "candidate_keys_count": 5,
+        "model_translation_keys_count": 3,
+        "translation_memory_reused_count": 2,
+        "source_identical_skipped_count": 7,
+    }
+    fake = MetricsAwareFakePipelineSteps(
+        changed_files=["app_de.properties"],
+        process_result=(1, ["app_de.properties"], {}, 5, run_metrics),
+    )
+
+    result = await run_translation_pipeline(
+        paths=pipeline_paths,
+        options=pipeline_options(),
+        steps=fake.as_steps(),
+        logger=logging.getLogger("test_pipeline_core"),
+    )
+
+    assert result.total_keys_translated == 5
+    assert result.run_metrics == run_metrics
+    assert (
+        "summary:/app/logs/translation_summary.json:['app_de.properties']:5:0:"
+        f"{run_metrics}"
+    ) in fake.calls
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -5,11 +5,36 @@ from typing import Dict, List
 import pytest
 
 from localize.pipeline_core import (
+    RUN_METRIC_KEYS,
     TranslationPipelineOptions,
     TranslationPipelinePaths,
     TranslationPipelineSteps,
     run_translation_pipeline,
 )
+
+
+class ProcessResultWithMetrics(tuple):
+    """Legacy four-item process result with attached run metrics."""
+
+    def __new__(
+        cls,
+        processed_files_count,
+        processed_filenames,
+        skipped_files,
+        total_keys_translated,
+        run_metrics,
+    ):
+        obj = super().__new__(
+            cls,
+            (
+                processed_files_count,
+                processed_filenames,
+                skipped_files,
+                total_keys_translated,
+            ),
+        )
+        obj.run_metrics = run_metrics
+        return obj
 
 
 @dataclass
@@ -213,7 +238,13 @@ async def test_pipeline_passes_run_metrics_to_summary(pipeline_paths):
     }
     fake = MetricsAwareFakePipelineSteps(
         changed_files=["app_de.properties"],
-        process_result=(1, ["app_de.properties"], {}, 5, run_metrics),
+        process_result=ProcessResultWithMetrics(
+            1,
+            ["app_de.properties"],
+            {},
+            5,
+            run_metrics,
+        ),
     )
 
     result = await run_translation_pipeline(
@@ -229,6 +260,33 @@ async def test_pipeline_passes_run_metrics_to_summary(pipeline_paths):
         "summary:/app/logs/translation_summary.json:['app_de.properties']:5:0:"
         f"{run_metrics}"
     ) in fake.calls
+
+
+@pytest.mark.asyncio
+async def test_pipeline_omits_run_metrics_for_legacy_summary_reporter(pipeline_paths):
+    run_metrics = {key: 0 for key in RUN_METRIC_KEYS}
+    run_metrics["changed_values_count"] = 1
+    fake = FakePipelineSteps(
+        changed_files=["app_de.properties"],
+        process_result=ProcessResultWithMetrics(
+            1,
+            ["app_de.properties"],
+            {},
+            4,
+            run_metrics,
+        ),
+    )
+
+    result = await run_translation_pipeline(
+        paths=pipeline_paths,
+        options=pipeline_options(),
+        steps=fake.as_steps(),
+        logger=logging.getLogger("test_pipeline_core"),
+    )
+
+    assert result.run_metrics == run_metrics
+    assert "summary:/app/logs/translation_summary.json:['app_de.properties']:4:0" in fake.calls
+    assert not any("changed_values_count" in call for call in fake.calls)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_translation_summary.py
+++ b/tests/unit/test_translation_summary.py
@@ -149,6 +149,29 @@ class TestTranslationSummary(unittest.TestCase):
         self.assertEqual(summary["translation_memory_reused_count"], 416)
         self.assertEqual(summary["source_identical_skipped_count"], 360)
 
+    def test_summary_title_treats_zero_changed_values_as_metric(self):
+        """Zero changed values should not fall back to candidate-key counts."""
+        summary = self._run_summary(
+            processed_files=[
+                "mobile_de.properties",
+                "mobile_es.properties",
+            ],
+            new_keys=433,
+            updated_keys=0,
+            run_metrics={
+                "changed_values_count": 0,
+                "candidate_keys_count": 433,
+                "model_translation_keys_count": 0,
+                "translation_memory_reused_count": 433,
+                "source_identical_skipped_count": 10,
+            },
+        )
+
+        self.assertNotIn("433 new", summary["title"])
+        self.assertNotIn("new keys", summary["title"])
+        self.assertEqual(summary["changed_values_count"], 0)
+        self.assertEqual(summary["candidate_keys_count"], 433)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_translation_summary.py
+++ b/tests/unit/test_translation_summary.py
@@ -15,7 +15,7 @@ class TestTranslationSummary(unittest.TestCase):
     """Tests for generate_translation_summary(), which produces a JSON file
     consumed by the shell script to build descriptive PR titles."""
 
-    def _run_summary(self, processed_files, new_keys, updated_keys):
+    def _run_summary(self, processed_files, new_keys, updated_keys, run_metrics=None):
         with tempfile.NamedTemporaryFile(
             mode='w', delete=False, suffix='.json'
         ) as f:
@@ -26,6 +26,7 @@ class TestTranslationSummary(unittest.TestCase):
             new_keys_count=new_keys,
             updated_keys_count=updated_keys,
             supported_codes=SUPPORTED_CODES,
+            run_metrics=run_metrics,
         )
         with open(path, 'r', encoding='utf-8') as f:
             summary = json.load(f)
@@ -120,6 +121,33 @@ class TestTranslationSummary(unittest.TestCase):
 
         self.assertIn("3 new", summary["title"])
         self.assertIn("5 updated", summary["title"])
+
+    def test_summary_title_uses_changed_values_when_available(self):
+        """PR title should describe final diff size, not candidate keys."""
+        summary = self._run_summary(
+            processed_files=[
+                "mobile_de.properties",
+                "mobile_es.properties",
+                "mobile_fr.properties",
+            ],
+            new_keys=433,
+            updated_keys=0,
+            run_metrics={
+                "changed_values_count": 20,
+                "candidate_keys_count": 433,
+                "model_translation_keys_count": 17,
+                "translation_memory_reused_count": 416,
+                "source_identical_skipped_count": 360,
+            },
+        )
+
+        self.assertIn("20 changed values", summary["title"])
+        self.assertNotIn("433 new", summary["title"])
+        self.assertEqual(summary["changed_values_count"], 20)
+        self.assertEqual(summary["candidate_keys_count"], 433)
+        self.assertEqual(summary["model_translation_keys_count"], 17)
+        self.assertEqual(summary["translation_memory_reused_count"], 416)
+        self.assertEqual(summary["source_identical_skipped_count"], 360)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -329,3 +329,20 @@ def test_pr_body_includes_token_usage_cost_summary():
     cost_index = script.index("token_usage_summary.json")
     pr_create_index = script.index("gh pr create")
     assert cost_index < pr_create_index
+
+
+def test_pr_body_includes_translation_run_summary_metrics():
+    """The PR description explains candidate, model, memory, and skipped counts."""
+    script = (REPO_ROOT / "update-translations.sh").read_text()
+
+    assert "translation_summary.json" in script
+    assert "Translation run summary" in script
+    assert "changed_values_count" in script
+    assert "candidate_keys_count" in script
+    assert "model_translation_keys_count" in script
+    assert "translation_memory_reused_count" in script
+    assert "source_identical_skipped_count" in script
+
+    summary_index = script.index("Translation run summary")
+    pr_create_index = script.index("gh pr create")
+    assert summary_index < pr_create_index

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -873,6 +873,34 @@ stage_and_submit_batch() {
 
 This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT}\` fork and targets the \`$TARGET_BRANCH_FOR_PR\` branch on \`$UPSTREAM_REPO_NAME\`."
 
+    local TRANSLATION_SUMMARY_JSON="$report_dir/translation_summary.json"
+    if [ -s "$TRANSLATION_SUMMARY_JSON" ] && command_exists jq; then
+        local RUN_SUMMARY_MD
+        RUN_SUMMARY_MD=$(jq -r '
+            def n($key): (.[$key] // 0);
+            if (n("changed_values_count") > 0
+                or n("candidate_keys_count") > 0
+                or n("model_translation_keys_count") > 0
+                or n("translation_memory_reused_count") > 0
+                or n("source_identical_skipped_count") > 0) then
+              [
+                "### Translation run summary",
+                "- Output values changed: \(n("changed_values_count"))",
+                "- Candidate keys selected: \(n("candidate_keys_count"))",
+                "- Sent to model: \(n("model_translation_keys_count"))",
+                "- Reused from translation memory: \(n("translation_memory_reused_count"))",
+                "- Source-identical skipped (no ledger baseline): \(n("source_identical_skipped_count"))"
+              ] | join("\n")
+            else
+              empty
+            end
+        ' "$TRANSLATION_SUMMARY_JSON" 2>/dev/null || true)
+        if [ -n "$RUN_SUMMARY_MD" ]; then
+            log "Appending translation run summary to PR description."
+            PR_BODY=$(printf "%s\n\n%s" "$PR_BODY" "$RUN_SUMMARY_MD")
+        fi
+    fi
+
     local SKIPPED_FILES_REPORT="$report_dir/skipped_files_report.log"
     if [ -s "$QUALITY_REPORT_MD" ]; then
         log "Found quality gate report. Prepending to PR description."


### PR DESCRIPTION
## Summary
- Report actual output value changes separately from candidate keys.
- Surface model calls, translation-memory reuse, and ledgerless source-identical skips in generated PR bodies.
- Preserve the legacy queue-result unpacking contract while passing run metrics into summaries.

## Verification
- venv/bin/pytest
- venv/bin/ruff check .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Translation run summary” section to generated PR descriptions, showing run metrics such as changed values, candidate keys, model translations, translation-memory reuse, and source-identical skips.
  * PR titles can now highlight the number of changed values when available.

* **Bug Fixes**
  * Improved troubleshooting guidance for unexpected PR titles or counts by pointing to the translation run summary.
  * Clarified changelog notes so changed output values are reported separately from other translation activity counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->