### PR TITLE
Guard network seed and transport terminology

### DIFF
--- a/profiles/bisq-mobile/config.yaml
+++ b/profiles/bisq-mobile/config.yaml
@@ -81,6 +81,22 @@ semantic_quality_rules:
     forbidden_target_regex: "^Aucune information personnelle,\\s*comptes\\b"
     severity: "error"
     source: "bisq-mobile#1484 CodeRabbit"
+  - id: "network-seed-node-not-seed-phrase"
+    message: "On the Network connections screen 'Seed' labels a seed node (bootstrap peer), not a wallet recovery phrase; do not translate it as seed phrase/words."
+    locales: ["cs", "es", "ru", "id", "it", "vi"]
+    keys: ["mobile.networkInfo.connections.seed"]
+    forbidden_target_regex: "(Slova|Frase|фраза|Kata|Parole|khóa)"
+    regex_ignorecase: true
+    severity: "error"
+    source: "bisq-mobile#1606 CodeRabbit"
+  - id: "network-transport-not-physical-transport"
+    message: "On the Network screens 'Transport' is the network transport (e.g. Tor/clearnet), not physical transportation/shipping."
+    locales: ["af_ZA", "cs", "vi"]
+    keys: ["mobile.networkInfo.myNode.transport", "mobile.networkInfo.overview.transport"]
+    forbidden_target_regex: "(Vervoer|Doprava|Vận chuyển)"
+    regex_ignorecase: true
+    severity: "error"
+    source: "bisq-mobile#1606 CodeRabbit"
 supported_locales:
   - code: "af_ZA"
     name: "Afrikaans"

--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -205,6 +205,22 @@ semantic_quality_rules:
     forbidden_target_regex: 'வர்த்தக சகோதரர்'
     severity: "error"
     source: "bisq2#4835 CodeRabbit"
+  - id: "network-seed-node-not-seed-phrase"
+    message: "On the Network connections screen 'Seed' labels a seed node (bootstrap peer), not a wallet recovery phrase; do not translate it as seed phrase/words."
+    locales: ["cs", "es", "ru", "id", "it", "vi"]
+    keys: ["mobile.networkInfo.connections.seed"]
+    forbidden_target_regex: "(Slova|Frase|фраза|Kata|Parole|khóa)"
+    regex_ignorecase: true
+    severity: "error"
+    source: "bisq-mobile#1606 CodeRabbit"
+  - id: "network-transport-not-physical-transport"
+    message: "On the Network screens 'Transport' is the network transport (e.g. Tor/clearnet), not physical transportation/shipping."
+    locales: ["af_ZA", "cs", "vi"]
+    keys: ["mobile.networkInfo.myNode.transport", "mobile.networkInfo.overview.transport"]
+    forbidden_target_regex: "(Vervoer|Doprava|Vận chuyển)"
+    regex_ignorecase: true
+    severity: "error"
+    source: "bisq-mobile#1606 CodeRabbit"
 supported_locales:
   - code: "cs"
     name: "Czech"

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -5,6 +5,12 @@ import re
 import pytest
 import yaml
 
+from localize.semantic_quality import (
+    TranslationChange,
+    evaluate_semantic_rules,
+    load_semantic_rules,
+)
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 BISQ_PROFILE_CONFIG = PROJECT_ROOT / "profiles" / "bisq" / "config.yaml"
@@ -426,3 +432,100 @@ def test_preimage_is_a_protected_brand_technical_term():
     assert "Preimage" in brand_glossary
     # Sibling Lightning terms must remain protected so the family stays consistent.
     assert {"Lightning", "Lightning Escrow", "Submarine Swaps"}.issubset(set(brand_glossary))
