### PR TITLE
Phase 4: harden config CLI provider

### DIFF
--- a/examples/generic-java-properties/config.yaml
+++ b/examples/generic-java-properties/config.yaml
@@ -1,5 +1,5 @@
 # Generic Java .properties example profile.
-target_project_root: "examples/generic-java-properties"
+target_project_root: "."
 input_folder: "resources"
 localization_format: "java_properties"
 localization_layout:

--- a/examples/generic-json/config.yaml
+++ b/examples/generic-json/config.yaml
@@ -1,6 +1,6 @@
 # Generic JSON example profile.
 
-target_project_root: "examples/generic-json"
+target_project_root: "."
 input_folder: "resources"
 localization_format: "json"
 localization_layout:

--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -1,4 +1,5 @@
 """Application configuration module for the translation service."""
+import hashlib
 import logging
 import os
 import sys
@@ -14,7 +15,6 @@ from localize.logging_config import setup_logger
 from localize.localization_formats import (
     JAVA_PROPERTIES_FORMAT,
     LocalizationFormat,
-    load_localization_format,
 )
 from localize.localization_layouts import (
     SUFFIX_LAYOUT,
@@ -129,6 +129,7 @@ def validate_config(
     effective_api_base_url: Optional[str] = None,
     api_key_available: Optional[bool] = None,
     dry_run_override: Optional[bool] = None,
+    config_base_dir: Optional[str] = None,
 ) -> List[ConfigIssue]:
     """Validate a raw config dict and return actionable issues.
 
@@ -143,6 +144,8 @@ def validate_config(
 
     # Required paths must be set, not a left-over placeholder, and must exist.
     target_root = config.get("target_project_root")
+    if target_root and config_base_dir and not os.path.isabs(str(target_root)):
+        target_root = os.path.join(config_base_dir, str(target_root))
     for key in ("target_project_root", "input_folder"):
         value = config.get(key)
         if not value:
@@ -159,9 +162,11 @@ def validate_config(
             continue
         # A relative input_folder is resolved against target_project_root, matching
         # how update-translations.sh builds ABSOLUTE_INPUT_FOLDER.
-        resolved = value
-        if key == "input_folder" and target_root and not os.path.isabs(value):
-            resolved = os.path.join(target_root, value)
+        resolved = str(value)
+        if not os.path.isabs(resolved) and key == "target_project_root" and config_base_dir:
+            resolved = os.path.join(config_base_dir, resolved)
+        if key == "input_folder" and target_root and not os.path.isabs(str(value)):
+            resolved = os.path.join(str(target_root), str(value))
         if not path_exists(resolved):
             issues.append(ConfigIssue(
                 "error",
@@ -173,8 +178,9 @@ def validate_config(
     locale_codes = set()
     if isinstance(locales, list):
         locale_codes = {
-            loc.get("code") for loc in locales
-            if isinstance(loc, dict) and loc.get("code")
+            loc if isinstance(loc, str) else loc.get("code")
+            for loc in locales
+            if (isinstance(loc, str) and loc) or (isinstance(loc, dict) and loc.get("code"))
         }
     if not locale_codes:
         issues.append(ConfigIssue(
@@ -270,6 +276,15 @@ def _compute_project_root() -> str:
     return os.path.abspath(os.path.join(script_dir, os.pardir))
 
 
+def _resolve_config_file_path(project_root: str) -> str:
+    """Resolve the active configuration file path."""
+    default_config_path = os.path.join(project_root, 'config.yaml')
+    config_file = os.environ.get('TRANSLATOR_CONFIG_FILE', default_config_path)
+    if not os.path.isabs(config_file):
+        config_file = os.path.abspath(config_file)
+    return config_file
+
+
 def _load_dotenv_files(project_root: str) -> None:
     """Load .env files from project root or docker directory."""
     dotenv_path_project_root = os.path.join(project_root, '.env')
@@ -283,13 +298,7 @@ def _load_dotenv_files(project_root: str) -> None:
 
 def _load_yaml_config(project_root: str) -> Dict[str, Any]:
     """Load YAML configuration file with enhanced error handling and path resolution."""
-    # If TRANSLATOR_CONFIG_FILE is set (potentially from .env), use it; otherwise, default to 'config.yaml'.
-    default_config_path = os.path.join(project_root, 'config.yaml')
-    config_file = os.environ.get('TRANSLATOR_CONFIG_FILE', default_config_path)
-
-    # Ensure we have an absolute path for better error reporting
-    if not os.path.isabs(config_file):
-        config_file = os.path.abspath(config_file)
+    config_file = _resolve_config_file_path(project_root)
 
     config = {}
     try:
@@ -321,21 +330,20 @@ def _load_yaml_config(project_root: str) -> Dict[str, Any]:
     except yaml.YAMLError as e:
         print(f"Error: Invalid YAML in configuration file '{config_file}': {e}", file=sys.stderr)
         print("Please check your YAML syntax. Using default configuration.", file=sys.stderr)
-    except (OSError, IOError) as e:
+    except OSError as e:
         print(f"Error: Could not read configuration file '{config_file}': {e}", file=sys.stderr)
-        print("Using default configuration.", file=sys.stderr)
-    except Exception as e:
-        print(f"Unexpected error loading configuration file '{config_file}': {e}", file=sys.stderr)
         print("Using default configuration.", file=sys.stderr)
 
     return config
 
 
-def _setup_logger_from_config(config: Dict[str, Any]) -> logging.Logger:
+def _setup_logger_from_config(config: Dict[str, Any], *, config_file_path: Optional[str] = None) -> logging.Logger:
     """Set up logger based on configuration."""
-    log_config = config.get('logging', {})
+    log_config = config.get('logging') or {}
     log_level_str = log_config.get('log_level', 'INFO').upper()
     log_file_path = log_config.get('log_file_path', 'logs/translation_log.log')
+    if config_file_path and not os.path.isabs(str(log_file_path)):
+        log_file_path = os.path.join(os.path.dirname(os.path.abspath(config_file_path)), str(log_file_path))
     log_to_console = log_config.get('log_to_console', True)
     return setup_logger(log_level_str, log_file_path, log_to_console)
 
@@ -363,8 +371,14 @@ def _build_language_mappings(locales_list: List[Dict[str, str]]) -> tuple[Dict[s
     name_to_code: Dict[str, str] = {}
 
     for locale in locales_list:
-        code = locale.get('code')
-        name = locale.get('name')
+        if isinstance(locale, str):
+            code = locale
+            name = locale
+        elif isinstance(locale, Mapping):
+            code = locale.get('code')
+            name = locale.get('name')
+        else:
+            continue
         if code and name:
             language_codes[code] = name
             name_to_code[name.lower()] = code
@@ -409,20 +423,21 @@ def _resolve_dry_run(config: Dict[str, Any]) -> bool:
 
 
 def _non_empty_env(name: str) -> Optional[str]:
-    """Return a stripped environment value, treating blanks as unset.
-
-    Some CI systems export optional inputs as empty environment variables. The
-    OpenAI SDK reads OPENAI_BASE_URL directly from the environment, so leaving a
-    blank value in place can override the SDK default endpoint with an empty URL.
-    """
+    """Return a stripped environment value, treating blanks as unset."""
     value = os.environ.get(name)
     if value is None:
         return None
     stripped = value.strip()
     if stripped:
         return stripped
-    os.environ.pop(name, None)
     return None
+
+
+def _scrub_blank_env(name: str) -> None:
+    """Remove a blank environment variable before SDKs can read it directly."""
+    value = os.environ.get(name)
+    if value is not None and not value.strip():
+        os.environ.pop(name, None)
 
 
 def _resolve_api_base_url(config: Dict[str, Any]) -> Optional[str]:
@@ -436,6 +451,57 @@ def _resolve_api_base_url(config: Dict[str, Any]) -> Optional[str]:
             if stripped:
                 return stripped
     return None
+
+
+def resolve_runtime_dir(
+    raw_path: Any,
+    *,
+    config_path: Optional[str],
+    default_name: str,
+) -> str:
+    """Resolve runtime scratch directories consistently for loader and CLI.
+
+    Explicit absolute paths are preserved. Explicit relative paths are resolved
+    against the config file directory. When the config omits the path entirely,
+    runtime queues stay under the system temp directory.
+    """
+    if raw_path is None or str(raw_path).strip() == "":
+        if config_path:
+            digest = hashlib.sha256(os.path.abspath(config_path).encode("utf-8")).hexdigest()[:12]
+            return os.path.abspath(
+                os.path.join(tempfile.gettempdir(), f"localize-pipeline-{digest}", default_name)
+            )
+        return os.path.abspath(os.path.join(tempfile.gettempdir(), default_name))
+
+    path = os.path.expanduser(str(raw_path))
+    if os.path.isabs(path):
+        return os.path.abspath(path)
+
+    base_dir = os.path.dirname(os.path.abspath(config_path)) if config_path else tempfile.gettempdir()
+    return os.path.abspath(os.path.join(base_dir, path))
+
+
+def _resolve_config_relative_path(raw_path: Any, *, config_path: str, default_path: str) -> str:
+    """Resolve state files relative to the active config when explicitly set."""
+    path = str(raw_path or default_path)
+    path = os.path.expanduser(path)
+    if os.path.isabs(path):
+        return os.path.abspath(path)
+    config_dir = os.path.dirname(os.path.abspath(config_path))
+    return os.path.abspath(os.path.join(config_dir, path))
+
+
+def _as_positive_int(value: Any, *, default: int, name: str) -> int:
+    """Parse a positive integer config value with an actionable error."""
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer.") from exc
+    if parsed < 1:
+        raise ValueError(f"{name} must be at least 1.")
+    return parsed
 
 
 def _create_model_provider(
@@ -475,7 +541,7 @@ def _create_model_provider(
             logger.critical("For dry-run mode, set 'dry_run: true' in your config file.")
         sys.exit(1)
     except Exception as e:
-        logger.critical("Failed to initialize model provider: %s", str(e))
+        logger.critical("Failed to initialize model provider: %s", str(e), exc_info=True)
         logger.critical("Please check your OPENAI_API_KEY and network connectivity.")
         sys.exit(1)
 
@@ -492,12 +558,15 @@ def load_app_config() -> AppConfig:
 
     # Load .env files
     _load_dotenv_files(project_root)
+    _scrub_blank_env('OPENAI_API_KEY')
+    _scrub_blank_env('OPENAI_BASE_URL')
+    config_file_path = _resolve_config_file_path(project_root)
 
     # Load YAML configuration
     config = _load_yaml_config(project_root)
 
     # Set up logger
-    logger = _setup_logger_from_config(config)
+    logger = _setup_logger_from_config(config, config_file_path=config_file_path)
 
     # Log .env status now that logger is available
     _log_dotenv_status(logger, project_root)
@@ -508,35 +577,43 @@ def load_app_config() -> AppConfig:
 
     # Get configuration values with defaults that validation and runtime share.
     dry_run = _resolve_dry_run(config)
+    review_model_env = _non_empty_env('REVIEW_MODEL_NAME')
+    validation_config = (
+        {**config, 'review_model_name': review_model_env}
+        if review_model_env
+        else config
+    )
 
     # Validate the configuration and surface actionable problems (non-fatal).
     _log_config_issues(
         validate_config(
-            config,
+            validation_config,
             effective_api_base_url=api_base_url,
-            api_key_available=bool(os.environ.get('OPENAI_API_KEY')),
+            api_key_available=bool(_non_empty_env('OPENAI_API_KEY')),
             dry_run_override=dry_run,
+            config_base_dir=os.path.dirname(config_file_path),
         ),
         logger,
     )
 
     # Build language mappings
-    locales_list = config.get('supported_locales', [])
+    locales_list = config.get('supported_locales') or []
     language_codes, name_to_code = _build_language_mappings(locales_list)
 
     # Process style rules
-    style_rules = config.get('style_rules', {})
+    style_rules = config.get('style_rules') or {}
     precomputed_style_rules_text = _precompute_style_rules(style_rules, language_codes)
 
     # Get configuration values with defaults
     # PROCESS_ALL_FILES env var overrides config (the GitHub Action sets it so a
     # clean CI checkout, which has no working-tree changes, still finds work).
+    process_all_files_env = _non_empty_env('PROCESS_ALL_FILES')
     process_all_files = _as_bool(
-        os.environ.get('PROCESS_ALL_FILES', config.get('process_all_files', False)),
+        process_all_files_env if process_all_files_env is not None else config.get('process_all_files', False),
         default=False,
     )
-    model_name = config.get('model_name', 'gpt-4')
-    review_model_name = _non_empty_env('REVIEW_MODEL_NAME') or config.get('review_model_name', model_name)
+    model_name = str(config.get('model_name') or 'gpt-4')
+    review_model_name = review_model_env or str(config.get('review_model_name') or model_name)
     model_provider_name = normalize_model_provider_name(
         str(config.get('model_provider', DEFAULT_MODEL_PROVIDER) or DEFAULT_MODEL_PROVIDER)
     )
@@ -545,14 +622,20 @@ def load_app_config() -> AppConfig:
     except ModelProviderConfigurationError as exc:
         logger.critical("CRITICAL: %s", exc)
         sys.exit(1)
-    retranslate_identical_source_strings = bool(config.get('retranslate_identical_source_strings', False))
-    ignore_key_patterns = compile_ignore_key_patterns(config.get('ignore_key_patterns', []))
+    retranslate_identical_source_strings = _as_bool(
+        config.get('retranslate_identical_source_strings', False),
+        default=False,
+    )
+    ignore_key_patterns = compile_ignore_key_patterns(config.get('ignore_key_patterns') or [])
     quality_gate_config = config.get('quality_gate', {}) or {}
     quality_gate = QualityGateConfig(
         source_identical_min_block_count=int(quality_gate_config.get('source_identical_min_block_count', 5)),
         source_identical_max_count=int(quality_gate_config.get('source_identical_max_count', 20)),
         source_identical_max_ratio=float(quality_gate_config.get('source_identical_max_ratio', 0.30)),
-        block_on_pipeline_warnings=bool(quality_gate_config.get('block_on_pipeline_warnings', True)),
+        block_on_pipeline_warnings=_as_bool(
+            quality_gate_config.get('block_on_pipeline_warnings', True),
+            default=True,
+        ),
         block_on_semantic_qa_findings=_as_bool(
             quality_gate_config.get('block_on_semantic_qa_findings', True),
             default=True,
@@ -569,49 +652,51 @@ def load_app_config() -> AppConfig:
 
     # Holistic review chunk size with environment override
     # Reduced default from 75 to 30 to handle content-heavy files better
-    default_chunk_size = config.get('holistic_review_chunk_size', 30)
-    holistic_review_chunk_size = int(os.environ.get('HOLISTIC_REVIEW_CHUNK_SIZE', default_chunk_size))
+    default_chunk_size = _as_positive_int(
+        config.get('holistic_review_chunk_size', 30),
+        default=30,
+        name='holistic_review_chunk_size',
+    )
+    holistic_review_chunk_size = _as_positive_int(
+        _non_empty_env('HOLISTIC_REVIEW_CHUNK_SIZE'),
+        default=default_chunk_size,
+        name='HOLISTIC_REVIEW_CHUNK_SIZE',
+    )
 
     # Queue folders
-    temp_dir = tempfile.gettempdir()
-    translation_queue_name = config.get('translation_queue_folder', 'translation_queue')
-    translated_queue_name = config.get('translated_queue_folder', 'translated_queue')
-    translation_queue_folder = os.path.join(temp_dir, translation_queue_name)
-    translated_queue_folder = os.path.join(temp_dir, translated_queue_name)
-    translation_key_ledger_file_path = config.get(
-        'translation_key_ledger_file_path',
-        os.path.join(project_root, 'logs', 'translation_key_ledger.json')
+    translation_queue_folder = resolve_runtime_dir(
+        config.get('translation_queue_folder'),
+        config_path=config_file_path,
+        default_name='translation_queue',
     )
-    if not os.path.isabs(translation_key_ledger_file_path):
-        translation_key_ledger_file_path = os.path.join(project_root, translation_key_ledger_file_path)
-    translation_memory_file_path = config.get(
-        'translation_memory_file_path',
-        os.path.join(project_root, 'logs', 'translation_memory.json')
+    translated_queue_folder = resolve_runtime_dir(
+        config.get('translated_queue_folder'),
+        config_path=config_file_path,
+        default_name='translated_queue',
     )
-    if not os.path.isabs(translation_memory_file_path):
-        translation_memory_file_path = os.path.join(project_root, translation_memory_file_path)
+    translation_key_ledger_file_path = _resolve_config_relative_path(
+        config.get('translation_key_ledger_file_path'),
+        config_path=config_file_path,
+        default_path=os.path.join(project_root, 'logs', 'translation_key_ledger.json'),
+    )
+    translation_memory_file_path = _resolve_config_relative_path(
+        config.get('translation_memory_file_path'),
+        config_path=config_file_path,
+        default_path=os.path.join(project_root, 'logs', 'translation_memory.json'),
+    )
     translation_memory_enabled = _as_bool(config.get('translation_memory_enabled', True), default=True)
 
     project_context = str(config.get('project_context') or '').strip()
     try:
         localization_profiles = load_localization_profiles(config)
     except ValueError:
-        if config.get('localization_formats') is not None:
+        if any(key in config for key in ('localization_formats', 'localization_format', 'localization_layout')):
             raise
-        try:
-            localization_format = load_localization_format(config.get('localization_format'))
-        except ValueError:
-            localization_format = JAVA_PROPERTIES_FORMAT
-        try:
-            localization_layout = load_localization_layout(
-                config.get('localization_layout'),
-                source_locale=str(config.get('source_locale') or 'en'),
-            )
-        except ValueError:
-            localization_layout = load_localization_layout(
-                None,
-                source_locale=str(config.get('source_locale') or 'en'),
-            )
+        localization_format = JAVA_PROPERTIES_FORMAT
+        localization_layout = load_localization_layout(
+            None,
+            source_locale=str(config.get('source_locale') or 'en'),
+        )
         localization_profiles = (LocalizationProfile(localization_format, localization_layout),)
     localization_format = localization_profiles[0].localization_format
     localization_layout = localization_profiles[0].localization_layout
@@ -634,11 +719,19 @@ def load_app_config() -> AppConfig:
         glossary_file_path=config.get('glossary_file_path', 'glossary.json'),
         model_name=model_name,
         review_model_name=review_model_name,
-        max_model_tokens=config.get('max_model_tokens', 4000),
+        max_model_tokens=_as_positive_int(
+            config.get('max_model_tokens', 4000),
+            default=4000,
+            name='max_model_tokens',
+        ),
         dry_run=dry_run,
         process_all_files=process_all_files,
         holistic_review_chunk_size=holistic_review_chunk_size,
-        max_concurrent_api_calls=config.get('max_concurrent_api_calls', 1),
+        max_concurrent_api_calls=_as_positive_int(
+            config.get('max_concurrent_api_calls', 1),
+            default=1,
+            name='max_concurrent_api_calls',
+        ),
         language_codes=language_codes,
         name_to_code=name_to_code,
         retranslate_identical_source_strings=retranslate_identical_source_strings,
@@ -651,7 +744,7 @@ def load_app_config() -> AppConfig:
         translation_key_ledger_file_path=translation_key_ledger_file_path,
         translation_memory_file_path=translation_memory_file_path,
         translation_memory_enabled=translation_memory_enabled,
-        preserve_queues_for_debug=config.get('preserve_queues_for_debug', False),
+        preserve_queues_for_debug=_as_bool(config.get('preserve_queues_for_debug', False), default=False),
         model_provider=model_provider,
         openai_client=openai_client,
         model_provider_name=model_provider_name,

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -11,10 +11,19 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Sequence
+from urllib.parse import urlsplit, urlunsplit
 
 import yaml
 
-from localize.app_config import ConfigIssue, validate_config
+from localize.app_config import (
+    ConfigIssue,
+    _compute_project_root,
+    _load_dotenv_files,
+    _non_empty_env,
+    _scrub_blank_env,
+    resolve_runtime_dir,
+    validate_config,
+)
 from localize.bootstrap_pr import BootstrapPrOptions, create_bootstrap_pr
 from localize.formats import list_localization_adapters, list_localization_formats
 from localize.init_config import main as init_config_main
@@ -23,7 +32,6 @@ from localize.plugins import load_plugins
 from localize.translation_quality_gate import main as translation_quality_gate_main
 from localize.translation_memory import (
     load_translation_memory_strict,
-    load_translation_memory,
     merge_translation_memory,
     translation_memory_suggestions,
     write_translation_memory,
@@ -41,12 +49,25 @@ def _load_config_file(config_path: Path) -> dict[str, Any]:
 
 
 def _effective_api_base_url(config: dict[str, Any]) -> str | None:
-    for candidate in (os.environ.get("OPENAI_BASE_URL"), config.get("api_base_url")):
+    for candidate in (_non_empty_env("OPENAI_BASE_URL"), config.get("api_base_url")):
         if candidate is not None:
             stripped = str(candidate).strip()
             if stripped:
                 return stripped
     return None
+
+
+def _redact_url_userinfo(url: str) -> str:
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return url
+    if not parts.username and not parts.password:
+        return url
+    host = parts.hostname or ""
+    if parts.port is not None:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, f"***@{host}", parts.path, parts.query, parts.fragment))
 
 
 def _effective_dry_run_override() -> bool | None:
@@ -77,6 +98,7 @@ def _cmd_formats(_args: argparse.Namespace) -> int:
 
 def _cmd_validate_config(args: argparse.Namespace, *, success_message: str) -> int:
     config_path = Path(args.config).expanduser().resolve()
+    _load_cli_dotenv()
     if not config_path.exists():
         print(f"error: configuration file not found: {config_path}", file=sys.stderr)
         return 1
@@ -92,8 +114,9 @@ def _cmd_validate_config(args: argparse.Namespace, *, success_message: str) -> i
     issues = validate_config(
         config,
         effective_api_base_url=_effective_api_base_url(config),
-        api_key_available=bool(os.environ.get("OPENAI_API_KEY")),
+        api_key_available=bool(_non_empty_env("OPENAI_API_KEY")),
         dry_run_override=_effective_dry_run_override(),
+        config_base_dir=str(config_path.parent),
     )
     _print_config_issues(issues)
     has_errors = any(issue.level == "error" for issue in issues)
@@ -119,14 +142,46 @@ def _resolve_input_folder(config: dict[str, Any]) -> Path:
     return input_folder.resolve()
 
 
-def _runtime_dir(raw_path: Any, *, config_path: Path) -> Path:
-    path = Path(str(raw_path)).expanduser()
+def _config_relative_path(raw_path: Any, *, config_path: Path) -> Path:
+    path = Path(str(raw_path or ".")).expanduser()
     if path.is_absolute():
-        return path
+        return path.resolve()
     return (config_path.parent / path).resolve()
 
 
+def _resolve_input_folder_for_config(config: dict[str, Any], *, config_path: Path) -> Path:
+    target_root = _config_relative_path(config.get("target_project_root"), config_path=config_path)
+    input_folder = Path(str(config.get("input_folder") or ".")).expanduser()
+    if not input_folder.is_absolute():
+        input_folder = target_root / input_folder
+    return input_folder.resolve()
+
+
+def _runtime_dir(raw_path: Any, *, config_path: Path, default_name: str = "translation_queue") -> Path:
+    return Path(resolve_runtime_dir(
+        raw_path,
+        config_path=str(config_path),
+        default_name=default_name,
+    ))
+
+
+def _load_cli_dotenv() -> None:
+    """Load project dotenv files before CLI preflight checks inspect env."""
+    _load_dotenv_files(_compute_project_root())
+    _scrub_blank_env("OPENAI_API_KEY")
+    _scrub_blank_env("OPENAI_BASE_URL")
+
+
+def _queue_dir(config: dict[str, Any], key: str, default_name: str, *, config_path: Path) -> Path:
+    return Path(resolve_runtime_dir(
+        config.get(key),
+        config_path=str(config_path),
+        default_name=default_name,
+    ))
+
+
 def _load_checked_config(config_path: Path) -> tuple[dict[str, Any], list[ConfigIssue]]:
+    _load_cli_dotenv()
     config = _load_config_file(config_path)
     review_model_override = os.environ.get("REVIEW_MODEL_NAME")
     if review_model_override:
@@ -134,8 +189,9 @@ def _load_checked_config(config_path: Path) -> tuple[dict[str, Any], list[Config
     issues = validate_config(
         config,
         effective_api_base_url=_effective_api_base_url(config),
-        api_key_available=bool(os.environ.get("OPENAI_API_KEY")),
+        api_key_available=bool(_non_empty_env("OPENAI_API_KEY")),
         dry_run_override=_effective_dry_run_override(),
+        config_base_dir=str(config_path.parent),
     )
     return config, issues
 
@@ -153,14 +209,15 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
         return 1
 
     profile = os.environ.get("TRANSLATOR_PROFILE") or "default"
-    target_root = Path(str(config.get("target_project_root") or ".")).expanduser().resolve()
-    input_folder = _resolve_input_folder(config)
+    target_root = _config_relative_path(config.get("target_project_root"), config_path=config_path)
+    input_folder = _resolve_input_folder_for_config(config, config_path=config_path)
     semantic_review = config.get("semantic_review", {}) or {}
     semantic_status = "enabled" if bool(semantic_review.get("enabled", False)) else "disabled"
-    api_base_url = _effective_api_base_url(config) or "default"
+    raw_api_base_url = _effective_api_base_url(config)
+    api_base_url = _redact_url_userinfo(raw_api_base_url) if raw_api_base_url else "default"
     model_provider = str(config.get("model_provider", "aisuite"))
-    queue = _runtime_dir(config.get("translation_queue_folder", "translation_queue"), config_path=config_path)
-    translated = _runtime_dir(config.get("translated_queue_folder", "translated_queue"), config_path=config_path)
+    queue = _queue_dir(config, "translation_queue_folder", "translation_queue", config_path=config_path)
+    translated = _queue_dir(config, "translated_queue_folder", "translated_queue", config_path=config_path)
     formats = ", ".join(
         f"{profile.localization_format.id}/{profile.localization_layout.id}"
         for profile in profiles
@@ -179,7 +236,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     print(f"review_model_name: {config.get('review_model_name', config.get('model_name', 'gpt-4'))}")
     print(f"api_base_url: {api_base_url}")
     print(f"semantic_review: {semantic_status}")
-    print(f"OPENAI_API_KEY: {'set' if os.environ.get('OPENAI_API_KEY') else 'unset'}")
+    print(f"OPENAI_API_KEY: {'set' if _non_empty_env('OPENAI_API_KEY') else 'unset'}")
     _print_config_issues(issues)
     return 1 if any(issue.level == "error" for issue in issues) else 0
 
@@ -199,8 +256,8 @@ def _cmd_smoke(args: argparse.Namespace) -> int:
     if any(issue.level == "error" for issue in issues):
         return 1
 
-    queue = _runtime_dir(config.get("translation_queue_folder", "translation_queue"), config_path=config_path)
-    translated = _runtime_dir(config.get("translated_queue_folder", "translated_queue"), config_path=config_path)
+    queue = _queue_dir(config, "translation_queue_folder", "translation_queue", config_path=config_path)
+    translated = _queue_dir(config, "translated_queue_folder", "translated_queue", config_path=config_path)
     queue.mkdir(parents=True, exist_ok=True)
     translated.mkdir(parents=True, exist_ok=True)
     print("Smoke OK")
@@ -209,11 +266,21 @@ def _cmd_smoke(args: argparse.Namespace) -> int:
 
 def _cmd_run(args: argparse.Namespace) -> int:
     config_path = Path(args.config).expanduser().resolve()
+    if not config_path.exists():
+        print(f"error: configuration file not found: {config_path}", file=sys.stderr)
+        return 1
+    _load_cli_dotenv()
     os.environ["TRANSLATOR_CONFIG_FILE"] = str(config_path)
     if args.dry_run:
         os.environ["LOCALIZE_DRY_RUN"] = "true"
     runtime = importlib.import_module("localize.translate_localization_files")
-    asyncio.run(runtime.main())
+    try:
+        result = asyncio.run(runtime.main())
+    except Exception as exc:
+        print(f"error: pipeline failed: {exc}", file=sys.stderr)
+        return 1
+    if result is False:
+        return 1
     return 0
 
 
@@ -281,7 +348,11 @@ def _cmd_quality_gate(args: argparse.Namespace) -> int:
 
 
 def _print_memory_stats(args: argparse.Namespace) -> int:
-    memory = load_translation_memory(args.memory_file)
+    try:
+        memory = load_translation_memory_strict(args.memory_file)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     stats = memory.stats()
     if args.output_format == "json":
         print(json.dumps({
@@ -420,15 +491,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="localize",
         description="Validate and run the AI localization translation pipeline.",
-    )
-    parser.add_argument(
-        "--plugin",
-        action="append",
-        default=[],
-        help=(
-            "Import a plugin module before running the command. Plugins register "
-            "custom localization adapters at import time."
-        ),
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -618,7 +680,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.init_args = forwarded_args
     elif forwarded_args:
         parser.error(f"unrecognized arguments: {' '.join(forwarded_args)}")
-    load_plugins([*plugin_args, *args.plugin])
+    load_plugins(plugin_args)
     return int(args.func(args))
 
 

--- a/localize/init_config.py
+++ b/localize/init_config.py
@@ -52,6 +52,7 @@ _HEADER = (
     "# Review the detected paths/locales, then run localize check and a dry run.\n"
     "# See config.example.yaml for the full set of optional settings.\n"
 )
+_IGNORED_DISCOVERY_DIRS = {".git", "node_modules", "build", "target"}
 
 
 @dataclass(frozen=True)
@@ -255,7 +256,8 @@ def _is_autodetect_source_file(
 def _discover_localization_roots(target_project_root: str, source_locale: str) -> List[str]:
     roots: set[str] = set()
     formats = tuple(list_localization_formats().values())
-    for root, _dirs, files in os.walk(target_project_root):
+    for root, dirs, files in os.walk(target_project_root):
+        dirs[:] = [directory for directory in dirs if directory not in _IGNORED_DISCOVERY_DIRS]
         file_set = set(files)
         for entry in files:
             path = os.path.join(root, entry)

--- a/localize/localization_profiles.py
+++ b/localize/localization_profiles.py
@@ -26,6 +26,23 @@ def _profile_format_raw(raw_profile: Any) -> Any:
     if isinstance(raw_profile, str):
         return raw_profile
     if isinstance(raw_profile, Mapping):
+        recognized_keys = (
+            "display_name",
+            "file_extension",
+            "code_fence",
+            "locale_suffix_regex",
+            "format",
+            "localization_format",
+            "id",
+            "layout",
+            "localization_layout",
+            "source_locale",
+        )
+        if not any(key in raw_profile for key in recognized_keys):
+            raise ValueError(
+                "Localization profile mappings must include a recognized format key "
+                "('id', 'format', 'localization_format') or custom format metadata."
+            )
         if any(
             key in raw_profile
             for key in ("display_name", "file_extension", "code_fence", "locale_suffix_regex")

--- a/localize/logging_config.py
+++ b/localize/logging_config.py
@@ -43,34 +43,48 @@ def setup_logger(log_level_str: str, log_file_path: str, log_to_console: bool) -
     Returns:
         The configured logger instance.
     """
-    # Use a specific logger name to avoid interfering with other loggers.
-    logger = logging.getLogger("translation_script")
-
     # Set the logging level from the config string
-    log_level = getattr(logging, log_level_str.upper(), logging.INFO)
+    requested_level = str(log_level_str or "INFO").upper()
+    if requested_level not in logging._nameToLevel:  # noqa: SLF001 - stdlib exposes configured level names here.
+        print(
+            f"Warning: invalid log_level '{log_level_str}', falling back to INFO.",
+            file=sys.stderr,
+        )
+        requested_level = "INFO"
+    log_level = logging._nameToLevel[requested_level]  # noqa: SLF001
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_logger.handlers.clear()
+
+    logger = logging.getLogger("translation_script")
     logger.setLevel(log_level)
-
-    # Clear any existing handlers to prevent duplicate logging
-    if logger.hasHandlers():
-        logger.handlers.clear()
-
-    # Prevent the log messages from being passed to the root logger
-    logger.propagate = False
+    logger.handlers.clear()
+    logger.propagate = True
 
     # Define a standard formatter for log messages
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 
     # --- File Handler ---
-    # Create the log directory if it doesn't exist
-    log_dir = os.path.dirname(log_file_path)
-    if log_dir:
-        os.makedirs(log_dir, exist_ok=True)
-    # Add a handler to write log messages to a file
-    file_handler = RotatingFileHandler(
-        log_file_path, maxBytes=5 * 1024 * 1024, backupCount=3, encoding='utf-8', delay=True
-    )
-    file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
+    try:
+        resolved_log_file_path = os.path.abspath(log_file_path)
+        log_dir = os.path.dirname(resolved_log_file_path)
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            resolved_log_file_path,
+            maxBytes=5 * 1024 * 1024,
+            backupCount=3,
+            encoding='utf-8',
+            delay=True,
+        )
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+    except OSError as exc:
+        print(
+            f"Warning: could not configure file logging at '{log_file_path}': {exc}",
+            file=sys.stderr,
+        )
     # --- End File Handler ---
 
     # --- Console Handler ---
