### PR TITLE
Fix runtime GPG fingerprint probe

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -151,7 +151,7 @@ import_runtime_gpg_key() {
         cleanup_gpg_import_file="$gpg_import_file"
     fi
 
-    fingerprint="$(run_as_appuser "$user_home" gpg --import-options show-only --with-colons "$gpg_import_file" \
+    fingerprint="$(run_as_appuser "$user_home" gpg --import-options show-only --import --with-colons "$gpg_import_file" \
         | awk -F: '/^fpr/ {print $10; exit}')"
     if [ -z "$fingerprint" ]; then
         rm -f "$cleanup_gpg_import_file"

--- a/tests/unit/test_docker_runtime_secrets.py
+++ b/tests/unit/test_docker_runtime_secrets.py
@@ -78,7 +78,7 @@ def test_entrypoint_installs_runtime_ssh_and_gpg_secrets():
     assert 'GPG_BOT_KEY_PATH:-/run/secrets/gpg_bot_key' in entrypoint
     assert 'SKIP_GPG_IMPORT:-false' in entrypoint
     assert 'gpg --batch --import "$gpg_import_file"' in entrypoint
-    assert 'gpg --import-options show-only --with-colons "$gpg_import_file"' in entrypoint
+    assert 'gpg --import-options show-only --import --with-colons "$gpg_import_file"' in entrypoint
     assert '"$runtime_deploy_key_path" "$user_home/.ssh/deploy_key"' in entrypoint
     assert 'chmod 600 "$user_home/.ssh/deploy_key"' in entrypoint
 


### PR DESCRIPTION
## Summary
- fix runtime GPG key fingerprint probing by using GPG show-only import mode
- keep runtime GPG import behavior unchanged after fingerprint discovery
- add/update Docker runtime secret regression coverage

## Verification
- venv/bin/python -m pytest tests/unit/test_docker_runtime_secrets.py tests/unit/test_docker_entrypoint.py -q
- venv/bin/ruff check .
- git diff --check
- venv/bin/python -m pytest -q

## Production context
Production smoke after PR #120 reached the rebuilt container entrypoint and failed before translation work with: Runtime GPG key source did not expose a secret-key fingerprint. This hotfix addresses the GPG probe command that caused that failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker startup handling for imported GPG keys, helping key fingerprint checks run more reliably.
* **Tests**
  * Updated automated coverage to match the revised GPG command used during container initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->