+
+
+_NETWORK_RULE_IDS = {
+    "network-seed-node-not-seed-phrase",
+    "network-transport-not-physical-transport",
+}
+
+
+@pytest.mark.parametrize("config_path", [BISQ_MOBILE_PROFILE_CONFIG, BISQ_PROFILE_CONFIG])
+def test_network_terminology_rules_from_1606_are_encoded(config_path):
+    """bisq-mobile#1606 CodeRabbit flagged mistranslated Network labels.
+
+    Across six locales `mobile.networkInfo.connections.seed` (source "Seed",
+    meaning a seed node) was rendered as a wallet recovery phrase, e.g. Czech
+    "Seedová Slova", Spanish "Frase Semilla", Russian "Seed-фраза". In three
+    locales the transport labels (source "Transport", the network transport)
+    became physical transportation, e.g. Afrikaans "Vervoer", Czech "Doprava".
+    Both rules are mirrored into every profile like the other mobile nits.
+    """
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    rules_by_id = {rule["id"]: rule for rule in config.get("semantic_quality_rules", [])}
+    supported = {loc["code"] for loc in config["supported_locales"]}
+
+    assert _NETWORK_RULE_IDS.issubset(rules_by_id)
+    for rule_id in _NETWORK_RULE_IDS:
+        rule = rules_by_id[rule_id]
+        assert rule["source"] == "bisq-mobile#1606 CodeRabbit"
+        assert rule["severity"] == "error"
+        assert set(rule["locales"]) <= supported
+
+    seed_rule = rules_by_id["network-seed-node-not-seed-phrase"]
+    assert seed_rule["keys"] == ["mobile.networkInfo.connections.seed"]
+    transport_rule = rules_by_id["network-transport-not-physical-transport"]
+    assert set(transport_rule["keys"]) == {
+        "mobile.networkInfo.myNode.transport",
+        "mobile.networkInfo.overview.transport",
+    }
+
+
+def test_network_terminology_rules_flag_the_real_1606_mistranslations():
+    """The shipped mobile-profile rules must catch the merged bad values only."""
+    config = yaml.safe_load(BISQ_MOBILE_PROFILE_CONFIG.read_text(encoding="utf-8"))
+    rules = load_semantic_rules(config["semantic_quality_rules"])
+
+    def _seed(locale, value):
+        return TranslationChange(
+            file=f"mobile_{locale}.properties",
+            locale_code=locale,
+            key="mobile.networkInfo.connections.seed",
+            source_value="Seed",
+            old_value=None,
+            new_value=value,
+        )
+
+    def _transport(locale, value):
+        return TranslationChange(
+            file=f"mobile_{locale}.properties",
+            locale_code=locale,
+            key="mobile.networkInfo.myNode.transport",
+            source_value="Transport",
+            old_value=None,
+            new_value=value,
+        )
+
+    # Confirmed-wrong values from the merged PR must be flagged.
+    flagged = [
+        _seed("cs", "Seedová Slova"),
+        _seed("es", "Frase Semilla"),
+        _seed("ru", "Seed-фраза"),
+        _seed("id", "Kata Seed"),
+        _seed("it", "Parole Seed"),
+        _seed("vi", "Từ khóa seed"),
+        _transport("af_ZA", "Vervoer"),
+        _transport("cs", "Doprava"),
+        _transport("vi", "Vận chuyển"),
+    ]
+    flagged_ids = {
+        finding.key + "|" + finding.value
+        for finding in evaluate_semantic_rules(changes=flagged, rules=rules)
+    }
+    for change in flagged:
+        assert change.key + "|" + change.new_value in flagged_ids, change.new_value
+
+    # Correct network-node/transport wording must pass, as must out-of-scope
+    # locales that kept an acceptable rendering of the same source string.
+    clean = [
+        _seed("cs", "Seedový uzel"),
+        _seed("es", "Nodo semilla"),
+        _seed("ru", "Seed-узел"),
+        _seed("vi", "Nút seed"),
+        _seed("de", "Seed"),
+        _seed("pcm", "Seed node"),
+        _transport("af_ZA", "Transport"),
+        _transport("cs", "Přenos"),
+        _transport("de", "Transport"),
+    ]
+    assert evaluate_semantic_rules(changes=clean, rules=rules) == []


### PR DESCRIPTION
## Summary

Encodes two error-level `semantic_quality_rules` that guard against
mistranslations CodeRabbit flagged on **bisq-mobile#1606** (merged; the
maintainer explicitly asked for a CRAI follow-up). Both rules follow the
existing CodeRabbit-sourced rule convention and are mirrored into the
`bisq` and `bisq-mobile` profiles.

## Evidence (from the merged bisq-mobile#1606)

**1. `mobile.networkInfo.connections.seed` — source `Seed` (a seed node /
bootstrap peer) rendered as a wallet recovery phrase in 6 locales:**

| locale | merged value | meaning |
| --- | --- | --- |
| cs | `Seedová Slova` | "seed words" |
| es | `Frase Semilla` | "seed phrase" |
| ru | `Seed-фраза` | "seed phrase" |
| id | `Kata Seed` | "seed word" |
| it | `Parole Seed` | "seed words" |
| vi | `Từ khóa seed` | "seed keyword" |

(pcm correctly used `Seed node`; de/fr kept `Seed`.)

**2. `mobile.networkInfo.{myNode,overview}.transport` — source
`Transport` (network transport, e.g. Tor/clearnet) rendered as physical
transportation in 3 locales:** af_ZA `Vervoer`, cs `Doprava`, vi
`Vận chuyển`.

## Root cause

The model translates each short UI value without enough domain context to
disambiguate "Seed" (a P2P seed node) from a wallet seed phrase, or
"Transport" (network transport) from physical transport. The deterministic
semantic-quality gate is the established place to catch this class of
recurring, confirmed error.

## Change

Two rules added to `profiles/bisq-mobile/config.yaml` and
`profiles/bisq/config.yaml`:

- `network-seed-node-not-seed-phrase` — locales cs/es/ru/id/it/vi, key
  `mobile.networkInfo.connections.seed`, forbids the recovery-phrase
  wordings.
- `network-transport-not-physical-transport` — locales af_ZA/cs/vi, keys
  `mobile.networkInfo.{myNode,overview}.transport`, forbids the
  physical-transport wordings.

Forbidden regexes are scoped to the exact keys (each is the *only* key
with that English source) and matched (`regex_ignorecase`) only against
the wrong renderings. Verified they flag every merged bad value and pass
correct node/transport wordings, so valid translations are never blocked.
`semantic_qa_audit_scope: changed` means already-merged values are not
re-audited retroactively.

## Tests

- `venv/bin/pytest` → **681 passed**
- isolated `docker compose ... build translator` → **passed**
- isolated smoke-only container doctor → **Smoke OK**

## Pre-merge checklist

- [x] Requires `docker compose run --rm translator` build + local run
      before merge.

## Links

- Source PR: https://github.com/bisq-network/bisq-mobile/pull/1606


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translations for network-related “Seed” and “Transport” labels in Bisq and Bisq Mobile.
  * Prevented these terms from being incorrectly translated as wallet recovery phrases or physical transportation.
  * Applied terminology checks across supported locales to ensure clearer network settings and screens.

* **Tests**
  * Added validation to confirm incorrect translations are detected while approved translations continue to pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->