### PR TITLE
Scope unreachable Go CVEs in Trivy scan

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -113,6 +113,7 @@ jobs:
             --vuln-type os,library \
             --severity CRITICAL,HIGH \
             --ignorefile /workspace/.trivyignore \
+            --ignore-policy /workspace/.trivyignore.rego \
             "translator-app:ci-${{ github.sha }}"
 
       # - name: Upload Trivy scan results to GitHub Security tab

--- a/.trivyignore
+++ b/.trivyignore
@@ -234,34 +234,3 @@ CVE-2026-27145
 # Revisit by: 2026-08-15
 CVE-2026-48702
 CVE-2026-39832
-
-# CVE-2026-39831:
-# Newly surfaced Trivy finding in a vendor-supplied Go binary baked into the image.
-# Affects: tx v1.6.17 (Transifex CLI, Go 1.16.15) via golang.org/x/crypto/ssh.
-# Title: "golang.org/x/crypto/ssh: security key bypass due to missing user
-#         presence check" (fixed upstream in x/crypto 0.52.0).
-# Rationale: Same golang.org/x/crypto/ssh family already accepted above
-#            (CVE-2025-47913 / CVE-2026-39827..39835). tx talks to Transifex's
-#            API using fixed workflow inputs and never performs SSH security-key
-#            authentication for untrusted users here, so the user-presence bypass
-#            is not reachable. No newer upstream tx release patches this and the
-#            binary cannot be rebuilt by us.
-# Checked CI Trivy report: 2026-07-10.
-# Added: 2026-07-11
-# Revisit by: 2026-08-15
-CVE-2026-39831
-
-# CVE-2026-39822:
-# Trivy matches this Go stdlib os.Root issue by compiler version, without
-# checking whether an affected symbol is linked or called.
-# Affects reported by Trivy: gh v2.93.0 (Go 1.26.4), yq v4.53.3
-# (Go 1.26.4), tx v1.6.17 (Go 1.16.15), and gosu 1.19 (Go 1.24.6).
-# Rationale: None of these exact upstream releases calls os.OpenInRoot,
-#            os.OpenRoot, or an affected os.Root method. The API did not exist
-#            in Go 1.16, so the tx finding is necessarily a false positive.
-#            These fixed-version CI/CD utilities also do not accept untrusted
-#            filesystem paths in this deployment flow.
-# Checked upstream source and CI Trivy report: 2026-07-12.
-# Added: 2026-07-12
-# Revisit by: 2026-08-15
-CVE-2026-39822

--- a/.trivyignore
+++ b/.trivyignore
@@ -234,3 +234,19 @@ CVE-2026-27145
 # Revisit by: 2026-08-15
 CVE-2026-48702
 CVE-2026-39832
+
+# CVE-2026-39831:
+# Newly surfaced Trivy finding in a vendor-supplied Go binary baked into the image.
+# Affects: tx v1.6.17 (Transifex CLI, Go 1.16.15) via golang.org/x/crypto/ssh.
+# Title: "golang.org/x/crypto/ssh: security key bypass due to missing user
+#         presence check" (fixed upstream in x/crypto 0.52.0).
+# Rationale: Same golang.org/x/crypto/ssh family already accepted above
+#            (CVE-2025-47913 / CVE-2026-39827..39835). tx talks to Transifex's
+#            API using fixed workflow inputs and never performs SSH security-key
+#            authentication for untrusted users here, so the user-presence bypass
+#            is not reachable. No newer upstream tx release patches this and the
+#            binary cannot be rebuilt by us.
+# Checked CI Trivy report: 2026-07-10.
+# Added: 2026-07-11
+# Revisit by: 2026-08-15
+CVE-2026-39831

--- a/.trivyignore
+++ b/.trivyignore
@@ -250,3 +250,18 @@ CVE-2026-39832
 # Added: 2026-07-11
 # Revisit by: 2026-08-15
 CVE-2026-39831
+
+# CVE-2026-39822:
+# Trivy matches this Go stdlib os.Root issue by compiler version, without
+# checking whether an affected symbol is linked or called.
+# Affects reported by Trivy: gh v2.93.0 (Go 1.26.4), yq v4.53.3
+# (Go 1.26.4), tx v1.6.17 (Go 1.16.15), and gosu 1.19 (Go 1.24.6).
+# Rationale: None of these exact upstream releases calls os.OpenInRoot,
+#            os.OpenRoot, or an affected os.Root method. The API did not exist
+#            in Go 1.16, so the tx finding is necessarily a false positive.
+#            These fixed-version CI/CD utilities also do not accept untrusted
+#            filesystem paths in this deployment flow.
+# Checked upstream source and CI Trivy report: 2026-07-12.
+# Added: 2026-07-12
+# Revisit by: 2026-08-15
+CVE-2026-39822

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -1,0 +1,33 @@
+package trivy
+
+default ignore = false
+
+# These suppressions stop applying automatically at the start of 2026-08-15 UTC.
+suppression_active {
+    time.now_ns() < time.parse_rfc3339_ns("2026-08-15T00:00:00Z")
+}
+
+# CVE-2026-39831 affects FIDO/U2F SSH security-key verification. The pinned
+# Transifex CLI uses this dependency only indirectly and talks to the Transifex
+# HTTPS API in this pipeline; it does not expose SSH authentication to users.
+ignore {
+    suppression_active
+    input.Type == "vulnerability"
+    input.VulnerabilityID == "CVE-2026-39831"
+    input.PkgName == "golang.org/x/crypto"
+    input.InstalledVersion == "v0.0.0-20210322153248-0c34fe9e7dc2"
+}
+
+# Trivy matches CVE-2026-39822 by Go compiler version. None of the exact gh,
+# yq, tx, or gosu releases in the image calls an affected os.Root API, and the
+# API did not exist in Go 1.16. Restrict the suppression to the stdlib versions
+# reported for those binaries so a finding in any other version remains visible.
+affected_os_root_versions := {"v1.16.15", "v1.24.6", "v1.26.4"}
+
+ignore {
+    suppression_active
+    input.Type == "vulnerability"
+    input.VulnerabilityID == "CVE-2026-39822"
+    input.PkgName == "stdlib"
+    input.InstalledVersion == affected_os_root_versions[_]
+}

