### PR TITLE
Guard action against unsafe PR contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ allow write tokens and workflow-created pull requests. The workflow-level
 sufficient if repository or organization settings keep the default token
 read-only.
 
+Run live translation from trusted `push` or `workflow_dispatch` workflows. For
+pull request checks, use dry-run mode with PR creation disabled and no model or
+signing secrets. Do not run live translation from `pull_request_target` or from
+`workflow_run` events triggered by pull request builds.
+
 Full guide: [docs/github-action.md](docs/github-action.md).
 
 ## Documentation

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,67 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate workflow context
+      shell: bash
+      env:
+        LOCALIZE_OPEN_PR: ${{ inputs.open-pr }}
+        LOCALIZE_DRY_RUN: ${{ inputs.dry-run }}
+        LOCALIZE_OPENAI_API_KEY_INPUT: ${{ inputs.openai-api-key }}
+        LOCALIZE_COMMIT_SIGNING_KEY_INPUT: ${{ inputs.commit-signing-key }}
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import json
+        import os
+        import sys
+        from pathlib import Path
+
+        event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+        event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+        open_pr = os.environ.get("LOCALIZE_OPEN_PR", "").lower() == "true"
+        dry_run = os.environ.get("LOCALIZE_DRY_RUN", "").lower() == "true"
+        has_sensitive_input = bool(os.environ.get("LOCALIZE_OPENAI_API_KEY_INPUT")) or bool(
+            os.environ.get("LOCALIZE_COMMIT_SIGNING_KEY_INPUT")
+        )
+
+        event = {}
+        if event_path:
+            path = Path(event_path)
+            if path.exists():
+                event = json.loads(path.read_text(encoding="utf-8"))
+
+        def fail(message: str) -> None:
+            print(f"::error::{message}")
+            sys.exit(1)
+
+        if event_name == "pull_request_target":
+            fail(
+                "Localize Pipeline must not run from pull_request_target. "
+                "Use push/workflow_dispatch for live translation, or pull_request "
+                "with dry-run:true and open-pr:false for untrusted PR checks."
+            )
+
+        if event_name == "workflow_run":
+            workflow_run = event.get("workflow_run") or {}
+            if workflow_run.get("event") == "pull_request":
+                fail(
+                    "Localize Pipeline must not run after a pull_request workflow_run. "
+                    "Trigger live translation from trusted push/workflow_dispatch runs instead."
+                )
+
+        if event_name == "pull_request":
+            pull_request = event.get("pull_request") or {}
+            head_repo = (pull_request.get("head") or {}).get("repo") or {}
+            repository = event.get("repository") or {}
+            if head_repo.get("full_name") != repository.get("full_name"):
+                if open_pr or has_sensitive_input or not dry_run:
+                    fail(
+                        "Fork pull_request runs may only use Localize Pipeline with "
+                        "dry-run:true, open-pr:false, and no secret inputs. Run live "
+                        "translation after merge or from a trusted manual workflow."
+                    )
+        PY
+
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
       with:

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -37,6 +37,11 @@ For a no-cost setup preview, add `dry-run: true`. The action still validates the
 config and discovery path, but the runtime skips model calls and translation
 writes.
 
+Do not run live translation from `pull_request_target` or from a `workflow_run`
+triggered by pull request builds. Those contexts can combine trusted repository
+secrets with untrusted PR code. Use `push` or `workflow_dispatch` for live
+translation PRs, and use the dry-run PR pattern below for untrusted PR checks.
+
 ## Recommended Rollout
 
 Use local runs for the initial locale baseline and use the GitHub Action for
@@ -182,12 +187,16 @@ path is used by local CLI runs and the Action.
 
 ## Pull Request Events
 
-For `pull_request` workflows, set `diff-base` to the PR base SHA:
+For `pull_request` workflows, use dry-run validation only. Set `diff-base` to
+the PR base SHA, disable PR creation, and do not pass model or signing secrets:
 
 ```yaml
 on:
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   translate:
@@ -200,8 +209,12 @@ jobs:
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          dry-run: true
+          open-pr: false
 ```
+
+Run the live translation workflow after the change is merged, or trigger it
+manually with `workflow_dispatch`.
 
 ## Inputs
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -143,9 +143,9 @@ charset-normalizer==3.4.2 \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
     # via requests
-click==8.2.1 \
-    --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
-    --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
+click==8.4.2 \
+    --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
+    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
     # via pip-tools
 cyclonedx-python-lib==9.1.0 \
     --hash=sha256:55693fca8edaecc3363b24af14e82cc6e659eb1e8353e58b587c42652ce0fb52 \

--- a/tests/unit/test_github_action.py
+++ b/tests/unit/test_github_action.py
@@ -77,6 +77,23 @@ def test_action_runs_preflight_check_before_translation(action):
     assert 'python -m localize.cli check --config "$TRANSLATOR_CONFIG_FILE"' in steps[preflight_index]["run"]
 
 
+def test_action_rejects_unsafe_pr_contexts_before_setup(action):
+    steps = action["runs"]["steps"]
+    guard = next(step for step in steps if step["name"] == "Validate workflow context")
+    setup_index = next(i for i, step in enumerate(steps) if step["name"] == "Set up Python")
+    guard_index = steps.index(guard)
+
+    assert guard_index == 0
+    assert guard_index < setup_index
+    assert guard["env"]["LOCALIZE_OPEN_PR"] == "${{ inputs.open-pr }}"
+    assert guard["env"]["LOCALIZE_DRY_RUN"] == "${{ inputs.dry-run }}"
+    assert guard["env"]["LOCALIZE_OPENAI_API_KEY_INPUT"] == "${{ inputs.openai-api-key }}"
+    assert guard["env"]["LOCALIZE_COMMIT_SIGNING_KEY_INPUT"] == "${{ inputs.commit-signing-key }}"
+    assert "pull_request_target" in guard["run"]
+    assert 'workflow_run.get("event") == "pull_request"' in guard["run"]
+    assert "Fork pull_request runs may only use Localize Pipeline" in guard["run"]
+
+
 def test_action_installs_dependencies_in_private_virtualenv(action):
     dependency_step = next(
         step for step in action["runs"]["steps"] if step["name"] == "Install pipeline dependencies"


### PR DESCRIPTION
## Summary

- Add a first-step safety guard to the marketplace composite action.
- Refuse `pull_request_target` and PR-triggered `workflow_run` contexts.
- Allow fork `pull_request` checks only when they are dry-run, do not open PRs, and do not receive model/signing secrets.
- Update the GitHub Action docs and README to recommend live translation only from trusted `push` or `workflow_dispatch` workflows.

## Why

The Localize Pipeline action itself does not use `actions/checkout`, so it is not directly affected by the Bisq2 `checkout@v7` failure. The risk is at the caller boundary: a user can wire the marketplace action into a privileged PR context after checking out untrusted PR code, then pass secrets and a write token to a workflow that opens pull requests.

The action cannot fully control how callers check out their repositories, but it can fail fast before installing dependencies, running translation, using model/signing secrets, or pushing generated changes.

## Verification

- Parsed `action.yml` as YAML locally.
- Ran `git diff --check`.
- Ran `tests/unit/test_github_action.py` with the project venv: 20 passed.
