### PR TITLE
Allow retained Dutch loanword "contact"

### DIFF
--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -28,6 +28,7 @@ quality_gate:
     es: ["personal"]
     fr: ["information", "message", "messages", "version"]
     it: ["reporting"]
+    nl: ["contact"]
     sv: ["version"]
 semantic_review:
   enabled: true

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -329,6 +329,7 @@ def test_recent_coderabbit_translation_nits_are_encoded_as_style_rules(config_pa
     assert "version" in retained_allowlist["da"]
     assert "version" in retained_allowlist["de"]
     assert {"information", "message", "messages", "version"}.issubset(retained_allowlist["fr"])
+    assert "contact" in retained_allowlist["nl"]
     assert "version" in retained_allowlist["sv"]
     assert {
         "trade-history-traders-label",


### PR DESCRIPTION
## Summary

Add a locale-scoped `nl: ["contact"]` entry to the quality gate's
`retained_source_word_allowlist` in `profiles/bisq/config.yaml` to
suppress a recurring **false positive** in the `retained-source-word`
semantic-QA heuristic.

## Evidence

- **PR:** [bisq-network/bisq2#4862](https://github.com/bisq-network/bisq2/pull/4862) — "Update translations (54 changed values) in bisq_easy for 54 locales" (merged 2026-07-07).
- **Key:** `bisqEasy.history.table.actionButtons.contactPeer.tooltip`
- **Locale:** `nl` (Dutch)
- **Source (en):** `Contact peer`
- **Target (nl):** `Neem contact op met de peer`
- **Heuristic finding (rules/heuristics):** *"Target may retain untranslated source term(s): Contact."*

The PR's own validation summary reported this as the single
rules/heuristics finding (43 semantic-QA warnings total, all
non-blocking). CodeRabbit generated no actionable comments on the PR.

## Root cause

`evaluate_retained_source_words` (`localize/semantic_quality.py`) flags
any English source word of 7+ characters
(`_SOURCE_WORD_RE = [A-Za-z][A-Za-z'-]{6,}`) that reappears verbatim in
a target value. It has no notion of loanwords/cognates. "Neem contact
op met" is the standard, idiomatic Dutch phrase for "get in touch", so
"contact" is genuine Dutch — but the heuristic still flags it. Note the
actually-retained English word here ("peer", 4 chars) is below the
threshold and was never flagged; only the correct Dutch word tripped
the rule.

Scope check across all 54 locales in the PR: among heuristic-eligible
locales, `nl` is the only one that retains the standalone word
"contact". `pcm` ("Contact pesin") is exempt (`{"en", "pcm"}` skip);
Romance locales use inflected forms ("Contacta", "Contacter",
"Contactați") that are not whole-word matches.

## Change

- `profiles/bisq/config.yaml`: add `nl: ["contact"]` to
  `quality_gate.retained_source_word_allowlist` (kept locale-scoped so
  genuinely-untranslated "contact" in other locales still warns).
- `tests/unit/test_config_quality.py`: assert the new entry so CI
  catches regressions.

This follows the established precedent for `version` (da/de/fr/sv),
`personal` (es), `reporting` (it) already in the allowlist.

## Test results

Behavioral check (before/after) confirms suppression:

```
WITHOUT allowlist -> [('retained-source-word', 'Target may retain untranslated source term(s): Contact.')]
WITH nl:[contact]  -> []
```

`.venv/bin/pytest -q tests/unit` → **657 passed, 4 subtests passed**.

## Checklist

- [ ] Requires `docker compose run --rm translator` build + local run before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation handling by preserving the word “contact” in Dutch content.
* **Tests**
  * Updated validation coverage to reflect the expanded retained-word allowance for Dutch translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->