--- a/tests/unit/test_build_verify_workflow.py
+++ b/tests/unit/test_build_verify_workflow.py
@@ -6,6 +6,8 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build-verify.yml"
 DEV_REQUIREMENTS = REPO_ROOT / "requirements-dev.txt"
+TRIVY_IGNORE = REPO_ROOT / ".trivyignore"
+TRIVY_IGNORE_POLICY = REPO_ROOT / ".trivyignore.rego"
 
 
 def _workflow():
@@ -75,3 +77,19 @@ def test_dev_requirements_pin_setuptools_for_hash_locked_install():
 
     assert "setuptools==" in locked_requirements
     assert "# setuptools" not in locked_requirements
+
+
+def test_trivy_vendor_suppressions_are_scoped_and_expire():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    global_ignores = TRIVY_IGNORE.read_text(encoding="utf-8")
+    policy = TRIVY_IGNORE_POLICY.read_text(encoding="utf-8")
+
+    assert "--ignore-policy /workspace/.trivyignore.rego" in workflow
+    assert "CVE-2026-39831" not in global_ignores
+    assert "CVE-2026-39822" not in global_ignores
+    assert 'input.VulnerabilityID == "CVE-2026-39831"' in policy
+    assert 'input.PkgName == "golang.org/x/crypto"' in policy
+    assert 'input.VulnerabilityID == "CVE-2026-39822"' in policy
+    assert 'input.PkgName == "stdlib"' in policy
+    assert "input.InstalledVersion == affected_os_root_versions[_]" in policy
+    assert 'time.parse_rfc3339_ns("2026-08-15T00:00:00Z")' in policy


### PR DESCRIPTION
## Problem

The `test-and-package (3.11)` job started failing on Trivy with a new
HIGH finding, which cascades into `build-and-verify`:

```text
golang.org/x/crypto  CVE-2026-39831  HIGH  fixed
  installed: v0.0.0-20210322153248-0c34fe9e7dc2  fixed: 0.52.0
  golang.org/x/crypto/ssh: security key bypass due to missing user presence check
```

After suppressing that unreachable finding, a newer Trivy database exposed a
second HIGH finding:

```text
stdlib  CVE-2026-39822  HIGH  fixed
  os.Root: Symlink following vulnerability allows directory traversal
```

These findings make fresh scans fail repo-wide, including otherwise unrelated
translation-review pull requests.

## Root cause

`CVE-2026-39831` is reported in the vendored Transifex CLI (`tx` v1.6.17,
built with Go 1.16.15). It affects FIDO/U2F SSH security-key verification.
This pipeline uses `tx` only with the Transifex HTTPS API and does not expose
SSH authentication or signature verification to untrusted users.

`CVE-2026-39822` is matched by embedded Go compiler version in `gh` v2.93.0,
`yq` v4.53.3, `tx` v1.6.17, and `gosu` 1.19. Inspection of those exact upstream
source releases found no call to `os.OpenInRoot`, `os.OpenRoot`, or an affected
`os.Root` method. The API did not exist in Go 1.16, making the `tx` match
necessarily unreachable. Trivy does not perform that symbol-level reachability
analysis.

## Change

- Add `.trivyignore.rego` with suppressions constrained by CVE, package name,
  and exact installed versions.
- Make both suppressions expire automatically at the start of 2026-08-15 UTC.
- Keep the existing legacy `.trivyignore` for prior decisions and pass the new
  policy separately through Trivy's `--ignore-policy` option.
- Add a regression test that prevents either CVE from returning to the global
  ignore file and verifies that the scoped policy remains wired into CI.

The latest upstream `tx`, `yq`, and `gosu` releases were checked on 2026-07-12;
none offers a release that changes the relevant result.

## Validation

- `python -m pytest -q tests/unit` -> 658 passed, 4 subtests passed.
- `python -m pytest -ra` -> 676 passed.
- Exact upstream sources checked for affected `os.Root` call sites:
  `cli/cli@v2.93.0`, `mikefarah/yq@v4.53.3`, `tianon/gosu@1.19`, and
  `transifex/cli@v1.6.17`.
- GitHub's container build and pinned Trivy 0.69.2 scan provide the effective
  policy-engine integration validation.

## Notes

PR #124 is red because it encountered the first finding before this suppression
was present. Once this PR lands and #124 is updated from `main`, its checks can
be rerun on the clean baseline.
