### PR TITLE
Protect Lightning term Preimage in Bisq glossary

### DIFF
--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -647,6 +647,7 @@ brand_technical_glossary:
   - Perfect Money
   - Pix
   - Popmoney
+  - Preimage
   - PromptPay
   - RSK
   - RTGS

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -409,3 +409,20 @@ def test_recent_coderabbit_translation_nits_are_encoded_as_style_rules(config_pa
         and "paymentAccounts.accountCreationDate" in rule
         for rule in style_rules["pcm"]
     )
+
+
+def test_preimage_is_a_protected_brand_technical_term():
+    """Keep the Lightning term 'Preimage' untranslated in the Bisq profile.
+
+    bisq2#4866 CodeRabbit flagged that the model rendered the source term
+    'Preimage' (bisqEasy.history.table.csv.txIdOrPreimage) as unrelated words
+    across several locales, e.g. Russian 'преобразование' (transformation),
+    Polish 'Prezentacja' and Bulgarian 'Представяне' (presentation), and Irish
+    'íomhá réamhtheoranta' (predefined image). Protecting it alongside the
+    other Lightning terms keeps the CSV export header accurate and consistent.
+    """
+    config = yaml.safe_load(BISQ_PROFILE_CONFIG.read_text(encoding="utf-8"))
+    brand_glossary = config["brand_technical_glossary"]
+    assert "Preimage" in brand_glossary
+    # Sibling Lightning terms must remain protected so the family stays consistent.
+    assert {"Lightning", "Lightning Escrow", "Submarine Swaps"}.issubset(set(brand_glossary))


### PR DESCRIPTION
## Problem

CodeRabbit's review of the (already-merged) translation PR
[bisq2#4866](https://github.com/bisq-network/bisq2/pull/4866) flagged a
recurring, systemic mistranslation: the model rendered the English source
term **"Preimage"** — a Lightning payment-proof term used in
`bisqEasy.history.table.csv.txIdOrPreimage` (source:
`Transaction ID/Preimage`) — as unrelated words in many locales:

| Locale | Produced | Means | CodeRabbit note |
|--------|----------|-------|-----------------|
| ru | `преобразование` | "transformation" | wrong term |
| pl | `Prezentacja` | "presentation" | wrong term |
| bg | `Представяне` | "presentation" | inconsistent w/ `Предобраз` elsewhere |
| ga | `íomhá réamhtheoranta` | "predefined image" | inconsistent w/ `Réamhíomhá` |
| mk | `преимеџ` | (transliteration) | inconsistent w/ other labels |
| sr | `преимеџ` | (transliteration) | inconsistent w/ `Прекурсор`/`Преимаге` |

These end up as CSV export headers, so a wrong label misrepresents what the
column contains.

## Root cause

"Preimage" is a Lightning technical term, but it is **not** in the Bisq
profile's `brand_technical_glossary`. That list is injected into every
translation prompt as "Do NOT translate these terms"
(`localize/translate_localization_files.py`), and it already protects the
sibling Lightning terms **Lightning**, **Lightning Escrow**, and
**Submarine Swaps**. Because "Preimage" was missing, the model was free to
invent a (frequently wrong) target word per locale.

## Change

- Add `Preimage` to `brand_technical_glossary` in
  `profiles/bisq/config.yaml` (kept alphabetized, between `Popmoney` and
  `PromptPay`). The model will now preserve it verbatim, preventing the
  nonsense renderings at generation time for **all** locales and future
  keys — the same mechanism already used for its Lightning siblings.
- Add `tests/unit/test_config_quality.py::test_preimage_is_a_protected_brand_technical_term`
  to lock this in and keep the Lightning family protected.

## Trade-off (reviewer decision)

This enforces **consistent English** for "Preimage" everywhere. That is the
simplest robust prevention and matches CodeRabbit's Polish suggestion
(`ID transakcji/Preimage`). However, CodeRabbit suggested an *established
localized* term for some locales (bg `Предобраз`, ga `Réamhíomhá`,
ru `прообраз`). If you prefer per-locale localization over English
consistency, the alternative is to add per-locale entries to
`profiles/bisq/glossary.json` instead of / in addition to this brand-glossary
entry. This PR takes the glossary-protection route because it prevents the
whole class of bug in one place; the alternative requires a vetted term for
each of 54 locales.

Note: it does not retroactively rewrite already-merged values; it guides
future translations of new/changed keys.

## Validation

- `.venv/bin/pytest -q tests/unit/test_config_quality.py` → 19 passed
- `.venv/bin/pytest -q tests/unit` → 658 passed

## Scope

Out of scope here: the same review also noted that
`bisqEasy.history.table.csv.quoteAmountCurrencyCode` reads as "fiat
currency" rather than "fiat currency code" across ~18 locales. That is
faithful to the **English source** (`quoteAmountCurrencyCode=Fiat currency`),
so it is a source-string wording issue in bisq2, not a pipeline defect, and
is intentionally not addressed here.

---

- [ ] Requires `docker compose run --rm translator` build + local run before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Preimage” to the Bisq technical glossary.

* **Tests**
  * Added coverage to ensure “Preimage” and related Lightning terminology remain present in the glossary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->