### PR TITLE
Prepare v0.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.6] - 2026-07-05
+
+### Fixed
+
+- Removed build-time SSH and GPG private-key persistence from Docker image
+  layers; runtime secrets are imported by the entrypoint instead.
+- Hardened core translation retries, holistic review scoping, failed-key ledger
+  handling, post-translation validation, queue cleanup, and reporting counts.
+- Tightened quality-gate, semantic-review, remediation, placeholder, and
+  validation behavior for blocking translation defects.
+- Aligned config, CLI, provider, shell, Docker, and GitHub Action behavior for
+  safer production runs.
+- Improved parser, adapter, translation-memory, connector, bootstrap, layout,
+  and documentation edge cases.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.6`.
+
 ### Added
 
 - `ignore_key_patterns` config to keep matching localization keys copied from

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.5
+      - uses: bisq-network/localize-pipeline@v0.1.6
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -209,7 +209,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.5
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.6
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -229,7 +229,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.5
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.6
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -311,7 +311,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.5
+- uses: bisq-network/localize-pipeline@v0.1.6
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.5
+      - uses: bisq-network/localize-pipeline@v0.1.6
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -94,7 +94,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.5
+      - uses: bisq-network/localize-pipeline@v0.1.6
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -149,7 +149,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.5
+      - uses: bisq-network/localize-pipeline@v0.1.6
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -168,7 +168,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.5
+      - uses: bisq-network/localize-pipeline@v0.1.6
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.5
+      - uses: bisq-network/localize-pipeline@v0.1.6
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.5
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.6
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -105,7 +105,7 @@ you are ready to let the pipeline write translations.
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.5
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.6
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -127,7 +127,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.5 \
+  --action-ref v0.1.6 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.6"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.5"
+    action_ref: str = "v0.1.6"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -572,7 +572,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.5", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.6", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.3"
+version = "0.1.6"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -63,7 +63,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     assert config["supported_locales"] == [{"code": "de", "name": "German"}]
 
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
-    assert "bisq-network/localize-pipeline@v0.1.5" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.6" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -444,7 +444,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.5"
+    assert create.call_args.args[0].action_ref == "v0.1.6"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -590,7 +590,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.3"
+    assert pyproject["project"]["version"] == "0.1.6"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"


### PR DESCRIPTION
## Summary
- bump package metadata and runtime version to 0.1.6
- update documented/default action refs to v0.1.6
- add changelog notes for the merged hardening release

## Verification
- venv/bin/pytest (620 passed)

## Production note
After merge, publish the signed v0.1.6 tag/release so pinned workflows can consume the merged fixes.