@@ -79,7 +93,7 @@ def setup_logger(log_level_str: str, log_file_path: str, log_to_console: bool) -
         # We now use the custom handler that plays nice with tqdm.
         tqdm_handler = TqdmLoggingHandler()
         tqdm_handler.setFormatter(formatter)
-        logger.addHandler(tqdm_handler)
+        root_logger.addHandler(tqdm_handler)
     # --- End Console Handler ---
 
     return logger

--- a/localize/model_provider.py
+++ b/localize/model_provider.py
@@ -365,6 +365,17 @@ class AiSuiteProvider(OpenAICompatibleProvider):
     def is_retryable_error(self, exc: Exception) -> bool:
         if super().is_retryable_error(exc):
             return True
+        status_code = getattr(exc, "status_code", None)
+        if status_code is None:
+            response = getattr(exc, "response", None)
+            status_code = getattr(response, "status_code", None)
+        if isinstance(status_code, int):
+            if status_code == 429:
+                return True
+            if 400 <= status_code < 500:
+                return False
+            if status_code >= 500:
+                return True
         exc_module = exc.__class__.__module__
         exc_name = exc.__class__.__name__
         return exc_module.startswith("aisuite") or exc_name == "LLMError"
@@ -431,11 +442,12 @@ def _openai_provider_config(
     *,
     api_key: Optional[str],
     api_base_url: Optional[str],
-) -> Dict[str, str]:
-    config: Dict[str, str] = {}
+    existing_config: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    config: Dict[str, Any] = dict(existing_config or {})
     if api_key:
         config["api_key"] = api_key
