### PR TITLE
[codex] Fix core translation failure paths

### DIFF
--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -1125,7 +1125,7 @@ async def translate_text_async(
         rate_limiter: AsyncLimiter,
         index: int,
         localization_format: Optional[LocalizationFormat] = None,
-) -> Tuple[int, str]:
+) -> Tuple[int, str, bool]:
     """
     Asynchronously translate a single text with context.
 
@@ -1141,15 +1141,15 @@ async def translate_text_async(
         index (int): The index of the text in the original list.
 
     Returns:
-        Tuple[int, str]: The index and the translated text.
+        Tuple[int, str, bool]: The index, translated text, and whether model translation succeeded.
     """
     if DRY_RUN:
         logger.info(f"[Dry Run] Skipping actual translation for key '{key}'. Returning original text.")
-        return index, text
+        return index, text, True
 
     if MODEL_PROVIDER is None:
         logger.error("Model provider is not configured. Cannot proceed with translation.")
-        return index, text
+        return index, text, False
 
     async with semaphore, rate_limiter:
         # 3) Use language_name_to_code instead of an Enum
@@ -1158,7 +1158,7 @@ async def translate_text_async(
         # If the language isn't recognized, just return original text
         if not language_code:
             logger.warning(f"Unsupported or unrecognized language: {target_language}")
-            return index, text
+            return index, text, False
 
         # Get the glossary for the current language
         language_glossary = glossary.get(language_code, {})
@@ -1228,7 +1228,7 @@ Provide the translation **of the Value only**, following the instructions above.
                 msg_content = response.choices[0].message.content
                 if not msg_content:
                     logger.warning("Empty assistant content for key '%s'; keeping original text.", key)
-                    return index, text
+                    return index, text, False
                 translated_text = msg_content.strip()
 
                 # Restore placeholders in the translated text
@@ -1238,7 +1238,7 @@ Provide the translation **of the Value only**, following the instructions above.
                 translated_text = clean_translated_text(translated_text, text)
 
                 logger.debug(f"Translated key '{key}' successfully.")
-                return index, translated_text
+                return index, translated_text, True
 
             except Exception as general_exc:
                 if MODEL_PROVIDER.is_retryable_error(general_exc):
@@ -1246,16 +1246,16 @@ Provide the translation **of the Value only**, following the instructions above.
                     should_retry = await _handle_retry(attempt, max_retries, base_delay, key, general_exc)
                     if should_retry:
                         continue
-                    return index, text
+                    return index, text, False
                 logger.error(f"An unexpected error occurred: {general_exc}", exc_info=True)
-                return index, text
+                return index, text, False
 
         # Fallback return statement to satisfy linters and ensure explicit return
         logger.warning(
             f"Translation loop for key '{key}' completed without an explicit return within the loop. "
             f"This shouldn't happen with current logic. Returning original text."
         )
-        return index, text
+        return index, text, False
 
 def _build_holistic_review_system_prompt(
         target_language: str,
@@ -1363,6 +1363,7 @@ async def holistic_review_async(
         )
         max_retries = 3
         base_delay = 5  # Longer delay for a potentially larger task
+        response_text = ""
         for attempt in range(1, max_retries + 1):
             try:
                 response = await MODEL_PROVIDER.create_chat_completion(
@@ -1378,6 +1379,7 @@ async def holistic_review_async(
                 msg_content = response.choices[0].message.content
                 if not msg_content or not msg_content.strip():
                     logger.error("Holistic review returned empty content.")
+                    response_text = ""
                     raise json.JSONDecodeError("empty response", "", 0)
                 response_text = msg_content.strip()
 
@@ -2146,6 +2148,19 @@ async def process_translation_queue(
                 )
                 translated_file_path = os.path.join(translated_queue_folder, translation_file)
                 new_file_content = adapter.reassemble_file(parsed_lines)
+                if not run_post_translation_validation(
+                        new_file_content,
+                        source_translations,
+                        translation_file,
+                        localization_format,
+                        ignore_key_patterns=IGNORE_KEY_PATTERNS,
+                ):
+                    logger.error(
+                        "Skipping write for '%s' because post-translation validation failed.",
+                        translation_file,
+                    )
+                    skipped_files[translation_file] = ["Post-translation validation failed."]
+                    continue
                 if DRY_RUN:
                     logger.info(f"[Dry Run] Would write ignored-key passthrough content to '{translated_file_path}'.")
                 else:
@@ -2210,7 +2225,10 @@ async def process_translation_queue(
         ]
 
         # Run tasks concurrently with progress indication
-        results = list(memory_plan.cached_results)
+        results: List[Tuple[int, str, bool]] = [
+            (position, value, True)
+            for position, value in memory_plan.cached_results
+        ]
         # The tqdm output is directed to stderr by default, which is ideal.
         # It prevents progress bars from being broken by stdout prints.
         if tasks:
@@ -2220,12 +2238,23 @@ async def process_translation_queue(
                     unit="translation",
                     total=len(tasks)  # Provide the total number of tasks
             ):
-                index, result = await coro
-                results.append((index, result))
+                index, result, succeeded = await coro
+                results.append((index, result, succeeded))
 
         # Sort results by index to ensure correct order
         results.sort(key=lambda x: x[0])
-        translations = [result for _, result in results]
+        translations = [result for _, result, _ in results]
+        model_failed_keys = {
+            keys_to_translate[position]
+            for position, _result, succeeded in results
+            if not succeeded and position < len(keys_to_translate)
+        }
+        if model_failed_keys:
+            logger.warning(
+                "Model translation failed for %d key(s) in '%s'; keeping source fallback and marking failed.",
+                len(model_failed_keys),
+                translation_file,
+            )
 
         # Integrate initial translations to create a draft file for review
         draft_lines = integrate_translations(
@@ -2290,7 +2319,19 @@ async def process_translation_queue(
                 for i, (corrected_chunk, key_chunk) in enumerate(zip(review_results, key_chunks)):
                     if corrected_chunk is not None:
                         if corrected_chunk:
-                            final_corrected_translations.update(corrected_chunk)
+                            key_chunk_set = set(key_chunk)
+                            scoped = {
+                                key: value
+                                for key, value in corrected_chunk.items()
+                                if key in key_chunk_set
+                            }
+                            dropped = set(corrected_chunk) - key_chunk_set
+                            if dropped:
+                                logger.warning(
+                                    "Holistic review returned %d out-of-scope key(s); ignored.",
+                                    len(dropped),
+                                )
+                            final_corrected_translations.update(scoped)
                         else:
                             logger.info("Holistic review returned no corrections for this chunk; keeping draft values.")
                             for key in key_chunk:
@@ -2370,7 +2411,7 @@ async def process_translation_queue(
             translation_file,
             ignore_key_patterns=IGNORE_KEY_PATTERNS,
         )
-        failed_keys = list(per_key_summary["failed_keys"])
+        failed_keys = set(per_key_summary["failed_keys"]).union(model_failed_keys)
         if validation_summary is not None:
             validation_summary[translation_file] = per_key_summary
 
@@ -2398,6 +2439,17 @@ async def process_translation_queue(
 
         translated_file_path = os.path.join(translated_queue_folder, translation_file)
 
+        if not run_post_translation_validation(
+                new_file_content,
+                source_translations,
+                translation_file,
+                localization_format,
+                ignore_key_patterns=IGNORE_KEY_PATTERNS,
+        ):
+            logger.error("Skipping write for '%s' because post-translation validation failed.", translation_file)
+            skipped_files[translation_file] = ["Post-translation validation failed."]
+            continue
+
         if DRY_RUN:
             logger.info(f"[Dry Run] Would write translated content to '{translated_file_path}'.")
         else:
@@ -2410,8 +2462,8 @@ async def process_translation_queue(
         # Update and persist per-file key ledger after successful file processing.
         key_ledger[translation_file] = build_file_key_ledger(
             source_translations,
-            valid_translations,
-            failed_keys=set(failed_keys)
+            final_output_translations,
+            failed_keys=failed_keys
         )
         save_translation_key_ledger(TRANSLATION_KEY_LEDGER_FILE_PATH, key_ledger)
         if translation_memory is not None and not DRY_RUN:
@@ -2422,7 +2474,7 @@ async def process_translation_queue(
                 keys_to_translate,
                 locale=language_code,
                 format_id=localization_format.id,
-                failed_keys=set(failed_keys),
+                failed_keys=failed_keys,
             )
             save_translation_memory(TRANSLATION_MEMORY_FILE_PATH, translation_memory)
 

--- a/tests/integration/test_quote_escaping.py
+++ b/tests/integration/test_quote_escaping.py
@@ -74,6 +74,7 @@ class TestQuoteEscaping(unittest.IsolatedAsyncioTestCase):
 
         # 4. Assertions
         mock_pre_validator.assert_called()
+        mock_post_validator.assert_called_once()
         mock_holistic_review.assert_awaited()
         # The AI should be called for the initial translation
         provider.create_chat_completion.assert_awaited()
@@ -143,6 +144,7 @@ class TestQuoteEscaping(unittest.IsolatedAsyncioTestCase):
         with open(output_file_path, 'r', encoding='utf-8') as f:
             output_content = f.read().strip()
 
+        mock_post_validator.assert_called_once()
         self.assertEqual(output_content, "test.key=C''est le choix {0}.")
 
     def test_reassemble_with_single_quotes(self):

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -15,7 +15,12 @@ from localize.ignore_keys import compile_ignore_key_patterns
 from localize.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
 from localize.localization_layouts import LocalizationLayout
 from localize.localization_profiles import LocalizationProfile
-from localize.translation_memory import TranslationMemory, save_translation_memory
+from localize.properties_parser import parse_properties_file
+from localize.translation_memory import (
+    TranslationMemory,
+    load_translation_memory,
+    save_translation_memory,
+)
 
 # All fixtures are now defined in conftest.py and are auto-discovered by pytest.
 
@@ -202,6 +207,185 @@ async def test_process_translation_queue_does_not_seed_memory_for_noop_file(inte
 
     assert not os.path.exists(memory_path)
     provider.create_chat_completion.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_translation_queue_ignores_out_of_scope_review_keys(integration_test_environment):
+    env = integration_test_environment
+    source_file_path = os.path.join(env['input_folder'], 'app.properties')
+    target_file_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.keep=Keep\nkey.new=New\n")
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.keep=Alt\n")
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Neu draft"))]
+    ))
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
+
+    with patch('localize.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('localize.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH',
+               os.path.join(env['input_folder'], 'ledger.json')), \
+         patch('localize.translate_localization_files.get_working_tree_changed_keys', return_value=set()), \
+         patch('localize.translate_localization_files.holistic_review_async', new_callable=AsyncMock) as review:
+        review.return_value = {"key.new": "Neu", "key.keep": "Nicht anwenden"}
+        await localize.translate_localization_files.process_translation_queue(
+            translation_queue_folder=env['translation_queue_folder'],
+            translated_queue_folder=env['translated_queue_folder'],
+            glossary_file_path=env['mock_glossary_path_resolved']
+        )
+
+    output_file_path = os.path.join(env['translated_queue_folder'], 'app_de.properties')
+    with open(output_file_path, 'r', encoding='utf-8') as f:
+        final_content = f.read()
+
+    assert "key.keep=Alt" in final_content
+    assert "key.keep=Nicht anwenden" not in final_content
+    assert "key.new=Neu" in final_content
+
+
+@pytest.mark.asyncio
+async def test_failed_model_translation_marks_ledger_and_skips_memory(integration_test_environment):
+    env = integration_test_environment
+    source_file_path = os.path.join(env['input_folder'], 'app.properties')
+    target_file_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
+    ledger_path = os.path.join(env['input_folder'], 'ledger.json')
+    memory_path = os.path.join(env['input_folder'], 'translation_memory.json')
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.fail=Needs translation\n")
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        f.write("")
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(side_effect=RuntimeError("rate limited"))
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = True
+
+    with patch('localize.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('localize.translate_localization_files.TRANSLATION_MEMORY_ENABLED', True), \
+         patch('localize.translate_localization_files.TRANSLATION_MEMORY_FILE_PATH', memory_path), \
+         patch('localize.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH', ledger_path), \
+         patch('localize.translate_localization_files.get_working_tree_changed_keys', return_value=set()), \
+         patch('localize.translate_localization_files._handle_retry', new_callable=AsyncMock) as retry, \
+         patch('localize.translate_localization_files.holistic_review_async', new_callable=AsyncMock) as review:
+        retry.return_value = False
+        review.return_value = None
+        await localize.translate_localization_files.process_translation_queue(
+            translation_queue_folder=env['translation_queue_folder'],
+            translated_queue_folder=env['translated_queue_folder'],
+            glossary_file_path=env['mock_glossary_path_resolved']
+        )
+
+    ledger = localize.translate_localization_files.load_translation_key_ledger(ledger_path)
+    assert ledger["app_de.properties"]["key.fail"]["status"] == "failed"
+
+    memory = load_translation_memory(memory_path)
+    assert memory.lookup(
+        "Needs translation",
+        locale="de",
+        format_id=JAVA_PROPERTIES_FORMAT.id,
+    ) is None
+
+    output_file_path = os.path.join(env['translated_queue_folder'], 'app_de.properties')
+    parsed_lines, target_translations = parse_properties_file(output_file_path)
+    texts, _indices, keys = localize.translate_localization_files.extract_texts_to_translate(
+        parsed_lines,
+        {"key.fail": "Needs translation"},
+        target_translations,
+        file_ledger_entries=ledger["app_de.properties"],
+    )
+    assert keys == ["key.fail"]
+    assert texts == ["Needs translation"]
+
+
+@pytest.mark.asyncio
+async def test_key_ledger_preserves_full_file_baseline_after_partial_translation(integration_test_environment):
+    env = integration_test_environment
+    source_file_path = os.path.join(env['input_folder'], 'app.properties')
+    target_file_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
+    ledger_path = os.path.join(env['input_folder'], 'ledger.json')
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.one=One\nkey.two=Two\nkey.three=Three\n")
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.one=Eins\nkey.three=Drei\n")
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Zwei"))]
+    ))
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
+
+    with patch('localize.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('localize.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH', ledger_path), \
+         patch('localize.translate_localization_files.get_working_tree_changed_keys', return_value=set()), \
+         patch('localize.translate_localization_files.holistic_review_async', new_callable=AsyncMock) as review:
+        review.return_value = None
+        await localize.translate_localization_files.process_translation_queue(
+            translation_queue_folder=env['translation_queue_folder'],
+            translated_queue_folder=env['translated_queue_folder'],
+            glossary_file_path=env['mock_glossary_path_resolved']
+        )
+
+    ledger = localize.translate_localization_files.load_translation_key_ledger(ledger_path)
+    assert set(ledger["app_de.properties"]) == {"key.one", "key.two", "key.three"}
+
+
+@pytest.mark.asyncio
+async def test_process_translation_queue_skips_file_when_post_validation_fails(integration_test_environment):
+    env = integration_test_environment
+    source_file_path = os.path.join(env['input_folder'], 'app.properties')
+    target_file_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.one=One\n")
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        f.write("")
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Eins"))]
+    ))
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
+
+    with patch('localize.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('localize.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH',
+               os.path.join(env['input_folder'], 'ledger.json')), \
+         patch('localize.translate_localization_files.get_working_tree_changed_keys', return_value=set()), \
+         patch('localize.translate_localization_files.holistic_review_async', new_callable=AsyncMock) as review, \
+         patch('localize.translate_localization_files.run_post_translation_validation') as post_validation:
+        review.return_value = None
+        post_validation.return_value = False
+        processed_count, processed_files, skipped_files, total_keys = (
+            await localize.translate_localization_files.process_translation_queue(
+                translation_queue_folder=env['translation_queue_folder'],
+                translated_queue_folder=env['translated_queue_folder'],
+                glossary_file_path=env['mock_glossary_path_resolved']
+            )
+        )
+
+    output_file_path = os.path.join(env['translated_queue_folder'], 'app_de.properties')
+    assert processed_count == 0
+    assert processed_files == []
+    assert total_keys == 0
+    assert "app_de.properties" in skipped_files
+    assert not os.path.exists(output_file_path)
+    post_validation.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_holistic_review_protection.py
+++ b/tests/unit/test_holistic_review_protection.py
@@ -7,10 +7,13 @@ to prevent the AI from modifying, removing, or adding placeholders.
 
 import asyncio
 import json
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "DUMMY_KEY_FOR_TESTING")
 
 from localize.translate_localization_files import (
     holistic_review_async,
@@ -224,3 +227,42 @@ async def test_holistic_review_uses_compatible_completion_token_limit():
     assert kwargs["response_format"] == {"type": "json_object"}
     assert "max_tokens" not in kwargs
     assert "max_completion_tokens" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_holistic_review_retries_empty_content_without_name_error():
+    empty_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=""))]
+    )
+    valid_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=json.dumps({"key1": "Hallo"})
+                )
+            )
+        ]
+    )
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(side_effect=[empty_response, valid_response])
+    provider.is_retryable_error.return_value = False
+
+    with (
+        patch("localize.translate_localization_files.DRY_RUN", False),
+        patch("localize.translate_localization_files.MODEL_PROVIDER", provider),
+        patch("localize.translate_localization_files._handle_retry", new_callable=AsyncMock) as retry,
+    ):
+        retry.return_value = True
+        result = await holistic_review_async(
+            source_content="key1=Hello",
+            translated_content="key1=Hallo draft",
+            target_language="German",
+            keys_to_review=["key1"],
+            semaphore=asyncio.Semaphore(1),
+            rate_limiter=_NullAsyncContext(),
+            style_rules_text="",
+        )
+
+    assert result == {"key1": "Hallo"}
+    assert provider.create_chat_completion.await_count == 2
+    retry.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Add success/failure state to model translation results so exhausted API retries do not become approved source-text translations.
- Mark failed model keys in the translation key ledger and skip them when updating translation memory, keeping next-run retry selection intact.
- Filter holistic-review JSON to the requested key chunk before applying corrections.
- Write full-file ledger baselines from final output translations after partial runs.
- Run post-translation validation before writing translated output and skip invalid files.

## Regression Coverage
- Empty holistic-review content retries without `response_text`/`NameError` fallout.
- Out-of-scope holistic-review keys do not modify untouched target keys.
- Retry-exhausted model failures are marked `status: failed`, do not seed translation memory, and are selected again on the next run.
- Partial file translations preserve ledger entries for unchanged keys.
- Failed post-validation skips output writes.
- Existing quote-escaping integration tests now assert post-validation is called.

## Verification
- Targeted Phase 2 regression subset failed before implementation and passes after it.
- `venv/bin/pytest tests/integration/` -> 18 passed.
- `venv/bin/pytest` -> 552 passed.

## Notes
- No findings were skipped as already fixed in this phase.
- This PR intentionally covers only Phase 2 major findings M1-M5; Phase 2 minors remain for the next branch.