### PR TITLE
[codex] Move Docker secrets to runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,9 +10,6 @@ FROM ubuntu:24.04
 # Set SHELL to fail on pipeline errors
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG SKIP_GPG_IMPORT=false
-ARG SKIP_DEPLOY_KEY=false
-
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -93,56 +90,11 @@ RUN TX_VERSION="v1.6.17" && \
     rm "tx-${TX_ARCH}.tar.gz" && \
     tx --version
 
-# Import the GPG key for the appuser using a BuildKit secret mount so the key is
-# never copied into an image layer. This step is skipped for CI builds.
-RUN --mount=type=secret,id=gpg_bot_key,target=/tmp/bot_secret_key.asc,uid=9999,gid=9999,mode=0400,required=false \
-    if [ "$SKIP_GPG_IMPORT" = "true" ]; then \
-      echo "Skipping GPG key import for CI build."; \
-    else \
-      echo "Importing GPG key for appuser..." && \
-      if [ ! -s /tmp/bot_secret_key.asc ]; then \
-        echo "Error: gpg_bot_key build secret is required when SKIP_GPG_IMPORT is false." >&2; \
-        exit 1; \
-      fi && \
-      # Switch to appuser to import the key into its own keyring
-      su - appuser -c "gpg --batch --import /tmp/bot_secret_key.asc" && \
-      \
-      echo "Determining key fingerprint and setting trust..." && \
-      # Programmatically get the fingerprint of the imported key
-      FINGERPRINT=$(su - appuser -c "gpg --list-keys --with-colons | grep '^fpr' | cut -d: -f10 | head -n1") && \
-      if [ -n "$FINGERPRINT" ]; then \
-        # Set ultimate trust on the key
-        su - appuser -c "echo \"$FINGERPRINT:6:\" | gpg --batch --import-ownertrust"; \
-        echo "GPG key import and trust set for fingerprint: $FINGERPRINT"; \
-      else \
-        echo "Error: Could not determine GPG key fingerprint after import." >&2; \
-        exit 1; \
-      fi; \
-    fi
-
-# Make the .ssh directory and set its permissions.
-RUN mkdir -p /home/appuser/.ssh && \
-    chmod 700 /home/appuser/.ssh
-
-# Mount the secret key file and copy it into the .ssh directory.
-# This method ensures the key is not stored in the image layers.
-# This step is skipped in CI builds by checking the SKIP_DEPLOY_KEY build argument.
-RUN --mount=type=secret,id=deploy_key,target=/tmp/deploy_key,required=false \
-    if [ "$SKIP_DEPLOY_KEY" = "true" ]; then \
-      echo "Skipping deploy key setup for CI build."; \
-    else \
-      echo "Setting up deploy key for production build..." && \
-      if [ -f /tmp/deploy_key ]; then \
-        cp /tmp/deploy_key /home/appuser/.ssh/deploy_key && \
-        chmod 600 /home/appuser/.ssh/deploy_key && \
-        chown -R appuser:appuser /home/appuser/.ssh && \
-        echo -e "Host github.com\n\tIdentityFile /home/appuser/.ssh/deploy_key\n\tIdentitiesOnly yes" > /home/appuser/.ssh/config && \
-        chown appuser:appuser /home/appuser/.ssh/config && \
-        chmod 600 /home/appuser/.ssh/config; \
-      else \
-        echo "Warning: Deploy key not found, skipping SSH setup."; \
-      fi; \
-    fi
+# Private deploy and GPG keys are mounted as runtime secrets and installed by
+# docker-entrypoint.sh so they never persist in image layers.
+RUN mkdir -p /home/appuser/.ssh /home/appuser/.gnupg && \
+    chmod 700 /home/appuser/.ssh /home/appuser/.gnupg && \
+    chown -R appuser:appuser /home/appuser/.ssh /home/appuser/.gnupg
 
 WORKDIR /app
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,15 +5,6 @@ services:
     build:
       context: .. # Build context is the project root
       dockerfile: docker/Dockerfile # Path to Dockerfile from project root
-      args:
-        # Pass the deploy key name as a build argument.
-        # This can be set in the .env file or the shell environment.
-        - DEPLOY_KEY_NAME=${DEPLOY_KEY_NAME:-id_ed25519}
-      # Requires DOCKER_BUILDKIT=1 and COMPOSE_DOCKER_CLI_BUILD=1
-      secrets:
-        # Make build-only secrets available without copying them into image layers
-        - gpg_bot_key
-        - deploy_key
     # The entrypoint is defined in the Dockerfile.
     # By default, run the main orchestration script. Can be overridden for debugging.
     command: ["/app/update-translations.sh"]
