### PR TITLE
Guard against Vietnamese-fragment contamination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 - Require GitPython 3.1.55 or newer, refresh both lockfiles, and build GitHub
   CLI 2.96.0 with gRPC-Go 1.82.1 so dependency and image audits reject the
   July 2026 advisories.
+- Reject Vietnamese horn-vowel contamination in non-Vietnamese Bisq locales,
+  including canonically equivalent decomposed Unicode text.
 
 ### Changed
 

--- a/localize/semantic_quality.py
+++ b/localize/semantic_quality.py
@@ -6,6 +6,7 @@ import fnmatch
 import json
 import os
 import re
+import unicodedata
 from collections.abc import Iterable as IterableABC
 from collections.abc import Mapping as MappingABC
 from dataclasses import asdict, dataclass, field
@@ -474,9 +475,10 @@ def _matches_any(value: str, patterns: Sequence[str]) -> bool:
 
 
 def _regex_matches(pattern: str | Pattern[str], value: Optional[str]) -> bool:
+    normalized_value = unicodedata.normalize("NFC", value or "")
     if isinstance(pattern, re.Pattern):
-        return pattern.search(value or "") is not None
-    return re.search(pattern, value or "") is not None
+        return pattern.search(normalized_value) is not None
+    return re.search(pattern, normalized_value) is not None
 
 
 def evaluate_semantic_rules(

--- a/profiles/bisq-mobile/config.yaml
+++ b/profiles/bisq-mobile/config.yaml
@@ -97,6 +97,14 @@ semantic_quality_rules:
     regex_ignorecase: true
     severity: "error"
     source: "bisq-mobile#1606 CodeRabbit"
+  - id: "no-vietnamese-horn-vowels-outside-vi"
+    message: "Vietnamese horn vowels (ư/ơ and their tone-mark variants) must not appear outside the Vietnamese locale; they signal cross-language contamination such as the Yoruba 'dữdata' token that fused Vietnamese 'dữ' with English 'data'."
+    locales: ["*"]
+    excluded_locales: ["vi"]
+    keys: ["*"]
+    forbidden_target_regex: '[ưừứữửựƯỪỨỮỬỰơờớỡởợƠỜỚỠỞỢ]'
+    severity: "error"
+    source: "bisq2#4884 CodeRabbit"
 supported_locales:
   - code: "af_ZA"
     name: "Afrikaans"

--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -221,6 +221,14 @@ semantic_quality_rules:
     regex_ignorecase: true
     severity: "error"
     source: "bisq-mobile#1606 CodeRabbit"
+  - id: "no-vietnamese-horn-vowels-outside-vi"
+    message: "Vietnamese horn vowels (ư/ơ and their tone-mark variants) must not appear outside the Vietnamese locale; they signal cross-language contamination such as the Yoruba 'dữdata' token that fused Vietnamese 'dữ' with English 'data'."
+    locales: ["*"]
+    excluded_locales: ["vi"]
+    keys: ["*"]
+    forbidden_target_regex: '[ưừứữửựƯỪỨỮỬỰơờớỡởợƠỜỚỠỞỢ]'
+    severity: "error"
+    source: "bisq2#4884 CodeRabbit"
 supported_locales:
   - code: "cs"
     name: "Czech"

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 import re
 import tomllib
+import unicodedata
 
 from packaging.version import Version
 import pytest
@@ -598,6 +599,10 @@ def test_contamination_guard_flags_the_real_4884_token(config_path):
         "O lè tún bẹ̀rẹ̀ ohun èlò náà láti tún gba dữdata nẹ́tíwọ̀kì.",
     )
     findings = evaluate_semantic_rules(changes=[contaminated], rules=rules)
+    assert any(f.rule_id == _CONTAMINATION_RULE_ID for f in findings)
+
+    decomposed = _warning("yo", unicodedata.normalize("NFD", contaminated.new_value))
+    findings = evaluate_semantic_rules(changes=[decomposed], rules=rules)
     assert any(f.rule_id == _CONTAMINATION_RULE_ID for f in findings)
 
     # Legitimate Vietnamese (horn vowels expected) and a cleaned Yoruba value

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -548,3 +548,66 @@ def test_network_terminology_rules_flag_the_real_1606_mistranslations():
         _transport("de", "Transport"),
     ]
     assert evaluate_semantic_rules(changes=clean, rules=rules) == []
