### PR TITLE
Reuse runtime secrets after privilege drop

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -100,6 +100,7 @@ ensure_insecure_ssh_config() {
 install_runtime_deploy_key() {
     local user_home="${APPUSER_HOME:-/home/appuser}"
     local runtime_deploy_key_path="${DEPLOY_KEY_PATH:-/run/secrets/deploy_key}"
+    local installed_deploy_key="$user_home/.ssh/deploy_key"
 
     if [ "${SKIP_DEPLOY_KEY:-false}" = "true" ]; then
         log "Skipping runtime deploy key setup because SKIP_DEPLOY_KEY=true."
@@ -107,13 +108,24 @@ install_runtime_deploy_key() {
     fi
 
     mkdir -p "$user_home/.ssh"
+    if [ -s "$user_home/.ssh/deploy_key" ]; then
+        chmod 600 "$installed_deploy_key"
+        ensure_github_identity_config "$user_home"
+        log "Runtime deploy key already installed for appuser."
+        return 0
+    fi
+
     if [ ! -s "$runtime_deploy_key_path" ]; then
         log "Runtime deploy key not found at $runtime_deploy_key_path; SSH clone/push may fail." "WARNING"
         return 0
     fi
+    if [ ! -r "$runtime_deploy_key_path" ]; then
+        log "Runtime deploy key at $runtime_deploy_key_path is not readable; SSH clone/push may fail." "WARNING"
+        return 0
+    fi
 
-    cp "$runtime_deploy_key_path" "$user_home/.ssh/deploy_key"
-    chmod 600 "$user_home/.ssh/deploy_key"
+    cp "$runtime_deploy_key_path" "$installed_deploy_key"
+    chmod 600 "$installed_deploy_key"
     ensure_github_identity_config "$user_home"
 
     if [ "$(id -u)" -eq 0 ]; then
@@ -135,8 +147,18 @@ import_runtime_gpg_key() {
         return 0
     fi
 
+    if run_as_appuser "$user_home" gpg --list-secret-keys --with-colons 2>/dev/null \
+        | awk -F: '/^sec/ {found=1} END {exit !found}'; then
+        log "Runtime GPG key already available for appuser."
+        return 0
+    fi
+
     if [ ! -s "$runtime_gpg_key_path" ]; then
         log "Runtime GPG key not found at $runtime_gpg_key_path; commit signing will be disabled." "WARNING"
+        return 0
+    fi
+    if [ ! -r "$runtime_gpg_key_path" ]; then
+        log "Runtime GPG key at $runtime_gpg_key_path is not readable; commit signing will be disabled." "WARNING"
         return 0
     fi
 

--- a/tests/unit/test_docker_runtime_secrets.py
+++ b/tests/unit/test_docker_runtime_secrets.py
@@ -79,8 +79,8 @@ def test_entrypoint_installs_runtime_ssh_and_gpg_secrets():
     assert 'SKIP_GPG_IMPORT:-false' in entrypoint
     assert 'gpg --batch --import "$gpg_import_file"' in entrypoint
     assert 'gpg --import-options show-only --import --with-colons "$gpg_import_file"' in entrypoint
-    assert '"$runtime_deploy_key_path" "$user_home/.ssh/deploy_key"' in entrypoint
-    assert 'chmod 600 "$user_home/.ssh/deploy_key"' in entrypoint
+    assert 'cp "$runtime_deploy_key_path" "$installed_deploy_key"' in entrypoint
+    assert 'chmod 600 "$installed_deploy_key"' in entrypoint
 
     appuser_block = entrypoint.split('if [ "$(id -u)" -ne 0 ]; then', 1)[1].split("else", 1)[0]
     assert appuser_block.index("install_runtime_deploy_key") < appuser_block.index("setup_ssh")
@@ -89,3 +89,12 @@ def test_entrypoint_installs_runtime_ssh_and_gpg_secrets():
     root_block = entrypoint.split("# --- Root Execution Block ---", 1)[1]
     assert root_block.index("install_runtime_deploy_key") < root_block.index("setup_ssh")
     assert root_block.index("import_runtime_gpg_key") < root_block.index("setup_ssh")
+
+
+def test_entrypoint_reuses_runtime_secrets_after_privilege_drop():
+    entrypoint = _entrypoint()
+
+    assert 'if [ -s "$user_home/.ssh/deploy_key" ]; then' in entrypoint
+    assert "Runtime deploy key already installed for appuser." in entrypoint
+    assert "gpg --list-secret-keys --with-colons" in entrypoint
+    assert "Runtime GPG key already available for appuser." in entrypoint


### PR DESCRIPTION
## Summary
- make runtime deploy-key setup idempotent after root installs the key and re-execs as appuser
- make runtime GPG setup reuse an already-imported appuser secret key after privilege drop
- add Docker runtime-secret coverage for the root-to-appuser re-exec path

## Verification
- venv/bin/python -m pytest tests/unit/test_docker_runtime_secrets.py tests/unit/test_docker_entrypoint.py -q
- venv/bin/ruff check .
- git diff --check
- venv/bin/python -m pytest -q

## Production context
After PR #121 fixed GPG fingerprint probing, production smoke imported and trusted the runtime GPG key, then failed when the appuser re-exec tried to read root-only compose secrets again. This fix reuses the already installed appuser secrets instead of rereading /run/secrets after privilege drop.