### PR TITLE
Update GitPython and patch GitHub CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ### Fixed
 
-- Require GitPython 3.1.55 or newer and refresh both lockfiles so dependency
-  audits reject releases affected by the July 2026 GitPython advisories.
+- Require GitPython 3.1.55 or newer, refresh both lockfiles, and build GitHub
+  CLI 2.96.0 with gRPC-Go 1.82.1 so dependency and image audits reject the
+  July 2026 advisories.
 
 ## [0.1.7] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+### Fixed
+
+- Require GitPython 3.1.55 or newer and refresh both lockfiles so dependency
+  audits reject releases affected by the July 2026 GitPython advisories.
+
 ## [0.1.7] - 2026-07-13
 
 ### Fixed

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,20 @@
 FROM golang:1.26.4-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d11e9c270a8f85106203d AS gh-builder
 
-ARG GH_VERSION=2.93.0
+ARG GH_VERSION=2.96.0
+ARG GH_COMMIT=b300f2ec7ec9dc9addc39b2ad88c54097ded7ca0
+ARG GRPC_VERSION=1.82.1
 ENV CGO_ENABLED=0
 
-RUN GOBIN=/out go install github.com/cli/cli/v2/cmd/gh@v${GH_VERSION}
+WORKDIR /src/gh
+RUN git clone --depth 1 --branch "v${GH_VERSION}" \
+        https://github.com/cli/cli.git . && \
+    test "$(git rev-parse HEAD)" = "$GH_COMMIT" && \
+    go get "google.golang.org/grpc@v${GRPC_VERSION}" && \
+    GH_VERSION="${GH_VERSION}" go run script/build.go bin/gh && \
+    install -D bin/gh /out/gh
+RUN go version -m /out/gh > /tmp/gh-buildinfo && \
+    grep -E "google[.]golang[.]org/grpc[[:space:]]+v${GRPC_VERSION}([[:space:]]|$)" \
+        /tmp/gh-buildinfo
 
 FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
   "aiolimiter",
   "aisuite==0.1.14",
-  "GitPython",
+  "GitPython>=3.1.55",
   "httpx",
   "jsonschema",
   "openai",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -171,9 +171,9 @@ gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
     # via gitpython
-gitpython==3.1.50 \
-    --hash=sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc \
-    --hash=sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9
+gitpython==3.1.55 \
+    --hash=sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f \
+    --hash=sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e
     # via -r requirements.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ openai
 aisuite==0.1.14
 python-dotenv
 PyYAML
-GitPython
+GitPython>=3.1.55
 httpx
 tiktoken
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -141,9 +141,9 @@ gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
     # via gitpython
-gitpython==3.1.50 \
-    --hash=sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc \
-    --hash=sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9
+gitpython==3.1.55 \
+    --hash=sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f \
+    --hash=sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e
     # via -r requirements.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -1,7 +1,9 @@
 """Regression tests for production translation prompt guidance."""
 from pathlib import Path
 import re
+import tomllib
 
+from packaging.version import Version
 import pytest
 import yaml
 
@@ -41,6 +43,23 @@ def test_aisuite_is_packaged_as_primary_provider():
     assert in_match is not None
     assert txt_match is not None
     assert txt_match.group(1) == in_match.group(1)
+
+
+def test_gitpython_security_floor_is_consistent():
+    requirements_in = (PROJECT_ROOT / "requirements.in").read_text(encoding="utf-8")
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    floor_match = re.search(r"^GitPython>=(\S+)$", requirements_in, flags=re.MULTILINE)
+    assert floor_match is not None
+    floor = Version(floor_match.group(1))
+    assert floor >= Version("3.1.55")
+    assert f"GitPython>={floor}" in pyproject["project"]["dependencies"]
+
+    for lockfile in ["requirements.txt", "requirements-dev.txt"]:
+        locked = (PROJECT_ROOT / lockfile).read_text(encoding="utf-8")
+        locked_match = re.search(r"^gitpython==([^\s\\]+)", locked, flags=re.MULTILINE)
+        assert locked_match is not None
+        assert Version(locked_match.group(1)) >= floor
 
 
 def test_runtime_requirements_are_hash_pinned():

--- a/tests/unit/test_shell_packaging_scripts.py
+++ b/tests/unit/test_shell_packaging_scripts.py
@@ -98,6 +98,16 @@ def test_dockerfile_uses_orchestration_default_command():
     assert 'CMD ["/app/update-translations.sh"]' in dockerfile
 
 
+def test_dockerfile_builds_current_gh_with_fixed_grpc():
+    dockerfile = (REPO_ROOT / "docker" / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "ARG GH_VERSION=2.96.0" in dockerfile
+    assert "ARG GH_COMMIT=b300f2ec7ec9dc9addc39b2ad88c54097ded7ca0" in dockerfile
+    assert "ARG GRPC_VERSION=1.82.1" in dockerfile
+    assert 'test "$(git rev-parse HEAD)" = "$GH_COMMIT"' in dockerfile
+    assert 'go get "google.golang.org/grpc@v${GRPC_VERSION}"' in dockerfile
+
+
 def test_dockerignore_excludes_local_configs_and_agent_scratch():
     dockerignore = (REPO_ROOT / ".dockerignore").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- require GitPython 3.1.55 or newer in both direct dependency manifests
- regenerate runtime and development hash locks at GitPython 3.1.55
- build the latest GitHub CLI 2.96.0 from its verified release commit with gRPC-Go 1.82.1
- add regression coverage for dependency metadata, lockfile alignment, and container tool pins

This removes the GitPython advisories currently blocking every open PR and the new gRPC-Go advisory detected in the production image. Updating the layered pip manifests also retriggers GitHub's dependency graph using Dependabot's released fix for nested `-r`/`-c` requirement discovery.

## Validation
- `pytest -q` (683 passed, 4 subtests passed)
- `ruff check .`
- `pip-audit -r requirements.txt`
- `pip-audit -r requirements-dev.txt`
- `python -m build`
- production Docker image build
- container smoke: GitPython 3.1.55 and GitHub CLI 2.96.0
- CI-equivalent Trivy scan: zero HIGH or CRITICAL findings