@@ -35,6 +26,15 @@ services:
       # Pass the absolute path of the config file inside the container to the application.
       # This makes the script's starting location irrelevant for finding its config.
       - TRANSLATOR_CONFIG_FILE=/app/config.yaml
+      - GPG_BOT_KEY_PATH=/run/secrets/gpg_bot_key
+      - DEPLOY_KEY_PATH=/run/secrets/deploy_key
+    secrets:
+      - source: gpg_bot_key
+        target: gpg_bot_key
+        mode: 0400
+      - source: deploy_key
+        target: deploy_key
+        mode: 0400
     # Note: Place the .env file alongside this compose file (docker/.env)
     # with API keys and HOST_UID/GID.
     # An example is provided in docker/.env.example
@@ -47,10 +47,10 @@ volumes:
     # Uncomment if volume is managed outside this compose project
     # external: true
 
-# Define build-time secrets.
-# The deploy key filename can be controlled via the DEPLOY_KEY_NAME environment variable.
+# Define runtime secrets. The files are mounted read-only at /run/secrets/*
+# and copied/imported by docker-entrypoint.sh during container startup.
 secrets:
   gpg_bot_key:
-    file: ../secrets/gpg_bot_key/bot_secret_key.asc
+    file: ${GPG_BOT_KEY_FILE:-../secrets/gpg_bot_key/bot_secret_key.asc}
   deploy_key:
-    file: ../secrets/deploy_key/${DEPLOY_KEY_NAME:-id_ed25519}
+    file: ${DEPLOY_KEY_FILE:-../secrets/deploy_key/id_ed25519}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -43,6 +43,133 @@ fi
 
 # --- Unified Helper Functions ---
 