-    elif api_base_url:
+    elif api_base_url and not config.get("api_key"):
         config["api_key"] = _LOCAL_PROVIDER_PLACEHOLDER_KEY
     if api_base_url:
         config["base_url"] = api_base_url
@@ -468,12 +480,10 @@ def create_model_provider(
         openai_config = _openai_provider_config(
             api_key=api_key,
             api_base_url=api_base_url,
+            existing_config=openai_provider_config,
         )
-        if openai_config:
-            provider_configs["openai"] = {
-                **openai_provider_config,
-                **openai_config,
-            }
+        if openai_config != openai_provider_config:
+            provider_configs["openai"] = openai_config
             openai_provider_config = provider_configs["openai"]
         if requires_openai_credentials(
             provider_name=normalized,

--- a/localize/plugins.py
+++ b/localize/plugins.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import os
 from importlib import metadata
 from typing import Iterable, List, Sequence
 
 ENTRY_POINT_GROUP = "localize.format_adapters"
 ENVIRONMENT_MODULES = "LOCALIZE_PLUGIN_MODULES"
+DISABLE_ENTRY_POINTS_ENV = "LOCALIZE_DISABLE_ENTRY_POINT_PLUGINS"
 
 _LOADED_PLUGIN_NAMES: set[str] = set()
+logger = logging.getLogger(__name__)
 
 
 def _split_module_list(value: str | None) -> List[str]:
@@ -20,6 +23,10 @@ def _split_module_list(value: str | None) -> List[str]:
 
 
 def _load_entry_points() -> None:
+    if os.environ.get(DISABLE_ENTRY_POINTS_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        logger.info("Entry-point localization plugins disabled by %s.", DISABLE_ENTRY_POINTS_ENV)
+        return
+
     entry_points = metadata.entry_points()
     if hasattr(entry_points, "select"):
         candidates = entry_points.select(group=ENTRY_POINT_GROUP)
@@ -30,17 +37,30 @@ def _load_entry_points() -> None:
         plugin_name = f"{ENTRY_POINT_GROUP}:{entry_point.name}"
         if plugin_name in _LOADED_PLUGIN_NAMES:
             continue
-        loaded = entry_point.load()
-        if callable(loaded):
-            loaded()
+        try:
+            loaded = entry_point.load()
+            if callable(loaded):
+                loaded()
+        except Exception as exc:
+            logger.warning("Could not load localization plugin entry point %s: %s", plugin_name, exc)
+            continue
         _LOADED_PLUGIN_NAMES.add(plugin_name)
 
 
-def _load_modules(module_names: Iterable[str]) -> None:
+def _load_modules(module_names: Iterable[str], *, source: str) -> None:
     for module_name in module_names:
         if module_name in _LOADED_PLUGIN_NAMES:
             continue
-        importlib.import_module(module_name)
+        try:
+            importlib.import_module(module_name)
+        except Exception as exc:
+            logger.warning(
+                "Could not load localization plugin module '%s' from %s: %s",
+                module_name,
+                source,
+                exc,
+            )
+            continue
         _LOADED_PLUGIN_NAMES.add(module_name)
 
 
@@ -53,5 +73,5 @@ def load_plugins(module_names: Sequence[str] | None = None) -> None:
     import with ``localize.formats.register_localization_adapter``.
     """
     _load_entry_points()
-    _load_modules(_split_module_list(os.environ.get(ENVIRONMENT_MODULES)))
-    _load_modules(module_names or ())
+    _load_modules(_split_module_list(os.environ.get(ENVIRONMENT_MODULES)), source=ENVIRONMENT_MODULES)
+    _load_modules(module_names or (), source="--plugin")

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -5,7 +5,13 @@ from unittest.mock import patch, mock_open, MagicMock
 import pytest
 import yaml
 
-from localize.app_config import AppConfig, _non_empty_env, load_app_config, validate_config
+from localize.app_config import (
+    AppConfig,
+    _non_empty_env,
+    _scrub_blank_env,
+    load_app_config,
+    validate_config,
+)
 from localize.localization_formats import JSON_FORMAT, JAVA_PROPERTIES_FORMAT
 from localize.localization_layouts import SUFFIX_LAYOUT
 
@@ -175,10 +181,62 @@ class TestLoadAppConfig:
                     with patch.dict(os.environ, {}, clear=True):
                         config = load_app_config()
 
-        assert config.translation_queue_folder == os.path.join(str(tmp_path), "translation_queue")
-        assert config.translated_queue_folder == os.path.join(str(tmp_path), "translated_queue")
+        import hashlib
+
+        config_path = os.path.join(config.project_root, "config.yaml")
+        digest = hashlib.sha256(os.path.abspath(config_path).encode("utf-8")).hexdigest()[:12]
+        assert config.translation_queue_folder == os.path.join(
+            str(tmp_path),
+            f"localize-pipeline-{digest}",
+            "translation_queue",
+        )
+        assert config.translated_queue_folder == os.path.join(
+            str(tmp_path),
+            f"localize-pipeline-{digest}",
+            "translated_queue",
+        )
         assert not os.path.exists(config.translation_queue_folder)
         assert not os.path.exists(config.translated_queue_folder)
+
+    def test_load_config_resolves_relative_state_paths_against_config_dir(self, tmp_path):
+        config_dir = tmp_path / "configs"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text(
+            "dry_run: true\n"
+            "translation_key_ledger_file_path: state/ledger.json\n"
+            "translation_memory_file_path: state/memory.json\n",
+            encoding="utf-8",
+        )
+
+        with patch("localize.app_config.setup_logger") as mock_logger:
+            mock_logger.return_value = MagicMock()
+            with patch.dict(os.environ, {"TRANSLATOR_CONFIG_FILE": str(config_path)}, clear=True):
+                config = load_app_config()
+
+        assert config.translation_key_ledger_file_path == str(config_dir / "state" / "ledger.json")
+        assert config.translation_memory_file_path == str(config_dir / "state" / "memory.json")
+
+    def test_load_config_and_cli_share_queue_dir_resolution(self, tmp_path):
+        from localize.cli import _runtime_dir
+
+        config_dir = tmp_path / "configs"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text(
+            "dry_run: true\n"
+            "translation_queue_folder: scratch/queue\n"
+            "translated_queue_folder: scratch/done\n",
+            encoding="utf-8",
+        )
+
+        with patch("localize.app_config.setup_logger") as mock_logger:
+            mock_logger.return_value = MagicMock()
+            with patch.dict(os.environ, {"TRANSLATOR_CONFIG_FILE": str(config_path)}, clear=True):
+                config = load_app_config()
+
+        assert config.translation_queue_folder == str(_runtime_dir("scratch/queue", config_path=config_path))
+        assert config.translated_queue_folder == str(_runtime_dir("scratch/done", config_path=config_path))
 
 
     def test_load_config_reads_project_context_and_format(self):
@@ -272,7 +330,7 @@ class TestLoadAppConfig:
         assert config.localization_format == JAVA_PROPERTIES_FORMAT
         assert config.localization_profiles[1].localization_layout.id == "locale_directory"
 
-    def test_load_config_with_invalid_format_falls_back_to_java_properties(self):
+    def test_load_config_with_invalid_format_raises(self):
         mock_config = {
             "dry_run": True,
             "localization_format": "unknown_format",
@@ -283,9 +341,8 @@ class TestLoadAppConfig:
                 with patch("localize.app_config.setup_logger") as mock_logger:
                     mock_logger.return_value = MagicMock()
                     with patch.dict(os.environ, {}, clear=True):
-                        config = load_app_config()
-
-        assert config.localization_format == JAVA_PROPERTIES_FORMAT
+                        with pytest.raises(ValueError, match="Unsupported localization_format"):
+                            load_app_config()
 
     def test_load_config_with_invalid_multi_profile_raises(self):
         mock_config = {
@@ -303,7 +360,7 @@ class TestLoadAppConfig:
                         with pytest.raises(ValueError, match="Unsupported localization_format"):
                             load_app_config()
 
-    def test_load_config_with_invalid_layout_preserves_source_locale(self):
+    def test_load_config_with_invalid_layout_raises(self):
         mock_config = {
             "dry_run": True,
             "source_locale": "fr",
@@ -315,10 +372,8 @@ class TestLoadAppConfig:
                 with patch("localize.app_config.setup_logger") as mock_logger:
                     mock_logger.return_value = MagicMock()
                     with patch.dict(os.environ, {}, clear=True):
-                        config = load_app_config()
-
-        assert config.localization_layout.id == "suffix"
-        assert config.localization_layout.source_locale == "fr"
+                        with pytest.raises(ValueError, match="Unsupported localization_layout"):
+                            load_app_config()
 
     def test_load_config_treats_null_brand_glossary_as_empty(self):
         mock_config = {
@@ -860,6 +915,8 @@ class TestProviderAbstraction:
     def test_empty_env_value_is_removed_before_sdk_initialization(self):
         with patch.dict(os.environ, {"OPENAI_BASE_URL": "   "}, clear=True):
             assert _non_empty_env("OPENAI_BASE_URL") is None
+            assert "OPENAI_BASE_URL" in os.environ
+            _scrub_blank_env("OPENAI_BASE_URL")
             assert "OPENAI_BASE_URL" not in os.environ
 
     def test_empty_review_model_env_falls_back_to_config(self):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -165,6 +165,36 @@ def test_cli_check_alias_runs_preflight_validation(tmp_path, capsys):
     assert "Preflight OK" in captured.out
 
 
+def test_cli_validate_loads_project_dotenv_before_checking_key(tmp_path, monkeypatch, capsys):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    repo = tmp_path / "repo"
+    i18n = repo / "i18n"
+    i18n.mkdir(parents=True)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({
+            "target_project_root": str(repo),
+            "input_folder": str(i18n),
+            "dry_run": False,
+            "model_provider": "openai_compatible",
+            "supported_locales": [{"code": "de", "name": "German"}],
+        }),
+        encoding="utf-8",
+    )
+
+    with patch("localize.cli._load_dotenv_files") as load_dotenv_files:
+        load_dotenv_files.side_effect = lambda _project_root: os.environ.__setitem__(
+            "OPENAI_API_KEY",
+            "sk-from-dotenv",
+        )
+        exit_code = cli.main(["validate", "--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Configuration OK" in captured.out
+    load_dotenv_files.assert_called()
+
+
 def test_cli_doctor_prints_redacted_effective_config(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-value")
     repo = tmp_path / "repo"

--- a/tests/unit/test_model_provider.py
+++ b/tests/unit/test_model_provider.py
@@ -459,3 +459,22 @@ def test_aisuite_factory_rejects_invalid_openai_config_before_endpoint_merge():
             aisuite_provider_configs={"openai": None},
             model_names=("gpt-4o-mini",),
         )
+
+
+def test_aisuite_factory_preserves_configured_openai_api_key_with_endpoint():
+    logger = logging.getLogger("test")
+    provider_configs = {"openai": {"api_key": "real-config-key"}}
+
+    with patch("localize.model_provider.create_aisuite_provider") as create_aisuite:
+        create_model_provider(
+            provider_name="aisuite",
+            api_key=None,
+            api_base_url="http://localhost:11434/v1",
+            logger=logger,
+            aisuite_provider_configs=provider_configs,
+            model_names=("gpt-4o-mini",),
+        )
+
+    kwargs = create_aisuite.call_args.kwargs
+    assert kwargs["provider_configs"]["openai"]["api_key"] == "real-config-key"
+    assert kwargs["provider_configs"]["openai"]["base_url"] == "http://localhost:11434/v1"


### PR DESCRIPTION
## Summary
- Resolve queue, ledger, memory, and logging paths from the active config so loader and CLI preflight agree.
- Load dotenv files before validate/check/doctor/smoke, scrub blank OpenAI env values explicitly, and keep validation aligned with env overrides.
- Raise on invalid explicit localization profile values, preserve configured AISuite OpenAI keys when a custom endpoint is set, and tighten provider retry classification.
- Harden adjacent config/CLI behavior: numeric range checks, string locale support, plugin isolation, root logger propagation, config-relative examples, and discovery pruning.

## Regression tests
- Added coverage for config-relative state paths.
- Added coverage that CLI and loader share queue path resolution.
- Added coverage that invalid explicit formats fail instead of falling back.
- Added coverage that CLI validate loads dotenv before checking OpenAI credentials.
- Added coverage that AISuite endpoint setup preserves a configured OpenAI API key.

## Verification
- venv/bin/pytest (551 passed)
- venv/bin/python -m py_compile localize/app_config.py localize/cli.py localize/model_provider.py localize/plugins.py localize/localization_profiles.py localize/logging_config.py localize/init_config.py
- git diff --check

## Notes
- Existing untracked docs/outreach files were left untouched.