+
+
+_CONTAMINATION_RULE_ID = "no-vietnamese-horn-vowels-outside-vi"
+
+
+@pytest.mark.parametrize("config_path", [BISQ_PROFILE_CONFIG, BISQ_MOBILE_PROFILE_CONFIG])
+def test_cross_language_contamination_guard_is_encoded(config_path):
+    """bisq2#4884 CodeRabbit flagged a cross-language contamination token.
+
+    The merged Yoruba `bisqEasy.takeOffer.noMediatorAvailable.warning`
+    contained `dữdata`, fusing the Vietnamese word `dữ` (from vi's
+    "dữ liệu mạng" = network data) with English "data". Vietnamese horn
+    vowels never appear in any other Bisq target locale, so a locale-wide
+    guard (every locale except vi) catches this class of vi-fragment bleed.
+    The guard is mirrored into every profile like the other shared nits.
+    """
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    rules_by_id = {rule["id"]: rule for rule in config.get("semantic_quality_rules", [])}
+
+    assert _CONTAMINATION_RULE_ID in rules_by_id
+    rule = rules_by_id[_CONTAMINATION_RULE_ID]
+    assert rule["source"] == "bisq2#4884 CodeRabbit"
+    assert rule["severity"] == "error"
+    assert rule["locales"] == ["*"]
+    assert rule["excluded_locales"] == ["vi"]
+    assert rule["keys"] == ["*"]
+
+
+@pytest.mark.parametrize("config_path", [BISQ_PROFILE_CONFIG, BISQ_MOBILE_PROFILE_CONFIG])
+def test_contamination_guard_flags_the_real_4884_token(config_path):
+    """The guard must catch the merged Yoruba `dữdata` token but not clean vi."""
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    rules = load_semantic_rules(config["semantic_quality_rules"])
+
+    def _warning(locale, value):
+        return TranslationChange(
+            file=f"bisq_easy_{locale}.properties",
+            locale_code=locale,
+            key="bisqEasy.takeOffer.noMediatorAvailable.warning",
+            source_value="No mediator is currently available.",
+            old_value=None,
+            new_value=value,
+        )
+
+    # The merged contamination must be flagged in the affected (non-vi) locale.
+    contaminated = _warning(
+        "yo",
+        "O lè tún bẹ̀rẹ̀ ohun èlò náà láti tún gba dữdata nẹ́tíwọ̀kì.",
+    )
+    findings = evaluate_semantic_rules(changes=[contaminated], rules=rules)
+    assert any(f.rule_id == _CONTAMINATION_RULE_ID for f in findings)
+
+    # Legitimate Vietnamese (horn vowels expected) and a cleaned Yoruba value
+    # (no horn vowels) must both pass the guard.
+    clean = [
+        _warning("vi", "Bạn có thể thử khởi động lại ứng dụng để tải lại dữ liệu mạng."),
+        _warning("yo", "O lè tún bẹ̀rẹ̀ ohun èlò náà láti tún gba data nẹ́tíwọ̀kì."),
+    ]
+    clean_findings = [
+        f for f in evaluate_semantic_rules(changes=clean, rules=rules)
+        if f.rule_id == _CONTAMINATION_RULE_ID
+    ]
+    assert clean_findings == []


### PR DESCRIPTION
## Problem

The merged translation PR **bisq-network/bisq2#4884** ("Update
translations (163 changed values) in bisq_easy for 54 locales")
shipped a cross-language contamination token in the Yoruba file.

`i18n/src/main/resources/bisq_easy_yo.properties` →
`bisqEasy.takeOffer.noMediatorAvailable.warning`:

```
... O lè tún bẹ̀rẹ̀ ohun èlò náà láti tún gba dữdata nẹ́tíwọ̀kì. ...
```

The token **`dữdata`** fuses the Vietnamese word `dữ` (from vi's
`dữ liệu mạng` = "network data", visible in the vi rendering of the
same key) with the English word `data`. CodeRabbit flagged it as a
malformed mixed-language token that breaks the Yoruba sentence.

## Root cause

- Translation runs **per single value**, so the "No Mixed Languages"
  style guidance in the system prompt did not prevent a Vietnamese
  fragment from bleeding into a different locale's output.
- The file validator (`localize/translation_validator.py`) only
  checks encoding/mojibake/placeholders, not cross-script
  contamination, so the token passed the quality gate and merged.

## Change

Add one `semantic_quality_rule`, mirrored into both profiles
(`profiles/bisq/config.yaml`, `profiles/bisq-mobile/config.yaml`):

```yaml
- id: "no-vietnamese-horn-vowels-outside-vi"
  locales: ["*"]
  excluded_locales: ["vi"]
  keys: ["*"]
  forbidden_target_regex: '[ưừứữửựƯỪỨỮỬỰơờớỡởợƠỜỚỠỞỢ]'
  severity: "error"
  source: "bisq2#4884 CodeRabbit"
```

Vietnamese horn vowels (`ư`/`ơ` and their tone-mark variants) do not
occur in any other Bisq target locale, so forbidding them everywhere
except `vi` catches this class of vi-fragment bleed.

**False-positive check:** scanned every `.properties` file in the
bisq2 corpus (HEAD `0ddc29dae`). Horn vowels appear only in the
legitimate `*_vi.properties` files and in the single contaminated
`bisq_easy_yo.properties` line — zero false positives.

Scope note: this guards the specific, high-signal vi→other-locale
contamination class. It does not attempt a general two-script
detector (too false-positive-prone for one pass).

## Not included (documented for transparency)

The other 19 CodeRabbit nits on #4884 were **not** encoded:

- The dominant "without mediation" vs "without mediator" cluster
  (am, jv, kk, pt_BR, zh-Hans, zh-Hant, …) is **faithful to the
  English source**, which itself is inconsistent: line 375 says
  "take the offer without **mediation**" while the button (line 378)
  says "without **mediator**". Not a pipeline defect; fixing it means
  editing the bisq2 English source, which is out of scope.
- The genuine per-locale mistranslations (am "with mediation /
  discount", km "without harm") are isolated one-offs in a merged PR,
  not a recurring class, so no rule was added.

## Test results

- Added regression tests in `tests/unit/test_config_quality.py`
  (parametrized over both profiles): the guard flags the real
  `dữdata` token and lets legitimate Vietnamese + cleaned Yoruba
  values pass.
- `.venv/bin/pytest -q tests/unit` → **667 passed, 4 subtests passed**.

## Links

- Merged PR: https://github.com/bisq-network/bisq2/pull/4884
- CodeRabbit finding (yo): `bisq_easy_yo.properties` L337

---

- [ ] Requires `docker compose run --rm translator` build + local run before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject Vietnamese horn-vowel characters in non-Vietnamese translations.
  * Detection now works consistently with both composed and decomposed Unicode text.
  * Vietnamese translations remain supported without false positives.

* **Documentation**
  * Documented the new translation-quality safeguard in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->