+run_as_appuser() {
+    local user_home="$1"
+    shift
+
+    if [ "$(id -u)" -eq 0 ] && id -u appuser >/dev/null 2>&1; then
+        HOME="$user_home" gosu appuser "$@"
+    else
+        HOME="$user_home" "$@"
+    fi
+}
+
+ensure_github_identity_config() {
+    local user_home="$1"
+    local config_file="${user_home}/.ssh/config"
+    local marker="# localize-pipeline runtime deploy key"
+
+    touch "$config_file"
+    if grep -Fq "$marker" "$config_file"; then
+        return 0
+    fi
+
+    {
+        if [ -s "$config_file" ]; then
+            printf '\n'
+        fi
+        printf '%s\n' "$marker"
+        printf 'Host github.com\n'
+        printf '\tIdentityFile %s/.ssh/deploy_key\n' "$user_home"
+        printf '\tIdentitiesOnly yes\n'
+        printf '\tBatchMode yes\n'
+    } >> "$config_file"
+}
+
+ensure_insecure_ssh_config() {
+    local user_home="$1"
+    local config_file="${user_home}/.ssh/config"
+    local marker="# localize-pipeline insecure ssh override"
+
+    touch "$config_file"
+    if grep -Fq "$marker" "$config_file"; then
+        return 0
+    fi
+
+    {
+        if [ -s "$config_file" ]; then
+            printf '\n'
+        fi
+        printf '%s\n' "$marker"
+        printf 'Host github.com\n'
+        printf '\tStrictHostKeyChecking no\n'
+        printf '\tUserKnownHostsFile=/dev/null\n'
+    } >> "$config_file"
+}
+
+install_runtime_deploy_key() {
+    local user_home="${APPUSER_HOME:-/home/appuser}"
+    local runtime_deploy_key_path="${DEPLOY_KEY_PATH:-/run/secrets/deploy_key}"
+
+    if [ "${SKIP_DEPLOY_KEY:-false}" = "true" ]; then
+        log "Skipping runtime deploy key setup because SKIP_DEPLOY_KEY=true."
+        return 0
+    fi
+
+    mkdir -p "$user_home/.ssh"
+    if [ ! -s "$runtime_deploy_key_path" ]; then
+        log "Runtime deploy key not found at $runtime_deploy_key_path; SSH clone/push may fail." "WARNING"
+        return 0
+    fi
+
+    cp "$runtime_deploy_key_path" "$user_home/.ssh/deploy_key"
+    chmod 600 "$user_home/.ssh/deploy_key"
+    ensure_github_identity_config "$user_home"
+
+    if [ "$(id -u)" -eq 0 ]; then
+        chown -R "${APPUSER_UID}:${APPUSER_GID}" "$user_home/.ssh" \
+          || log "Warning: unable to chown ${user_home}/.ssh" "WARNING"
+    fi
+    log "Runtime deploy key installed for appuser."
+}
+
+import_runtime_gpg_key() {
+    local user_home="${APPUSER_HOME:-/home/appuser}"
+    local runtime_gpg_key_path="${GPG_BOT_KEY_PATH:-/run/secrets/gpg_bot_key}"
+    local gpg_import_file="$runtime_gpg_key_path"
+    local cleanup_gpg_import_file=""
+    local fingerprint
+
+    if [ "${SKIP_GPG_IMPORT:-false}" = "true" ]; then
+        log "Skipping runtime GPG import because SKIP_GPG_IMPORT=true."
+        return 0
+    fi
+
+    if [ ! -s "$runtime_gpg_key_path" ]; then
+        log "Runtime GPG key not found at $runtime_gpg_key_path; commit signing will be disabled." "WARNING"
+        return 0
+    fi
+
+    mkdir -p "$user_home/.gnupg"
+    chmod 700 "$user_home/.gnupg"
+
+    if [ "$(id -u)" -eq 0 ] && id -u appuser >/dev/null 2>&1; then
+        gpg_import_file="$user_home/.gnupg/runtime_gpg_import.asc"
+        cp "$runtime_gpg_key_path" "$gpg_import_file"
+        chown "${APPUSER_UID}:${APPUSER_GID}" "$gpg_import_file" "$user_home/.gnupg"
+        chmod 600 "$gpg_import_file"
+        cleanup_gpg_import_file="$gpg_import_file"
+    fi
+
+    if ! run_as_appuser "$user_home" gpg --batch --import "$gpg_import_file"; then
+        rm -f "$cleanup_gpg_import_file"
+        log "Failed to import runtime GPG key from $runtime_gpg_key_path." "ERROR"
+        return 1
+    fi
+
+    rm -f "$cleanup_gpg_import_file"
+    fingerprint="$(run_as_appuser "$user_home" gpg --list-secret-keys --with-colons \
+        | awk -F: '/^fpr/ {print $10; exit}')"
+    if [ -z "$fingerprint" ]; then
+        log "Runtime GPG key import completed, but no secret-key fingerprint was found." "ERROR"
+        return 1
+    fi
+
+    printf '%s:6:\n' "$fingerprint" \
+        | run_as_appuser "$user_home" gpg --batch --import-ownertrust
+    log "Runtime GPG key imported and trusted for fingerprint: $fingerprint"
+}
+
 # Set up SSH host keys for secure git operations.
 setup_ssh() {
     local user_home="${APPUSER_HOME:-/home/appuser}"
@@ -51,7 +178,7 @@ setup_ssh() {
 
     if [ "${ALLOW_INSECURE_SSH:-false}" = "true" ]; then
         log "WARNING: ALLOW_INSECURE_SSH is true. Host key verification is disabled." "WARNING"
-        echo -e "Host github.com\n\tBatchMode yes\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile=/dev/null" > "${user_home}/.ssh/config"
+        ensure_insecure_ssh_config "$user_home"
     else
         KNOWN_HOSTS_PATH="${PINNED_KNOWN_HOSTS_PATH:-/etc/ssh/ssh_known_hosts}"
         if [ ! -r "$KNOWN_HOSTS_PATH" ] || ! grep -q "github.com" "$KNOWN_HOSTS_PATH"; then
@@ -149,6 +276,8 @@ if [ "$(id -u)" -ne 0 ]; then
 
     # Ensure logs and SSH are configured correctly before proceeding.
     ensure_logs_dir
+    install_runtime_deploy_key
+    import_runtime_gpg_key
     setup_ssh
     export GIT_TERMINAL_PROMPT=0
 
@@ -431,6 +560,8 @@ else
     fi
 
     # Set up SSH. This is done as root to ensure correct ownership of created files.
+    install_runtime_deploy_key
+    import_runtime_gpg_key
     setup_ssh
 
     # Attempt to switch to the appuser.

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -151,6 +151,14 @@ import_runtime_gpg_key() {
         cleanup_gpg_import_file="$gpg_import_file"
     fi
 
+    fingerprint="$(run_as_appuser "$user_home" gpg --import-options show-only --with-colons "$gpg_import_file" \
+        | awk -F: '/^fpr/ {print $10; exit}')"
+    if [ -z "$fingerprint" ]; then
+        rm -f "$cleanup_gpg_import_file"
+        log "Runtime GPG key source did not expose a secret-key fingerprint." "ERROR"
+        return 1
+    fi
+
     if ! run_as_appuser "$user_home" gpg --batch --import "$gpg_import_file"; then
         rm -f "$cleanup_gpg_import_file"
         log "Failed to import runtime GPG key from $runtime_gpg_key_path." "ERROR"
@@ -158,12 +166,6 @@ import_runtime_gpg_key() {
     fi
 
     rm -f "$cleanup_gpg_import_file"
-    fingerprint="$(run_as_appuser "$user_home" gpg --list-secret-keys --with-colons \
-        | awk -F: '/^fpr/ {print $10; exit}')"
-    if [ -z "$fingerprint" ]; then
-        log "Runtime GPG key import completed, but no secret-key fingerprint was found." "ERROR"
-        return 1
-    fi
 
     printf '%s:6:\n' "$fingerprint" \
         | run_as_appuser "$user_home" gpg --batch --import-ownertrust

--- a/tests/unit/test_docker_runtime_secrets.py
+++ b/tests/unit/test_docker_runtime_secrets.py
@@ -42,13 +42,33 @@ def test_compose_mounts_private_keys_only_as_runtime_secrets():
     build = translator.get("build", {})
 
     assert "secrets" not in build
-    assert "DEPLOY_KEY_NAME" not in "\n".join(build.get("args", []))
+    build_args = build.get("args", [])
+    if isinstance(build_args, dict):
+        build_args_text = "\n".join(f"{key}={value}" for key, value in build_args.items())
+    else:
+        build_args_text = "\n".join(build_args)
+    assert "DEPLOY_KEY_NAME" not in build_args_text
 
-    service_secrets = {
-        secret["source"] if isinstance(secret, dict) else secret
-        for secret in translator["secrets"]
-    }
-    assert {"gpg_bot_key", "deploy_key"} <= service_secrets
+    assert translator["secrets"] == [
+        {
+            "source": "gpg_bot_key",
+            "target": "gpg_bot_key",
+            "mode": 0o400,
+        },
+        {
+            "source": "deploy_key",
+            "target": "deploy_key",
+            "mode": 0o400,
+        },
+    ]
+    assert (
+        compose["secrets"]["gpg_bot_key"]["file"]
+        == "${GPG_BOT_KEY_FILE:-../secrets/gpg_bot_key/bot_secret_key.asc}"
+    )
+    assert (
+        compose["secrets"]["deploy_key"]["file"]
+        == "${DEPLOY_KEY_FILE:-../secrets/deploy_key/id_ed25519}"
+    )
 
 
 def test_entrypoint_installs_runtime_ssh_and_gpg_secrets():
@@ -58,5 +78,14 @@ def test_entrypoint_installs_runtime_ssh_and_gpg_secrets():
     assert 'GPG_BOT_KEY_PATH:-/run/secrets/gpg_bot_key' in entrypoint
     assert 'SKIP_GPG_IMPORT:-false' in entrypoint
     assert 'gpg --batch --import "$gpg_import_file"' in entrypoint
+    assert 'gpg --import-options show-only --with-colons "$gpg_import_file"' in entrypoint
     assert '"$runtime_deploy_key_path" "$user_home/.ssh/deploy_key"' in entrypoint
     assert 'chmod 600 "$user_home/.ssh/deploy_key"' in entrypoint
+
+    appuser_block = entrypoint.split('if [ "$(id -u)" -ne 0 ]; then', 1)[1].split("else", 1)[0]
+    assert appuser_block.index("install_runtime_deploy_key") < appuser_block.index("setup_ssh")
+    assert appuser_block.index("import_runtime_gpg_key") < appuser_block.index("setup_ssh")
+
+    root_block = entrypoint.split("# --- Root Execution Block ---", 1)[1]
+    assert root_block.index("install_runtime_deploy_key") < root_block.index("setup_ssh")
+    assert root_block.index("import_runtime_gpg_key") < root_block.index("setup_ssh")

--- a/tests/unit/test_docker_runtime_secrets.py
+++ b/tests/unit/test_docker_runtime_secrets.py
@@ -1,0 +1,62 @@
+"""Static checks for Docker runtime secret handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = PROJECT_ROOT / "docker" / "Dockerfile"
+COMPOSE_FILE = PROJECT_ROOT / "docker" / "docker-compose.yml"
+ENTRYPOINT = PROJECT_ROOT / "docker" / "docker-entrypoint.sh"
+
+
+def _dockerfile() -> str:
+    return DOCKERFILE.read_text(encoding="utf-8")
+
+
+def _compose() -> dict:
+    return yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+
+
+def _entrypoint() -> str:
+    return ENTRYPOINT.read_text(encoding="utf-8")
+
+
+def test_dockerfile_does_not_handle_private_keys_at_build_time():
+    dockerfile = _dockerfile()
+
+    assert "id=gpg_bot_key" not in dockerfile
+    assert "id=deploy_key" not in dockerfile
+    assert "/tmp/bot_secret_key.asc" not in dockerfile
+    assert "/tmp/deploy_key" not in dockerfile
+    assert "gpg --batch --import" not in dockerfile
+    assert "cp /tmp/deploy_key" not in dockerfile
+
+
+def test_compose_mounts_private_keys_only_as_runtime_secrets():
+    compose = _compose()
+    translator = compose["services"]["translator"]
+    build = translator.get("build", {})
+
+    assert "secrets" not in build
+    assert "DEPLOY_KEY_NAME" not in "\n".join(build.get("args", []))
+
+    service_secrets = {
+        secret["source"] if isinstance(secret, dict) else secret
+        for secret in translator["secrets"]
+    }
+    assert {"gpg_bot_key", "deploy_key"} <= service_secrets
+
+
+def test_entrypoint_installs_runtime_ssh_and_gpg_secrets():
+    entrypoint = _entrypoint()
+
+    assert 'DEPLOY_KEY_PATH:-/run/secrets/deploy_key' in entrypoint
+    assert 'GPG_BOT_KEY_PATH:-/run/secrets/gpg_bot_key' in entrypoint
+    assert 'SKIP_GPG_IMPORT:-false' in entrypoint
+    assert 'gpg --batch --import "$gpg_import_file"' in entrypoint
+    assert '"$runtime_deploy_key_path" "$user_home/.ssh/deploy_key"' in entrypoint
+    assert 'chmod 600 "$user_home/.ssh/deploy_key"' in entrypoint


### PR DESCRIPTION
## Summary
- Remove build-time GPG import and SSH deploy-key copy layers from `docker/Dockerfile`.
- Mount the deploy and GPG keys as Compose runtime secrets and install/import them from `docker/docker-entrypoint.sh`.
- Add regression tests that prevent private key handling from moving back into Docker build layers.

## Action Required
**After this PR merges, rotate the SSH deploy key and GPG bot key.** They were present in previously built image layers and must be treated as exposed.

## Verification
- `venv/bin/pytest tests/unit/test_docker_runtime_secrets.py` failed before the implementation and passes after it.
- `venv/bin/pytest` -> 550 passed.
- `bash -n docker/docker-entrypoint.sh`.
- YAML parse of `docker/docker-compose.yml`.
- `DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker compose -f docker/docker-compose.yml build`.
- Local `docker run` of the built `docker-translator` image verified runtime deploy-key installation, repo reset, and command handoff (`runtime-ok`).
- `docker history --no-trunc docker-translator` shows no build layer importing `/tmp/bot_secret_key.asc` or copying `/tmp/deploy_key`.

## Notes
- No findings were skipped as already fixed in this phase.
- `shellcheck` is not installed locally, so shell validation used `bash -n` plus the container run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker-based runs now install sensitive SSH deploy keys and GPG keys at runtime rather than during image build.
  * Compose now provides these credentials as runtime secrets with explicit target paths and restrictive permissions.

* **Bug Fixes**
  * Improved startup ordering so SSH and GPG setup completes before Git operations begin.
  * Added clearer support for an optional insecure SSH override behavior.

* **Tests**
  * Added automated checks ensuring private keys aren’t referenced in build-time configuration and are handled securely at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->