### PR TITLE
Configure GPT-5.6 Terra review

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Key settings:
 | `translation_source` | `git` or `transifex`. New projects usually start with `git`. |
 | `model_provider` | `aisuite` by default; `openai_compatible` is the direct SDK fallback. |
 | `model_name`, `review_model_name` | Translation and review models. |
+| `review_reasoning_effort` | Optional reasoning effort for the holistic review model. |
+| `semantic_review.reasoning_effort` | Optional reasoning effort for the semantic review model. |
 | `api_base_url` | OpenAI-compatible endpoint, for example Ollama. |
 | `supported_locales` | Target locales. |
 | `project_context` | Product/domain context injected into prompts. |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -51,6 +51,7 @@ translation_source: "git"
 model_provider: "aisuite"           # Default AISuite-backed provider abstraction.
 model_name: "gpt-4o-mini"          # fast initial translation
 review_model_name: "gpt-4o"        # holistic review pass (set equal to model_name to save cost)
+# review_reasoning_effort: "none"   # reasoning-capable review models only
 
 # Optional semantic sidecar. If auto_apply_error_suggestions is true, only
 # error-level findings with concrete suggested_value are applied, and only after
@@ -58,6 +59,7 @@ review_model_name: "gpt-4o"        # holistic review pass (set equal to model_na
 # semantic_review:
 #   enabled: true
 #   model: "gpt-4o"
+#   reasoning_effort: "none"        # reasoning-capable semantic models only
 #   auto_apply_error_suggestions: false
 
 # (Optional) OpenAI-compatible endpoint. Point this at a local Ollama server to

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.26.4-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d1
 ARG GH_VERSION=2.96.0
 ARG GH_COMMIT=b300f2ec7ec9dc9addc39b2ad88c54097ded7ca0
 ARG GRPC_VERSION=1.82.1
+ARG X_TEXT_VERSION=0.40.0
 ENV CGO_ENABLED=0
 
 WORKDIR /src/gh
@@ -10,11 +11,32 @@ RUN git clone --depth 1 --branch "v${GH_VERSION}" \
         https://github.com/cli/cli.git . && \
     test "$(git rev-parse HEAD)" = "$GH_COMMIT" && \
     go get "google.golang.org/grpc@v${GRPC_VERSION}" && \
+    go get "golang.org/x/text@v${X_TEXT_VERSION}" && \
     GH_VERSION="${GH_VERSION}" go run script/build.go bin/gh && \
     install -D bin/gh /out/gh
 RUN go version -m /out/gh > /tmp/gh-buildinfo && \
     grep -E "google[.]golang[.]org/grpc[[:space:]]+v${GRPC_VERSION}([[:space:]]|$)" \
+        /tmp/gh-buildinfo && \
+    grep -E "golang[.]org/x/text[[:space:]]+v${X_TEXT_VERSION}([[:space:]]|$)" \
         /tmp/gh-buildinfo
+
+FROM golang:1.26.4-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d11e9c270a8f85106203d AS yq-builder
+
+ARG YQ_VERSION=4.53.3
+ARG YQ_COMMIT=1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d
+ARG X_TEXT_VERSION=0.40.0
+ENV CGO_ENABLED=0
+
+WORKDIR /src/yq
+RUN git clone --depth 1 --branch "v${YQ_VERSION}" \
+        https://github.com/mikefarah/yq.git . && \
+    test "$(git rev-parse HEAD)" = "$YQ_COMMIT" && \
+    go get "golang.org/x/text@v${X_TEXT_VERSION}" && \
+    go build -trimpath -ldflags="-s -w" -o /out/yq .
+RUN /out/yq --version && \
+    go version -m /out/yq > /tmp/yq-buildinfo && \
+    grep -E "golang[.]org/x/text[[:space:]]+v${X_TEXT_VERSION}([[:space:]]|$)" \
+        /tmp/yq-buildinfo
 
 FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
@@ -49,22 +71,8 @@ RUN apt-get update && \
 COPY --from=gh-builder /out/gh /usr/bin/gh
 RUN gh --version
 
-# Download and install yq for YAML processing
-RUN set -eux; \
-    YQ_VERSION=v4.53.3; \
-    YQ_ARCH="$(dpkg --print-architecture)"; \
-    YQ_BINARY="yq_linux_${YQ_ARCH}"; \
-    curl -sSL -o /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}"; \
-    if [ "$YQ_ARCH" = "amd64" ]; then \
-        YQ_SHA256="fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"; \
-    elif [ "$YQ_ARCH" = "arm64" ]; then \
-        YQ_SHA256="578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"; \
-    else \
-        echo "Unsupported architecture for yq: $YQ_ARCH" >&2; \
-        exit 1; \
-    fi; \
-    echo "$YQ_SHA256 /usr/bin/yq" | sha256sum -c -; \
-    chmod +x /usr/bin/yq
+COPY --from=yq-builder /out/yq /usr/bin/yq
+RUN yq --version
 
 # Download and install gosu for user switching
 RUN set -eux; \

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -23,6 +23,7 @@ override or secret.
 | `TRANSLATOR_PROFILE` | Docker Compose | Selects `profiles/<name>/config.yaml` and `profiles/<name>/glossary.json`. |
 | `OPENAI_BASE_URL` | Python pipeline, Action wrapper | Optional OpenAI-compatible API base URL. Blank values are unset by the Action wrapper. |
 | `REVIEW_MODEL_NAME` | Python pipeline, Action wrapper | Overrides the configured holistic/semantic review model. |
+| `REVIEW_REASONING_EFFORT` | Python pipeline | Overrides `review_reasoning_effort` for holistic review. |
 | `PROCESS_ALL_FILES` | Python pipeline, Action wrapper | When true, process all discoverable translation files rather than changed files only. |
 
 ## Runtime Controls

--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -26,7 +26,9 @@ from localize.model_provider import (
     ChatModelProvider,
     DEFAULT_MODEL_PROVIDER,
     ModelProviderConfigurationError,
+    REASONING_EFFORT_VALUES,
     create_model_provider,
+    normalize_reasoning_effort,
     normalize_model_provider_name,
     requires_openai_credentials,
 )
@@ -122,17 +124,6 @@ _PLACEHOLDER_PATHS = frozenset({
     "/path/to/your/git/repo",
     "/path/to/properties/files",
 })
-_REASONING_EFFORT_VALUES = frozenset({
-    "none",
-    "minimal",
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-    "max",
-})
-
-
 def validate_config(
     config: Dict[str, Any],
     *,
@@ -230,11 +221,11 @@ def validate_config(
     model_name = str(config.get("model_name") or "gpt-4")
     review_model_name = str(config.get("review_model_name") or model_name)
     review_reasoning_effort = str(config.get("review_reasoning_effort") or "").strip()
-    if review_reasoning_effort and review_reasoning_effort not in _REASONING_EFFORT_VALUES:
+    if review_reasoning_effort and review_reasoning_effort not in REASONING_EFFORT_VALUES:
         issues.append(ConfigIssue(
             "error",
             "review_reasoning_effort must be one of: "
-            + ", ".join(sorted(_REASONING_EFFORT_VALUES))
+            + ", ".join(sorted(REASONING_EFFORT_VALUES))
             + ".",
         ))
     model_provider_name = normalize_model_provider_name(
@@ -653,10 +644,10 @@ def load_app_config() -> AppConfig:
     )
     model_name = str(config.get('model_name') or 'gpt-4')
     review_model_name = review_model_env or str(config.get('review_model_name') or model_name)
-    review_reasoning_effort = (
+    review_reasoning_effort = normalize_reasoning_effort(
         review_reasoning_effort_env
-        or str(config.get('review_reasoning_effort') or '').strip()
-        or None
+        if review_reasoning_effort_env is not None
+        else config.get('review_reasoning_effort')
     )
     model_provider_name = normalize_model_provider_name(
         str(config.get('model_provider', DEFAULT_MODEL_PROVIDER) or DEFAULT_MODEL_PROVIDER)

--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -105,6 +105,7 @@ class AppConfig:
     localization_profiles: Tuple[LocalizationProfile, ...] = field(default_factory=lambda: (
         LocalizationProfile(JAVA_PROPERTIES_FORMAT, SUFFIX_LAYOUT),
     ))
+    review_reasoning_effort: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -120,6 +121,15 @@ _PLACEHOLDER_PATHS = frozenset({
     "/path/to/default/input_folder",
     "/path/to/your/git/repo",
     "/path/to/properties/files",
+})
+_REASONING_EFFORT_VALUES = frozenset({
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
 })
 
 
@@ -219,6 +229,14 @@ def validate_config(
     dry_run = dry_run_override if dry_run_override is not None else _as_bool(config.get("dry_run", False), False)
     model_name = str(config.get("model_name") or "gpt-4")
     review_model_name = str(config.get("review_model_name") or model_name)
+    review_reasoning_effort = str(config.get("review_reasoning_effort") or "").strip()
+    if review_reasoning_effort and review_reasoning_effort not in _REASONING_EFFORT_VALUES:
+        issues.append(ConfigIssue(
+            "error",
+            "review_reasoning_effort must be one of: "
+            + ", ".join(sorted(_REASONING_EFFORT_VALUES))
+            + ".",
+        ))
     model_provider_name = normalize_model_provider_name(
         str(config.get("model_provider", DEFAULT_MODEL_PROVIDER) or DEFAULT_MODEL_PROVIDER)
     )
@@ -598,11 +616,12 @@ def load_app_config() -> AppConfig:
     ):
         os.environ['TRANSLATION_FILTER_GLOB'] = config_filter_glob
     review_model_env = _non_empty_env('REVIEW_MODEL_NAME')
-    validation_config = (
-        {**config, 'review_model_name': review_model_env}
-        if review_model_env
-        else config
-    )
+    review_reasoning_effort_env = _non_empty_env('REVIEW_REASONING_EFFORT')
+    validation_config = dict(config)
+    if review_model_env:
+        validation_config['review_model_name'] = review_model_env
+    if review_reasoning_effort_env:
+        validation_config['review_reasoning_effort'] = review_reasoning_effort_env
 
     # Validate the configuration and surface actionable problems (non-fatal).
     _log_config_issues(
@@ -634,6 +653,11 @@ def load_app_config() -> AppConfig:
     )
     model_name = str(config.get('model_name') or 'gpt-4')
     review_model_name = review_model_env or str(config.get('review_model_name') or model_name)
+    review_reasoning_effort = (
+        review_reasoning_effort_env
+        or str(config.get('review_reasoning_effort') or '').strip()
+        or None
+    )
     model_provider_name = normalize_model_provider_name(
         str(config.get('model_provider', DEFAULT_MODEL_PROVIDER) or DEFAULT_MODEL_PROVIDER)
     )
@@ -804,4 +828,5 @@ def load_app_config() -> AppConfig:
         localization_format=localization_format,
         localization_layout=localization_layout,
         localization_profiles=localization_profiles,
+        review_reasoning_effort=review_reasoning_effort,
     )

--- a/localize/cost_estimator.py
+++ b/localize/cost_estimator.py
@@ -70,10 +70,18 @@ def estimate_run_cost(
     estimated_completion_tokens = completion_per_pass * _PASSES
 
     translate_cost = cost_for_tokens(
-        translate_model, prompt_per_pass, completion_per_pass, prices
+        translate_model,
+        prompt_per_pass,
+        completion_per_pass,
+        prices,
+        apply_long_context_pricing=False,
     )
     review_cost = cost_for_tokens(
-        review_model, prompt_per_pass, completion_per_pass, prices
+        review_model,
+        prompt_per_pass,
+        completion_per_pass,
+        prices,
+        apply_long_context_pricing=False,
     )
 
     if translate_cost is None or review_cost is None:

--- a/localize/json_response.py
+++ b/localize/json_response.py
@@ -14,6 +14,20 @@ def chat_json_mode_kwargs(provider: Any, model: str) -> dict[str, dict[str, str]
     return {}
 
 
+def chat_reasoning_effort_kwargs(
+    provider: Any,
+    model: str,
+    reasoning_effort: str | None,
+) -> dict[str, str]:
+    """Return reasoning effort only when configured and supported by the route."""
+    if not reasoning_effort:
+        return {}
+    capabilities = provider.capabilities_for_model(model)
+    if getattr(capabilities, "supports_reasoning_effort", False):
+        return {"reasoning_effort": reasoning_effort}
+    return {}
+
+
 def extract_json_object_text(response_text: str) -> str:
     """Extract the first balanced JSON object from raw or fenced model output."""
     stripped = response_text.strip()

--- a/localize/json_response.py
+++ b/localize/json_response.py
@@ -23,7 +23,11 @@ def chat_reasoning_effort_kwargs(
     if not reasoning_effort:
         return {}
     capabilities = provider.capabilities_for_model(model)
-    if getattr(capabilities, "supports_reasoning_effort", False):
+    supported_efforts = getattr(capabilities, "supported_reasoning_efforts", frozenset())
+    if (
+        getattr(capabilities, "supports_reasoning_effort", False)
+        and (not supported_efforts or reasoning_effort in supported_efforts)
+    ):
         return {"reasoning_effort": reasoning_effort}
     return {}
 

--- a/localize/model_provider.py
+++ b/localize/model_provider.py
@@ -28,6 +28,7 @@ _LOCAL_PROVIDER_PLACEHOLDER_KEY = "not-needed"
 DEFAULT_MODEL_PROVIDER = "aisuite"
 DEFAULT_AISUITE_PROVIDER = "openai"
 _AISUITE_OPENAI_ONLY_REQUEST_KWARGS = frozenset({
+    "reasoning_effort",
     "response_format",
 })
 _MODEL_PROVIDER_ALIASES = {
@@ -44,6 +45,7 @@ class ModelProviderCapabilities:
     provider_key: str
     supports_response_format: bool
     supports_completion_token_limit: bool = True
+    supports_reasoning_effort: bool = False
 
 
 class ModelProviderConfigurationError(RuntimeError):
@@ -86,7 +88,13 @@ class ChatModelProvider(Protocol):
     def record_response(self, model: str, response: Any) -> None:
         """Record token usage from a provider response."""
 
-    def write_usage_summary(self, path: str) -> None:
+    def write_usage_summary(
+        self,
+        path: str,
+        *,
+        merge_existing: bool = False,
+        stage_name: Optional[str] = None,
+    ) -> None:
         """Persist the accumulated provider usage summary."""
 
     def format_usage_summary(self) -> str:
@@ -199,6 +207,7 @@ def _aisuite_capabilities_for_model(model: str, default_provider: str) -> ModelP
         provider_key=provider_key,
         supports_response_format=provider_key == "openai",
         supports_completion_token_limit=True,
+        supports_reasoning_effort=provider_key == "openai",
     )
 
 
@@ -286,8 +295,18 @@ class OpenAICompatibleProvider:
     def record_response(self, model: str, response: Any) -> None:
         self._usage_tracker.record_response(model, response)
 
-    def write_usage_summary(self, path: str) -> None:
-        self._usage_tracker.write_json(path)
+    def write_usage_summary(
+        self,
+        path: str,
+        *,
+        merge_existing: bool = False,
+        stage_name: Optional[str] = None,
+    ) -> None:
+        self._usage_tracker.write_json(
+            path,
+            merge_existing=merge_existing,
+            stage_name=stage_name,
+        )
 
     def format_usage_summary(self) -> str:
         return self._usage_tracker.format_summary()
@@ -304,6 +323,7 @@ class OpenAICompatibleProvider:
             provider_key="openai_compatible",
             supports_response_format=True,
             supports_completion_token_limit=True,
+            supports_reasoning_effort=True,
         )
 
     def _status_code_from_exception(self, exc: Any) -> Optional[int]:

--- a/localize/model_provider.py
+++ b/localize/model_provider.py
@@ -31,6 +31,16 @@ _AISUITE_OPENAI_ONLY_REQUEST_KWARGS = frozenset({
     "reasoning_effort",
     "response_format",
 })
+REASONING_EFFORT_VALUES = frozenset({
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+})
+_OPENAI_REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
 _MODEL_PROVIDER_ALIASES = {
     "aisuite": "aisuite",
     "openai": "openai_compatible",
@@ -105,6 +115,17 @@ class ChatModelProvider(Protocol):
 
     def capabilities_for_model(self, model: str) -> ModelProviderCapabilities:
         """Return request capabilities for a configured model route."""
+
+
+def normalize_reasoning_effort(value: Any) -> Optional[str]:
+    """Return a supported reasoning effort, or disable an invalid value."""
+    normalized = str(value or "").strip()
+    return normalized if normalized in REASONING_EFFORT_VALUES else None
+
+
+def _openai_model_supports_reasoning_effort(model: str) -> bool:
+    bare_model = model.split(":", 1)[-1].strip().lower()
+    return bare_model.startswith(_OPENAI_REASONING_MODEL_PREFIXES)
 
 
 def normalize_model_provider_name(provider_name: str) -> str:
@@ -190,10 +211,23 @@ def _aisuite_provider_config(
     return dict(provider_config)
 
 
-def _sanitize_aisuite_request_kwargs(model: str, kwargs: Dict[str, Any], default_provider: str) -> Dict[str, Any]:
-    capabilities = _aisuite_capabilities_for_model(model, default_provider)
+def _sanitize_aisuite_request_kwargs(
+    model: str,
+    kwargs: Dict[str, Any],
+    default_provider: str,
+    *,
+    supports_openai_reasoning_effort: bool,
+) -> Dict[str, Any]:
+    capabilities = _aisuite_capabilities_for_model(
+        model,
+        default_provider,
+        supports_openai_reasoning_effort=supports_openai_reasoning_effort,
+    )
     if capabilities.supports_response_format:
-        return dict(kwargs)
+        sanitized = dict(kwargs)
+        if not capabilities.supports_reasoning_effort:
+            sanitized.pop("reasoning_effort", None)
+        return sanitized
     return {
         key: value
         for key, value in kwargs.items()
@@ -201,13 +235,22 @@ def _sanitize_aisuite_request_kwargs(model: str, kwargs: Dict[str, Any], default
     }
 
 
-def _aisuite_capabilities_for_model(model: str, default_provider: str) -> ModelProviderCapabilities:
+def _aisuite_capabilities_for_model(
+    model: str,
+    default_provider: str,
+    *,
+    supports_openai_reasoning_effort: bool,
+) -> ModelProviderCapabilities:
     provider_key = _aisuite_provider_key_for_model(model, default_provider)
     return ModelProviderCapabilities(
         provider_key=provider_key,
         supports_response_format=provider_key == "openai",
         supports_completion_token_limit=True,
-        supports_reasoning_effort=provider_key == "openai",
+        supports_reasoning_effort=(
+            provider_key == "openai"
+            and supports_openai_reasoning_effort
+            and _openai_model_supports_reasoning_effort(model)
+        ),
     )
 
 
@@ -224,10 +267,12 @@ class OpenAICompatibleProvider:
         client: Any,
         usage_tracker: Optional[UsageTracker] = None,
         prices: Optional[Dict[str, Dict[str, float]]] = None,
+        supports_openai_reasoning_effort: bool = False,
     ) -> None:
         self.client = client
         self._prices = prices if prices is not None else DEFAULT_PRICES
         self._usage_tracker = usage_tracker or UsageTracker(prices=self._prices)
+        self._supports_openai_reasoning_effort = supports_openai_reasoning_effort
 
     async def create_chat_completion(
         self,
@@ -323,7 +368,10 @@ class OpenAICompatibleProvider:
             provider_key="openai_compatible",
             supports_response_format=True,
             supports_completion_token_limit=True,
-            supports_reasoning_effort=True,
+            supports_reasoning_effort=(
+                self._supports_openai_reasoning_effort
+                and _openai_model_supports_reasoning_effort(model)
+            ),
         )
 
     def _status_code_from_exception(self, exc: Any) -> Optional[int]:
@@ -360,8 +408,14 @@ class AiSuiteProvider(OpenAICompatibleProvider):
         usage_tracker: Optional[UsageTracker] = None,
         prices: Optional[Dict[str, Dict[str, float]]] = None,
         default_provider: str = DEFAULT_AISUITE_PROVIDER,
+        supports_openai_reasoning_effort: bool = False,
     ) -> None:
-        super().__init__(client=client, usage_tracker=usage_tracker, prices=prices)
+        super().__init__(
+            client=client,
+            usage_tracker=usage_tracker,
+            prices=prices,
+            supports_openai_reasoning_effort=supports_openai_reasoning_effort,
+        )
         self.default_provider = default_provider
 
     def _provider_model_name(self, model: str) -> str:
@@ -385,6 +439,7 @@ class AiSuiteProvider(OpenAICompatibleProvider):
             provider_model_name,
             kwargs,
             self.default_provider,
+            supports_openai_reasoning_effort=self._supports_openai_reasoning_effort,
         )
 
         async def call_aisuite(**request_kwargs: Any) -> Any:
@@ -425,7 +480,11 @@ class AiSuiteProvider(OpenAICompatibleProvider):
         return exc_module.startswith("aisuite") or exc_name == "LLMError"
 
     def capabilities_for_model(self, model: str) -> ModelProviderCapabilities:
-        return _aisuite_capabilities_for_model(self._provider_model_name(model), self.default_provider)
+        return _aisuite_capabilities_for_model(
+            self._provider_model_name(model),
+            self.default_provider,
+            supports_openai_reasoning_effort=self._supports_openai_reasoning_effort,
+        )
 
 
 def create_openai_compatible_provider(
@@ -460,7 +519,10 @@ def create_openai_compatible_provider(
 
     client = AsyncOpenAI(**client_kwargs)
     logger.info("OpenAI-compatible model provider initialized successfully")
-    return OpenAICompatibleProvider(client=client)
+    return OpenAICompatibleProvider(
+        client=client,
+        supports_openai_reasoning_effort=not is_custom_endpoint,
+    )
 
 
 def create_aisuite_provider(
@@ -468,6 +530,7 @@ def create_aisuite_provider(
     provider_configs: Dict[str, Any],
     logger: logging.Logger,
     default_provider: str = DEFAULT_AISUITE_PROVIDER,
+    supports_openai_reasoning_effort: bool = False,
 ) -> AiSuiteProvider:
     """Create the AISuite-backed provider used by the default runtime path."""
     try:
@@ -479,7 +542,11 @@ def create_aisuite_provider(
 
     client = aisuite.Client(provider_configs=provider_configs)
     logger.info("AISuite model provider initialized successfully")
-    return AiSuiteProvider(client=client, default_provider=default_provider)
+    return AiSuiteProvider(
+        client=client,
+        default_provider=default_provider,
+        supports_openai_reasoning_effort=supports_openai_reasoning_effort,
+    )
 
 
 def _openai_provider_config(
@@ -543,6 +610,9 @@ def create_model_provider(
             provider_configs=provider_configs,
             logger=logger,
             default_provider=DEFAULT_AISUITE_PROVIDER,
+            supports_openai_reasoning_effort=not bool(
+                openai_provider_config.get("base_url")
+            ),
         )
     raise ModelProviderConfigurationError(
         f"Unsupported model_provider '{provider_name}'. Supported values: openai_compatible, aisuite."

--- a/localize/model_provider.py
+++ b/localize/model_provider.py
@@ -40,7 +40,15 @@ REASONING_EFFORT_VALUES = frozenset({
     "xhigh",
     "max",
 })
-_OPENAI_REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+_GPT56_REASONING_EFFORTS = frozenset({
+    "none", "low", "medium", "high", "xhigh", "max",
+})
+_GPT54_55_REASONING_EFFORTS = frozenset({
+    "none", "low", "medium", "high", "xhigh",
+})
+_GPT51_REASONING_EFFORTS = frozenset({"none", "low", "medium", "high"})
+_GPT5_REASONING_EFFORTS = frozenset({"minimal", "low", "medium", "high"})
+_GPT_PRO_REASONING_EFFORTS = frozenset({"medium", "high", "xhigh"})
 _MODEL_PROVIDER_ALIASES = {
     "aisuite": "aisuite",
     "openai": "openai_compatible",
@@ -56,6 +64,7 @@ class ModelProviderCapabilities:
     supports_response_format: bool
     supports_completion_token_limit: bool = True
     supports_reasoning_effort: bool = False
+    supported_reasoning_efforts: frozenset[str] = frozenset()
 
 
 class ModelProviderConfigurationError(RuntimeError):
@@ -123,9 +132,25 @@ def normalize_reasoning_effort(value: Any) -> Optional[str]:
     return normalized if normalized in REASONING_EFFORT_VALUES else None
 
 
-def _openai_model_supports_reasoning_effort(model: str) -> bool:
+def _openai_supported_reasoning_efforts(model: str) -> frozenset[str]:
+    """Return documented effort values for an OpenAI model family."""
     bare_model = model.split(":", 1)[-1].strip().lower()
-    return bare_model.startswith(_OPENAI_REASONING_MODEL_PREFIXES)
+    if bare_model.startswith("gpt-5.6"):
+        return _GPT56_REASONING_EFFORTS
+    if bare_model.startswith(("gpt-5.5-pro", "gpt-5.4-pro", "gpt-5.2-pro")):
+        return _GPT_PRO_REASONING_EFFORTS
+    if bare_model.startswith("gpt-5-pro"):
+        return frozenset({"high"})
+    if bare_model.startswith(("gpt-5.5", "gpt-5.4", "gpt-5.2")):
+        return _GPT54_55_REASONING_EFFORTS
+    if bare_model.startswith("gpt-5.1"):
+        return _GPT51_REASONING_EFFORTS
+    if (
+        bare_model == "gpt-5"
+        or bare_model.startswith(("gpt-5-", "gpt-5-mini", "gpt-5-nano"))
+    ):
+        return _GPT5_REASONING_EFFORTS
+    return frozenset()
 
 
 def normalize_model_provider_name(provider_name: str) -> str:
@@ -225,7 +250,11 @@ def _sanitize_aisuite_request_kwargs(
     )
     if capabilities.supports_response_format:
         sanitized = dict(kwargs)
-        if not capabilities.supports_reasoning_effort:
+        reasoning_effort = sanitized.get("reasoning_effort")
+        if reasoning_effort is not None and (
+            not capabilities.supports_reasoning_effort
+            or reasoning_effort not in capabilities.supported_reasoning_efforts
+        ):
             sanitized.pop("reasoning_effort", None)
         return sanitized
     return {
@@ -242,15 +271,17 @@ def _aisuite_capabilities_for_model(
     supports_openai_reasoning_effort: bool,
 ) -> ModelProviderCapabilities:
     provider_key = _aisuite_provider_key_for_model(model, default_provider)
+    reasoning_efforts = (
+        _openai_supported_reasoning_efforts(model)
+        if provider_key == "openai" and supports_openai_reasoning_effort
+        else frozenset()
+    )
     return ModelProviderCapabilities(
         provider_key=provider_key,
         supports_response_format=provider_key == "openai",
         supports_completion_token_limit=True,
-        supports_reasoning_effort=(
-            provider_key == "openai"
-            and supports_openai_reasoning_effort
-            and _openai_model_supports_reasoning_effort(model)
-        ),
+        supports_reasoning_effort=bool(reasoning_efforts),
+        supported_reasoning_efforts=reasoning_efforts,
     )
 
 
@@ -285,6 +316,14 @@ class OpenAICompatibleProvider:
         if self.client is None:
             raise ModelProviderConfigurationError("OpenAI-compatible client is not configured.")
 
+        capabilities = self.capabilities_for_model(model)
+        reasoning_effort = kwargs.get("reasoning_effort")
+        if reasoning_effort is not None and (
+            not capabilities.supports_reasoning_effort
+            or reasoning_effort not in capabilities.supported_reasoning_efforts
+        ):
+            kwargs = dict(kwargs)
+            kwargs.pop("reasoning_effort", None)
         response = await create_chat_completion(
             self.client,
             model=model,
@@ -364,14 +403,17 @@ class OpenAICompatibleProvider:
         return False
 
     def capabilities_for_model(self, model: str) -> ModelProviderCapabilities:
+        reasoning_efforts = (
+            _openai_supported_reasoning_efforts(model)
+            if self._supports_openai_reasoning_effort
+            else frozenset()
+        )
         return ModelProviderCapabilities(
             provider_key="openai_compatible",
             supports_response_format=True,
             supports_completion_token_limit=True,
-            supports_reasoning_effort=(
-                self._supports_openai_reasoning_effort
-                and _openai_model_supports_reasoning_effort(model)
-            ),
+            supports_reasoning_effort=bool(reasoning_efforts),
+            supported_reasoning_efforts=reasoning_efforts,
         )
 
     def _status_code_from_exception(self, exc: Any) -> Optional[int]:

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -34,7 +34,11 @@ from tqdm.asyncio import tqdm
 from localize.app_config import load_app_config
 from localize.atomic_io import write_json_atomic, write_text_atomic
 from localize.ignore_keys import is_ignored_key
-from localize.json_response import chat_json_mode_kwargs, loads_json_object
+from localize.json_response import (
+    chat_json_mode_kwargs,
+    chat_reasoning_effort_kwargs,
+    loads_json_object,
+)
 from localize.localization_adapters import (
     get_localization_adapter,
     lint_properties_file as lint_properties_file,
@@ -93,6 +97,7 @@ INPUT_FOLDER = config.input_folder
 GLOSSARY_FILE_PATH = config.glossary_file_path
 MODEL_NAME = config.model_name
 REVIEW_MODEL_NAME = config.review_model_name
+REVIEW_REASONING_EFFORT = config.review_reasoning_effort
 MAX_MODEL_TOKENS = config.max_model_tokens
 DRY_RUN = config.dry_run
 PROCESS_ALL_FILES = config.process_all_files
@@ -1491,6 +1496,11 @@ async def holistic_review_async(
             try:
                 async with rate_limiter:
                     review_json_kwargs = chat_json_mode_kwargs(MODEL_PROVIDER, REVIEW_MODEL_NAME)
+                    review_reasoning_kwargs = chat_reasoning_effort_kwargs(
+                        MODEL_PROVIDER,
+                        REVIEW_MODEL_NAME,
+                        REVIEW_REASONING_EFFORT,
+                    )
                     response = await MODEL_PROVIDER.create_chat_completion(
                         model=REVIEW_MODEL_NAME,
                         messages=[
@@ -1499,6 +1509,7 @@ async def holistic_review_async(
                         ],
                         temperature=0.1,
                         **review_json_kwargs,
+                        **review_reasoning_kwargs,
                         completion_token_limit=_holistic_review_completion_token_limit(keys_to_review),
                         timeout=120.0,
                     )
@@ -2795,7 +2806,10 @@ def write_token_usage_summary(summary_path: str) -> None:
     """Persist and log token usage for the current run."""
     try:
         provider = MODEL_PROVIDER or _FALLBACK_PROVIDER
-        provider.write_usage_summary(summary_path)
+        provider.write_usage_summary(
+            summary_path,
+            stage_name="translation_and_holistic_review",
+        )
         for line in provider.format_usage_summary().splitlines():
             logger.info(line)
         logger.info(f"Wrote token usage summary to {summary_path}")

--- a/localize/translation_semantic_reviewer.py
+++ b/localize/translation_semantic_reviewer.py
@@ -14,7 +14,11 @@ import jsonschema
 import yaml
 from openai.types.chat import ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam
 
-from localize.json_response import chat_json_mode_kwargs, loads_json_object
+from localize.json_response import (
+    chat_json_mode_kwargs,
+    chat_reasoning_effort_kwargs,
+    loads_json_object,
+)
 from localize.model_provider import (
     ChatModelProvider,
     DEFAULT_MODEL_PROVIDER,
@@ -290,6 +294,7 @@ async def review_translation_changes(
     brand_glossary: Sequence[str],
     model_provider: Optional[ChatModelProvider] = None,
     failed_batches: Optional[List[str]] = None,
+    reasoning_effort: Optional[str] = None,
 ) -> List[Dict[str, str]]:
     if not changes:
         return []
@@ -306,6 +311,7 @@ async def review_translation_changes(
                     changes=batch,
                     style_rules=style_rules,
                     brand_glossary=brand_glossary,
+                    reasoning_effort=reasoning_effort,
                 )
             )
         except Exception as exc:
@@ -326,6 +332,7 @@ async def _review_translation_change_batch(
     changes: Sequence[TranslationChange],
     style_rules: Sequence[str],
     brand_glossary: Sequence[str],
+    reasoning_effort: Optional[str],
 ) -> List[Dict[str, str]]:
     messages = build_semantic_review_messages(
         target_language=target_language,
@@ -341,6 +348,7 @@ async def _review_translation_change_batch(
         ],
         temperature=0,
         **chat_json_mode_kwargs(provider, model),
+        **chat_reasoning_effort_kwargs(provider, model, reasoning_effort),
         completion_token_limit=4096,
         timeout=120.0,
     )
@@ -365,6 +373,7 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
     parser.add_argument("--input-folder", required=True)
     parser.add_argument("--config", required=True)
     parser.add_argument("--validation-summary", required=True)
+    parser.add_argument("--token-usage-summary")
     parser.add_argument("--changed-files", nargs="+", required=True)
     return parser.parse_args(argv)
 
@@ -407,6 +416,10 @@ async def _run(argv: Optional[Sequence[str]]) -> int:
             config.get("review_model_name", config.get("model_name", "gpt-4o")),
         )
     )
+    reasoning_effort = (
+        str(semantic_review_config.get("reasoning_effort") or "").strip()
+        or None
+    )
     provider_name = str(config.get("model_provider", DEFAULT_MODEL_PROVIDER) or DEFAULT_MODEL_PROVIDER)
     api_base_url = os.environ.get("OPENAI_BASE_URL") or config.get("api_base_url")
     aisuite_config = config.get("aisuite", {}) or {}
@@ -441,6 +454,7 @@ async def _run(argv: Optional[Sequence[str]]) -> int:
                 brand_glossary=brand_glossary,
                 model_provider=provider,
                 failed_batches=failed_batches,
+                reasoning_effort=reasoning_effort,
             )
 
     locale_results = await asyncio.gather(
@@ -483,6 +497,18 @@ async def _run(argv: Optional[Sequence[str]]) -> int:
         ]
 
     append_semantic_review_findings(args.validation_summary, findings)
+    if args.token_usage_summary:
+        try:
+            provider.write_usage_summary(
+                args.token_usage_summary,
+                merge_existing=True,
+                stage_name="semantic_review",
+            )
+        except Exception:
+            logger.exception(
+                "Failed to merge semantic review usage into %s",
+                args.token_usage_summary,
+            )
     return 0
 
 

--- a/localize/translation_semantic_reviewer.py
+++ b/localize/translation_semantic_reviewer.py
@@ -25,6 +25,7 @@ from localize.model_provider import (
     ModelProviderConfigurationError,
     OpenAICompatibleProvider,
     create_model_provider,
+    normalize_reasoning_effort,
 )
 from localize.semantic_quality import (
     TranslationChange,
@@ -298,7 +299,10 @@ async def review_translation_changes(
 ) -> List[Dict[str, str]]:
     if not changes:
         return []
-    provider = model_provider or OpenAICompatibleProvider(client=client)
+    provider = model_provider or OpenAICompatibleProvider(
+        client=client,
+        supports_openai_reasoning_effort=True,
+    )
     findings: List[Dict[str, str]] = []
     for start in range(0, len(changes), SEMANTIC_REVIEW_BATCH_SIZE):
         batch = list(changes[start:start + SEMANTIC_REVIEW_BATCH_SIZE])
@@ -416,9 +420,8 @@ async def _run(argv: Optional[Sequence[str]]) -> int:
             config.get("review_model_name", config.get("model_name", "gpt-4o")),
         )
     )
-    reasoning_effort = (
-        str(semantic_review_config.get("reasoning_effort") or "").strip()
-        or None
+    reasoning_effort = normalize_reasoning_effort(
+        semantic_review_config.get("reasoning_effort")
     )
     provider_name = str(config.get("model_provider", DEFAULT_MODEL_PROVIDER) or DEFAULT_MODEL_PROVIDER)
     api_base_url = os.environ.get("OPENAI_BASE_URL") or config.get("api_base_url")

--- a/localize/usage_tracker.py
+++ b/localize/usage_tracker.py
@@ -255,24 +255,26 @@ class UsageTracker:
         merge_existing: bool = False,
         stage_name: Optional[str] = None,
     ) -> None:
-        """Write usage, optionally merging an earlier stage and stage subtotal."""
+        """Write usage, optionally merging totals and preserving stage subtotals."""
         current_summary = self.summary()
         payload = current_summary
         stages: Dict[str, Any] = {}
-        if merge_existing:
+        existing_summary: Dict[str, Any] = {}
+        if merge_existing or stage_name:
             try:
                 with open(path, "r", encoding="utf-8") as file:
                     existing_summary = json.load(file)
             except FileNotFoundError:
                 existing_summary = {}
+        if merge_existing:
             combined = UsageTracker(prices=self._prices)
             combined.merge_summary(existing_summary)
             combined.merge_summary(current_summary)
             payload = combined.summary()
+        if stage_name:
             raw_stages = existing_summary.get("stages", {})
             if isinstance(raw_stages, dict):
                 stages = dict(raw_stages)
-        if stage_name:
             stage = UsageTracker(prices=self._prices)
             if stage_name in stages:
                 stage.merge_summary(stages[stage_name])

--- a/localize/usage_tracker.py
+++ b/localize/usage_tracker.py
@@ -20,17 +20,25 @@ from localize.atomic_io import write_json_atomic
 
 # USD per 1,000,000 tokens. Verify against current OpenAI pricing before relying.
 DEFAULT_PRICES: Dict[str, Dict[str, float]] = {
-    "gpt-5.6": {"input": 5.00, "output": 30.00},
-    "gpt-5.6-sol": {"input": 5.00, "output": 30.00},
-    "gpt-5.6-terra": {"input": 2.50, "output": 15.00},
-    "gpt-5.6-luna": {"input": 1.00, "output": 6.00},
-    "gpt-5.5": {"input": 5.00, "output": 30.00},
-    "gpt-5.4": {"input": 2.50, "output": 15.00},
-    "gpt-5.4-mini": {"input": 0.75, "output": 4.50},
-    "gpt-5.4-nano": {"input": 0.20, "output": 1.25},
+    "gpt-5.6": {
+        "input": 5.00, "cached_input": 0.50, "cache_write": 6.25, "output": 30.00,
+    },
+    "gpt-5.6-sol": {
+        "input": 5.00, "cached_input": 0.50, "cache_write": 6.25, "output": 30.00,
+    },
+    "gpt-5.6-terra": {
+        "input": 2.50, "cached_input": 0.25, "cache_write": 3.125, "output": 15.00,
+    },
+    "gpt-5.6-luna": {
+        "input": 1.00, "cached_input": 0.10, "cache_write": 1.25, "output": 6.00,
+    },
+    "gpt-5.5": {"input": 5.00, "cached_input": 0.50, "output": 30.00},
+    "gpt-5.4": {"input": 2.50, "cached_input": 0.25, "output": 15.00},
+    "gpt-5.4-mini": {"input": 0.75, "cached_input": 0.075, "output": 4.50},
+    "gpt-5.4-nano": {"input": 0.20, "cached_input": 0.02, "output": 1.25},
     "gpt-5.4-pro": {"input": 30.00, "output": 180.00},
-    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
-    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "gpt-4o-mini": {"input": 0.15, "cached_input": 0.075, "output": 0.60},
+    "gpt-4o": {"input": 2.50, "cached_input": 1.25, "output": 10.00},
     "gpt-4": {"input": 30.00, "output": 60.00},
     "gpt-4-turbo": {"input": 10.00, "output": 30.00},
 }
@@ -49,6 +57,9 @@ def cost_for_tokens(
     prompt_tokens: int,
     completion_tokens: int,
     prices: Optional[Dict[str, Dict[str, float]]] = None,
+    *,
+    cached_tokens: int = 0,
+    cache_write_tokens: int = 0,
 ) -> Optional[float]:
     """USD cost for token counts, or ``None`` if ``model`` has no known price.
 
@@ -61,8 +72,19 @@ def cost_for_tokens(
         price = table.get(_price_lookup_model(model))
     if price is None:
         return None
+    cached_tokens = max(0, min(int(cached_tokens or 0), prompt_tokens))
+    remaining_prompt_tokens = prompt_tokens - cached_tokens
+    cache_write_tokens = max(
+        0,
+        min(int(cache_write_tokens or 0), remaining_prompt_tokens),
+    )
+    uncached_tokens = remaining_prompt_tokens - cache_write_tokens
+    cached_input_price = price.get("cached_input", price["input"])
+    cache_write_price = price.get("cache_write", price["input"])
     return (
-        prompt_tokens / 1_000_000 * price["input"]
+        uncached_tokens / 1_000_000 * price["input"]
+        + cached_tokens / 1_000_000 * cached_input_price
+        + cache_write_tokens / 1_000_000 * cache_write_price
         + completion_tokens / 1_000_000 * price["output"]
     )
 
@@ -72,6 +94,8 @@ class _ModelUsage:
     calls: int = 0
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    cached_tokens: int = 0
+    cache_write_tokens: int = 0
 
 
 class UsageTracker:
@@ -100,27 +124,49 @@ class UsageTracker:
             entry.calls += int(raw_usage.get("calls", 0) or 0)
             entry.prompt_tokens += int(raw_usage.get("prompt_tokens", 0) or 0)
             entry.completion_tokens += int(raw_usage.get("completion_tokens", 0) or 0)
+            entry.cached_tokens += int(raw_usage.get("cached_tokens", 0) or 0)
+            entry.cache_write_tokens += int(raw_usage.get("cache_write_tokens", 0) or 0)
 
-    def record(self, model: str, prompt_tokens: int, completion_tokens: int) -> None:
+    def record(
+        self,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        *,
+        cached_tokens: int = 0,
+        cache_write_tokens: int = 0,
+    ) -> None:
         """Add one API call's token counts for ``model``."""
         entry = self._by_model.setdefault(model, _ModelUsage())
         entry.calls += 1
         entry.prompt_tokens += int(prompt_tokens or 0)
         entry.completion_tokens += int(completion_tokens or 0)
+        entry.cached_tokens += int(cached_tokens or 0)
+        entry.cache_write_tokens += int(cache_write_tokens or 0)
 
     def record_response(self, model: str, response: Any) -> None:
         """Record usage from an OpenAI ChatCompletion response (no-op if absent)."""
         usage = getattr(response, "usage", None)
         if usage is None:
             return
+        prompt_details = getattr(usage, "prompt_tokens_details", None)
         self.record(
             model,
             getattr(usage, "prompt_tokens", 0) or 0,
             getattr(usage, "completion_tokens", 0) or 0,
+            cached_tokens=getattr(prompt_details, "cached_tokens", 0) or 0,
+            cache_write_tokens=getattr(prompt_details, "cache_write_tokens", 0) or 0,
         )
 
-    def _model_cost(self, model: str, prompt_tokens: int, completion_tokens: int) -> Optional[float]:
-        return cost_for_tokens(model, prompt_tokens, completion_tokens, self._prices)
+    def _model_cost(self, model: str, usage: _ModelUsage) -> Optional[float]:
+        return cost_for_tokens(
+            model,
+            usage.prompt_tokens,
+            usage.completion_tokens,
+            self._prices,
+            cached_tokens=usage.cached_tokens,
+            cache_write_tokens=usage.cache_write_tokens,
+        )
 
     def summary(self) -> Dict[str, Any]:
         """Return a structured summary of usage and estimated cost."""
@@ -129,7 +175,7 @@ class UsageTracker:
         total_cost = 0.0
         cost_known = True
         for model, u in sorted(self._by_model.items()):
-            cost = self._model_cost(model, u.prompt_tokens, u.completion_tokens)
+            cost = self._model_cost(model, u)
             if cost is None:
                 cost_known = False
             else:
@@ -138,6 +184,8 @@ class UsageTracker:
                 "calls": u.calls,
                 "prompt_tokens": u.prompt_tokens,
                 "completion_tokens": u.completion_tokens,
+                "cached_tokens": u.cached_tokens,
+                "cache_write_tokens": u.cache_write_tokens,
                 "total_tokens": u.prompt_tokens + u.completion_tokens,
                 "estimated_cost_usd": round(cost, 6) if cost is not None else None,
             }

--- a/localize/usage_tracker.py
+++ b/localize/usage_tracker.py
@@ -28,6 +28,9 @@ DEFAULT_PRICES: Dict[str, Dict[str, float]] = {
     },
     "gpt-5.6-terra": {
         "input": 2.50, "cached_input": 0.25, "cache_write": 3.125, "output": 15.00,
+        "long_context_threshold": 272_000,
+        "long_context_input_multiplier": 2.0,
+        "long_context_output_multiplier": 1.5,
     },
     "gpt-5.6-luna": {
         "input": 1.00, "cached_input": 0.10, "cache_write": 1.25, "output": 6.00,
@@ -60,6 +63,7 @@ def cost_for_tokens(
     *,
     cached_tokens: int = 0,
     cache_write_tokens: int = 0,
+    apply_long_context_pricing: bool = True,
 ) -> Optional[float]:
     """USD cost for token counts, or ``None`` if ``model`` has no known price.
 
@@ -81,11 +85,20 @@ def cost_for_tokens(
     uncached_tokens = remaining_prompt_tokens - cache_write_tokens
     cached_input_price = price.get("cached_input", price["input"])
     cache_write_price = price.get("cache_write", price["input"])
+    input_multiplier = output_multiplier = 1.0
+    long_context_threshold = price.get("long_context_threshold")
+    if (
+        apply_long_context_pricing
+        and long_context_threshold is not None
+        and prompt_tokens > long_context_threshold
+    ):
+        input_multiplier = price.get("long_context_input_multiplier", 1.0)
+        output_multiplier = price.get("long_context_output_multiplier", 1.0)
     return (
-        uncached_tokens / 1_000_000 * price["input"]
-        + cached_tokens / 1_000_000 * cached_input_price
-        + cache_write_tokens / 1_000_000 * cache_write_price
-        + completion_tokens / 1_000_000 * price["output"]
+        uncached_tokens / 1_000_000 * price["input"] * input_multiplier
+        + cached_tokens / 1_000_000 * cached_input_price * input_multiplier
+        + cache_write_tokens / 1_000_000 * cache_write_price * input_multiplier
+        + completion_tokens / 1_000_000 * price["output"] * output_multiplier
     )
 
 
@@ -96,6 +109,8 @@ class _ModelUsage:
     completion_tokens: int = 0
     cached_tokens: int = 0
     cache_write_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    cost_complete: bool = True
 
 
 class UsageTracker:
@@ -126,6 +141,11 @@ class UsageTracker:
             entry.completion_tokens += int(raw_usage.get("completion_tokens", 0) or 0)
             entry.cached_tokens += int(raw_usage.get("cached_tokens", 0) or 0)
             entry.cache_write_tokens += int(raw_usage.get("cache_write_tokens", 0) or 0)
+            raw_cost = raw_usage.get("estimated_cost_usd")
+            if raw_cost is None:
+                entry.cost_complete = False
+            else:
+                entry.estimated_cost_usd += float(raw_cost)
 
     def record(
         self,
@@ -143,6 +163,18 @@ class UsageTracker:
         entry.completion_tokens += int(completion_tokens or 0)
         entry.cached_tokens += int(cached_tokens or 0)
         entry.cache_write_tokens += int(cache_write_tokens or 0)
+        cost = cost_for_tokens(
+            model,
+            prompt_tokens,
+            completion_tokens,
+            self._prices,
+            cached_tokens=cached_tokens,
+            cache_write_tokens=cache_write_tokens,
+        )
+        if cost is None:
+            entry.cost_complete = False
+        else:
+            entry.estimated_cost_usd += cost
 
     def record_response(self, model: str, response: Any) -> None:
         """Record usage from an OpenAI ChatCompletion response (no-op if absent)."""
@@ -158,16 +190,6 @@ class UsageTracker:
             cache_write_tokens=getattr(prompt_details, "cache_write_tokens", 0) or 0,
         )
 
-    def _model_cost(self, model: str, usage: _ModelUsage) -> Optional[float]:
-        return cost_for_tokens(
-            model,
-            usage.prompt_tokens,
-            usage.completion_tokens,
-            self._prices,
-            cached_tokens=usage.cached_tokens,
-            cache_write_tokens=usage.cache_write_tokens,
-        )
-
     def summary(self) -> Dict[str, Any]:
         """Return a structured summary of usage and estimated cost."""
         models: Dict[str, Any] = {}
@@ -175,11 +197,11 @@ class UsageTracker:
         total_cost = 0.0
         cost_known = True
         for model, u in sorted(self._by_model.items()):
-            cost = self._model_cost(model, u)
-            if cost is None:
+            cost = u.estimated_cost_usd if u.cost_complete else None
+            if not u.cost_complete:
                 cost_known = False
             else:
-                total_cost += cost
+                total_cost += u.estimated_cost_usd
             models[model] = {
                 "calls": u.calls,
                 "prompt_tokens": u.prompt_tokens,

--- a/localize/usage_tracker.py
+++ b/localize/usage_tracker.py
@@ -12,6 +12,7 @@ constructor) and treat reported cost as an estimate, not a billing figure.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -19,6 +20,10 @@ from localize.atomic_io import write_json_atomic
 
 # USD per 1,000,000 tokens. Verify against current OpenAI pricing before relying.
 DEFAULT_PRICES: Dict[str, Dict[str, float]] = {
+    "gpt-5.6": {"input": 5.00, "output": 30.00},
+    "gpt-5.6-sol": {"input": 5.00, "output": 30.00},
+    "gpt-5.6-terra": {"input": 2.50, "output": 15.00},
+    "gpt-5.6-luna": {"input": 1.00, "output": 6.00},
     "gpt-5.5": {"input": 5.00, "output": 30.00},
     "gpt-5.4": {"input": 2.50, "output": 15.00},
     "gpt-5.4-mini": {"input": 0.75, "output": 4.50},
@@ -82,6 +87,19 @@ class UsageTracker:
 
     def reset(self) -> None:
         self._by_model = {}
+
+    def merge_summary(self, summary: Dict[str, Any]) -> None:
+        """Merge a previously serialized usage summary into this tracker."""
+        models = summary.get("models", {})
+        if not isinstance(models, dict):
+            raise ValueError("Usage summary models must be an object.")
+        for model, raw_usage in models.items():
+            if not isinstance(raw_usage, dict):
+                raise ValueError(f"Usage summary for {model!r} must be an object.")
+            entry = self._by_model.setdefault(str(model), _ModelUsage())
+            entry.calls += int(raw_usage.get("calls", 0) or 0)
+            entry.prompt_tokens += int(raw_usage.get("prompt_tokens", 0) or 0)
+            entry.completion_tokens += int(raw_usage.get("completion_tokens", 0) or 0)
 
     def record(self, model: str, prompt_tokens: int, completion_tokens: int) -> None:
         """Add one API call's token counts for ``model``."""
@@ -160,9 +178,39 @@ class UsageTracker:
         )
         return "\n".join(lines)
 
-    def write_json(self, path: str) -> None:
-        """Write the summary to ``path`` as JSON (creates parent dirs)."""
-        write_json_atomic(path, self.summary())
+    def write_json(
+        self,
+        path: str,
+        *,
+        merge_existing: bool = False,
+        stage_name: Optional[str] = None,
+    ) -> None:
+        """Write usage, optionally merging an earlier stage and stage subtotal."""
+        current_summary = self.summary()
+        payload = current_summary
+        stages: Dict[str, Any] = {}
+        if merge_existing:
+            try:
+                with open(path, "r", encoding="utf-8") as file:
+                    existing_summary = json.load(file)
+            except FileNotFoundError:
+                existing_summary = {}
+            combined = UsageTracker(prices=self._prices)
+            combined.merge_summary(existing_summary)
+            combined.merge_summary(current_summary)
+            payload = combined.summary()
+            raw_stages = existing_summary.get("stages", {})
+            if isinstance(raw_stages, dict):
+                stages = dict(raw_stages)
+        if stage_name:
+            stage = UsageTracker(prices=self._prices)
+            if stage_name in stages:
+                stage.merge_summary(stages[stage_name])
+            stage.merge_summary(current_summary)
+            stages[stage_name] = stage.summary()
+        if stages:
+            payload["stages"] = stages
+        write_json_atomic(path, payload)
 
 
 # Module-level singleton, consistent with the module-global style of the pipeline.

--- a/profiles/bisq-mobile/config.yaml
+++ b/profiles/bisq-mobile/config.yaml
@@ -9,6 +9,8 @@ project_context: >
   preserve product names, and prefer mobile UI wording over long desktop-style
   phrases.
 model_name: "gpt-4o-mini"
+review_model_name: "gpt-5.6-terra"
+review_reasoning_effort: "none"
 translation_queue_folder: "translation_queue"
 translated_queue_folder: "translated_queue"
 dry_run: false
@@ -29,6 +31,7 @@ quality_gate:
 semantic_review:
   enabled: true
   model: "gpt-5.4-mini"
+  reasoning_effort: "none"
   auto_apply_error_suggestions: true
 semantic_quality_rules:
   - id: "trade-history-traders-label"

--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -33,6 +33,7 @@ quality_gate:
 semantic_review:
   enabled: true
   model: "gpt-5.4-mini"
+  reasoning_effort: "none"
   auto_apply_error_suggestions: true
 semantic_quality_rules:
   - id: "trade-history-traders-label"
@@ -343,7 +344,8 @@ logging:
   log_level: "INFO"
   log_file_path: "/app/logs/translation_log.log"
   log_to_console: true
-review_model_name: "gpt-4o"
+review_model_name: "gpt-5.6-terra"
+review_reasoning_effort: "none"
 style_rules:
   da:
     - "Use standard Danish throughout."

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -368,9 +368,9 @@ msgpack==1.2.1 \
     --hash=sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc \
     --hash=sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c
     # via cachecontrol
-openai==1.99.1 \
-    --hash=sha256:2c9d8e498c298f51bb94bcac724257a3a6cac6139ccdfc1186c6708f7a93120f \
-    --hash=sha256:8eeccc69e0ece1357b51ca0d9fb21324afee09b20c3e5b547d02445ca18a4e03
+openai==2.50.0 \
+    --hash=sha256:5128f7caf4a6b01aefd6e7e93efe170a2c3427b8de286b9af5cdff3aa47e02c8 \
+    --hash=sha256:90bdddcc5a2fa529b350fac9c5780d87e5c361dcc6090ab57b0d470b0d7af7fa
     # via -r requirements.in
 packageurl-python==0.17.5 \
     --hash=sha256:a7be3f3ba70d705f738ace9bf6124f31920245a49fa69d4b416da7037dd2de61 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -254,9 +254,9 @@ jsonschema-specifications==2025.4.1 \
     --hash=sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af \
     --hash=sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608
     # via jsonschema
-openai==1.99.1 \
-    --hash=sha256:2c9d8e498c298f51bb94bcac724257a3a6cac6139ccdfc1186c6708f7a93120f \
-    --hash=sha256:8eeccc69e0ece1357b51ca0d9fb21324afee09b20c3e5b547d02445ca18a4e03
+openai==2.50.0 \
+    --hash=sha256:5128f7caf4a6b01aefd6e7e93efe170a2c3427b8de286b9af5cdff3aa47e02c8 \
+    --hash=sha256:90bdddcc5a2fa529b350fac9c5780d87e5c361dcc6090ab57b0d470b0d7af7fa
     # via -r requirements.in
 pydantic==2.11.7 \
     --hash=sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db \

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -74,6 +74,8 @@ class TestLoadAppConfig:
             "target_project_root": "/custom/target",
             "input_folder": "/custom/input",
             "model_name": "gpt-4o-mini",
+            "review_model_name": "gpt-5.6-terra",
+            "review_reasoning_effort": "none",
             "dry_run": True,
             "retranslate_identical_source_strings": True,
             "translation_key_ledger_file_path": "/tmp/test-ledger.json",
@@ -113,6 +115,8 @@ class TestLoadAppConfig:
         assert config.target_project_root == "/custom/target"
         assert config.input_folder == "/custom/input"
         assert config.model_name == "gpt-4o-mini"
+        assert config.review_model_name == "gpt-5.6-terra"
+        assert config.review_reasoning_effort == "none"
         assert config.dry_run is True
         assert config.retranslate_identical_source_strings is True
         assert config.translation_key_ledger_file_path == "/tmp/test-ledger.json"
@@ -510,12 +514,14 @@ class TestLoadAppConfig:
                         mock_logger.return_value = MagicMock()
                         with patch.dict(os.environ, {
                             "REVIEW_MODEL_NAME": "gpt-4o",
+                            "REVIEW_REASONING_EFFORT": "low",
                             "HOLISTIC_REVIEW_CHUNK_SIZE": "100"
                         }):
                             config = load_app_config()
 
         assert config.model_name == "gpt-4"  # From config file
         assert config.review_model_name == "gpt-4o"  # From environment
+        assert config.review_reasoning_effort == "low"
         assert config.holistic_review_chunk_size == 100  # From environment
 
     def test_load_config_with_dotenv_file(self):

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -524,6 +524,25 @@ class TestLoadAppConfig:
         assert config.review_reasoning_effort == "low"
         assert config.holistic_review_chunk_size == 100  # From environment
 
+    def test_invalid_review_reasoning_effort_is_disabled(self):
+        mock_config = {
+            "model_name": "gpt-4o-mini",
+            "review_reasoning_effort": "medium",
+            "dry_run": True,
+        }
+
+        with patch("localize.app_config._load_yaml_config", return_value=mock_config):
+            with patch("localize.app_config.setup_logger") as mock_logger:
+                mock_logger.return_value = MagicMock()
+                with patch.dict(
+                    os.environ,
+                    {"REVIEW_REASONING_EFFORT": "medum"},
+                    clear=True,
+                ):
+                    config = load_app_config()
+
+        assert config.review_reasoning_effort is None
+
     def test_load_config_with_dotenv_file(self):
         """Test that .env file is loaded properly."""
         mock_config = {"model_name": "gpt-4", "dry_run": True}

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -251,6 +251,9 @@ def test_bisq_mobile_profile_packages_sanitized_production_shape():
     assert "Bisq mobile" in config["project_context"]
     assert config["semantic_review"]["enabled"] is True
     assert config["semantic_review"]["auto_apply_error_suggestions"] is True
+    assert config["semantic_review"]["reasoning_effort"] == "none"
+    assert config["review_model_name"] == "gpt-5.6-terra"
+    assert config["review_reasoning_effort"] == "none"
     assert config["quality_gate"]["semantic_qa_audit_scope"] == "changed"
     assert isinstance(glossary, dict) and {"de", "es", "fr"}.issubset(glossary)
 
@@ -352,6 +355,9 @@ def test_recent_coderabbit_translation_nits_are_encoded_as_style_rules(config_pa
     )
     assert semantic_review.get("enabled") is True
     assert semantic_review.get("model") == "gpt-5.4-mini"
+    assert semantic_review.get("reasoning_effort") == "none"
+    assert config["review_model_name"] == "gpt-5.6-terra"
+    assert config["review_reasoning_effort"] == "none"
     assert "version" in retained_allowlist["da"]
     assert "version" in retained_allowlist["de"]
     assert {"information", "message", "messages", "version"}.issubset(retained_allowlist["fr"])

--- a/tests/unit/test_holistic_review_protection.py
+++ b/tests/unit/test_holistic_review_protection.py
@@ -207,7 +207,8 @@ async def test_holistic_review_uses_compatible_completion_token_limit():
 
     with (
         patch("localize.translate_localization_files.DRY_RUN", False),
-        patch("localize.translate_localization_files.REVIEW_MODEL_NAME", "gpt-5.4-mini"),
+        patch("localize.translate_localization_files.REVIEW_MODEL_NAME", "gpt-5.6-terra"),
+        patch("localize.translate_localization_files.REVIEW_REASONING_EFFORT", "none"),
         patch("localize.translate_localization_files.MODEL_PROVIDER", provider),
     ):
         result = await holistic_review_async(
@@ -222,7 +223,8 @@ async def test_holistic_review_uses_compatible_completion_token_limit():
 
     assert result == {"key1": "Hallo {0}"}
     kwargs = provider.create_chat_completion.await_args.kwargs
-    assert kwargs["model"] == "gpt-5.4-mini"
+    assert kwargs["model"] == "gpt-5.6-terra"
+    assert kwargs["reasoning_effort"] == "none"
     assert kwargs["completion_token_limit"] == 8192
     assert kwargs["response_format"] == {"type": "json_object"}
     assert [message["role"] for message in kwargs["messages"]] == ["system", "user"]

--- a/tests/unit/test_holistic_review_protection.py
+++ b/tests/unit/test_holistic_review_protection.py
@@ -204,6 +204,17 @@ async def test_holistic_review_uses_compatible_completion_token_limit():
     provider = MagicMock()
     provider.create_chat_completion = AsyncMock(return_value=response)
     provider.is_retryable_error.return_value = False
+    provider.capabilities_for_model.return_value = SimpleNamespace(
+        supports_reasoning_effort=True,
+        supported_reasoning_efforts=frozenset({
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+        }),
+    )
 
     with (
         patch("localize.translate_localization_files.DRY_RUN", False),

--- a/tests/unit/test_model_provider.py
+++ b/tests/unit/test_model_provider.py
@@ -147,6 +147,9 @@ def test_factory_builds_default_openai_client():
 
     openai.assert_called_once_with(api_key="sk-test")
     assert isinstance(provider, OpenAICompatibleProvider)
+    assert provider.capabilities_for_model(
+        "gpt-5.6-terra"
+    ).supports_reasoning_effort is True
 
 
 def test_factory_builds_custom_endpoint_with_placeholder_key():
@@ -163,6 +166,9 @@ def test_factory_builds_custom_endpoint_with_placeholder_key():
     assert kwargs["api_key"]
     assert kwargs["base_url"] == "http://localhost:11434/v1"
     assert isinstance(provider, OpenAICompatibleProvider)
+    assert provider.capabilities_for_model(
+        "gpt-5.6-terra"
+    ).supports_reasoning_effort is False
 
 
 def test_normalize_model_provider_name_canonicalizes_aliases():
@@ -314,6 +320,9 @@ def test_provider_factory_can_select_aisuite_backend():
 
     assert provider is create_aisuite.return_value
     create_aisuite.assert_called_once()
+    assert create_aisuite.call_args.kwargs[
+        "supports_openai_reasoning_effort"
+    ] is True
 
 
 def test_provider_factory_defaults_to_aisuite_backend():
@@ -348,6 +357,7 @@ def test_aisuite_factory_adds_openai_placeholder_for_custom_endpoint_without_key
     _, kwargs = create_aisuite.call_args
     assert kwargs["provider_configs"]["openai"]["base_url"] == "http://localhost:11434/v1"
     assert kwargs["provider_configs"]["openai"]["api_key"]
+    assert kwargs["supports_openai_reasoning_effort"] is False
 
 
 def test_aisuite_factory_requires_openai_credentials_for_default_models():

--- a/tests/unit/test_provider_capabilities.py
+++ b/tests/unit/test_provider_capabilities.py
@@ -15,14 +15,30 @@ def test_openai_compatible_provider_reports_structured_output_capability():
         provider_key="openai_compatible",
         supports_response_format=True,
         supports_completion_token_limit=True,
-        supports_reasoning_effort=True,
+        supports_reasoning_effort=False,
     )
 
 
-def test_aisuite_reports_openai_capabilities_for_bare_default_models():
-    provider = AiSuiteProvider(client=None, default_provider="openai")
+def test_official_openai_provider_reports_reasoning_capability_for_gpt5():
+    provider = OpenAICompatibleProvider(
+        client=None,
+        supports_openai_reasoning_effort=True,
+    )
 
-    capabilities = provider.capabilities_for_model("gpt-4o")
+    assert provider.capabilities_for_model(
+        "gpt-5.6-terra"
+    ).supports_reasoning_effort is True
+    assert provider.capabilities_for_model("gpt-4o").supports_reasoning_effort is False
+
+
+def test_aisuite_reports_model_specific_openai_capabilities():
+    provider = AiSuiteProvider(
+        client=None,
+        default_provider="openai",
+        supports_openai_reasoning_effort=True,
+    )
+
+    capabilities = provider.capabilities_for_model("gpt-5.6-terra")
 
     assert capabilities.provider_key == "openai"
     assert capabilities.supports_response_format is True
@@ -42,7 +58,11 @@ def test_aisuite_reports_reduced_capabilities_for_non_openai_models():
 
 
 def test_reasoning_effort_is_only_sent_to_supported_routes():
-    openai_provider = AiSuiteProvider(client=None, default_provider="openai")
+    openai_provider = AiSuiteProvider(
+        client=None,
+        default_provider="openai",
+        supports_openai_reasoning_effort=True,
+    )
 
     assert chat_reasoning_effort_kwargs(
         openai_provider,
@@ -52,6 +72,11 @@ def test_reasoning_effort_is_only_sent_to_supported_routes():
     assert chat_reasoning_effort_kwargs(
         openai_provider,
         "anthropic:claude-3-5-sonnet-latest",
+        "none",
+    ) == {}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-4o",
         "none",
     ) == {}
     assert chat_reasoning_effort_kwargs(

--- a/tests/unit/test_provider_capabilities.py
+++ b/tests/unit/test_provider_capabilities.py
@@ -3,6 +3,7 @@ from localize.model_provider import (
     ModelProviderCapabilities,
     OpenAICompatibleProvider,
 )
+from localize.json_response import chat_reasoning_effort_kwargs
 
 
 def test_openai_compatible_provider_reports_structured_output_capability():
@@ -14,6 +15,7 @@ def test_openai_compatible_provider_reports_structured_output_capability():
         provider_key="openai_compatible",
         supports_response_format=True,
         supports_completion_token_limit=True,
+        supports_reasoning_effort=True,
     )
 
 
@@ -25,6 +27,7 @@ def test_aisuite_reports_openai_capabilities_for_bare_default_models():
     assert capabilities.provider_key == "openai"
     assert capabilities.supports_response_format is True
     assert capabilities.supports_completion_token_limit is True
+    assert capabilities.supports_reasoning_effort is True
 
 
 def test_aisuite_reports_reduced_capabilities_for_non_openai_models():
@@ -35,3 +38,24 @@ def test_aisuite_reports_reduced_capabilities_for_non_openai_models():
     assert capabilities.provider_key == "anthropic"
     assert capabilities.supports_response_format is False
     assert capabilities.supports_completion_token_limit is True
+    assert capabilities.supports_reasoning_effort is False
+
+
+def test_reasoning_effort_is_only_sent_to_supported_routes():
+    openai_provider = AiSuiteProvider(client=None, default_provider="openai")
+
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-5.6-terra",
+        "none",
+    ) == {"reasoning_effort": "none"}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "anthropic:claude-3-5-sonnet-latest",
+        "none",
+    ) == {}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-5.6-terra",
+        None,
+    ) == {}

--- a/tests/unit/test_provider_capabilities.py
+++ b/tests/unit/test_provider_capabilities.py
@@ -28,6 +28,16 @@ def test_official_openai_provider_reports_reasoning_capability_for_gpt5():
     assert provider.capabilities_for_model(
         "gpt-5.6-terra"
     ).supports_reasoning_effort is True
+    assert provider.capabilities_for_model(
+        "gpt-5.6-terra"
+    ).supported_reasoning_efforts == frozenset({
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    })
     assert provider.capabilities_for_model("gpt-4o").supports_reasoning_effort is False
 
 
@@ -79,6 +89,41 @@ def test_reasoning_effort_is_only_sent_to_supported_routes():
         "gpt-4o",
         "none",
     ) == {}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-5.6-terra",
+        "minimal",
+    ) == {}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-5.4-mini",
+        "max",
+    ) == {}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-5.4-mini",
+        "none",
+    ) == {"reasoning_effort": "none"}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-5-pro",
+        "none",
+    ) == {}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-5-pro",
+        "high",
+    ) == {"reasoning_effort": "high"}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-5",
+        "none",
+    ) == {}
+    assert chat_reasoning_effort_kwargs(
+        openai_provider,
+        "gpt-5",
+        "minimal",
+    ) == {"reasoning_effort": "minimal"}
     assert chat_reasoning_effort_kwargs(
         openai_provider,
         "gpt-5.6-terra",

--- a/tests/unit/test_shell_packaging_scripts.py
+++ b/tests/unit/test_shell_packaging_scripts.py
@@ -98,14 +98,20 @@ def test_dockerfile_uses_orchestration_default_command():
     assert 'CMD ["/app/update-translations.sh"]' in dockerfile
 
 
-def test_dockerfile_builds_current_gh_with_fixed_grpc():
+def test_dockerfile_builds_go_tools_with_fixed_dependencies():
     dockerfile = (REPO_ROOT / "docker" / "Dockerfile").read_text(encoding="utf-8")
 
     assert "ARG GH_VERSION=2.96.0" in dockerfile
     assert "ARG GH_COMMIT=b300f2ec7ec9dc9addc39b2ad88c54097ded7ca0" in dockerfile
+    assert "ARG YQ_VERSION=4.53.3" in dockerfile
+    assert "ARG YQ_COMMIT=1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d" in dockerfile
     assert "ARG GRPC_VERSION=1.82.1" in dockerfile
+    assert "ARG X_TEXT_VERSION=0.40.0" in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$GH_COMMIT"' in dockerfile
+    assert 'test "$(git rev-parse HEAD)" = "$YQ_COMMIT"' in dockerfile
     assert 'go get "google.golang.org/grpc@v${GRPC_VERSION}"' in dockerfile
+    assert dockerfile.count('go get "golang.org/x/text@v${X_TEXT_VERSION}"') == 2
+    assert "COPY --from=yq-builder /out/yq /usr/bin/yq" in dockerfile
 
 
 def test_dockerignore_excludes_local_configs_and_agent_scratch():

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -225,6 +225,10 @@ async def test_semantic_reviewer_uses_compatible_completion_token_limit():
     )
     provider = MagicMock()
     provider.create_chat_completion = AsyncMock(return_value=response)
+    provider.capabilities_for_model.return_value = SimpleNamespace(
+        supports_reasoning_effort=True,
+        supported_reasoning_efforts=frozenset({"none", "low", "medium", "high", "xhigh"}),
+    )
     changes = [
         TranslationChange(
             file="resources/mobile_es.properties",

--- a/tests/unit/test_translation_semantic_reviewer.py
+++ b/tests/unit/test_translation_semantic_reviewer.py
@@ -244,11 +244,13 @@ async def test_semantic_reviewer_uses_compatible_completion_token_limit():
         style_rules=[],
         brand_glossary=[],
         model_provider=provider,
+        reasoning_effort="none",
     )
 
     assert findings == []
     kwargs = provider.create_chat_completion.await_args.kwargs
     assert kwargs["model"] == "gpt-5.4-mini"
+    assert kwargs["reasoning_effort"] == "none"
     assert kwargs["completion_token_limit"] == 4096
     assert kwargs["response_format"] == {"type": "json_object"}
     assert "max_tokens" not in kwargs
@@ -366,6 +368,7 @@ async def test_semantic_reviewer_chunks_and_survives_failed_batch():
 async def test_semantic_reviewer_defaults_to_aisuite_provider(tmp_path):
     config_path = tmp_path / "config.yaml"
     validation_summary_path = tmp_path / "translation_validation_summary.json"
+    token_usage_summary_path = tmp_path / "token_usage_summary.json"
     config_path.write_text(
         "\n".join(
             [
@@ -425,6 +428,8 @@ async def test_semantic_reviewer_defaults_to_aisuite_provider(tmp_path):
                 str(config_path),
                 "--validation-summary",
                 str(validation_summary_path),
+                "--token-usage-summary",
+                str(token_usage_summary_path),
                 "--changed-files",
                 "resources/messages_de.properties",
             ]
@@ -433,6 +438,11 @@ async def test_semantic_reviewer_defaults_to_aisuite_provider(tmp_path):
     assert exit_code == 0
     assert create_provider.call_args.kwargs["provider_name"] == "aisuite"
     assert create_provider.call_args.kwargs["model_names"] == ("gpt-4o",)
+    provider.write_usage_summary.assert_called_once_with(
+        str(token_usage_summary_path),
+        merge_existing=True,
+        stage_name="semantic_review",
+    )
     assert json.loads(validation_summary_path.read_text(encoding="utf-8"))[
         "semantic_review_findings"
     ] == []

--- a/tests/unit/test_update_translations_script.py
+++ b/tests/unit/test_update_translations_script.py
@@ -524,6 +524,9 @@ def test_pr_body_includes_token_usage_cost_summary():
 
     assert "token_usage_summary.json" in script
     assert "Translation cost" in script
+    assert "--token-usage-summary" in script
+    assert "all AI stages" in script
+    assert ".stages" in script
     # The cost section must be assembled before the PR is created.
     cost_index = script.index("token_usage_summary.json")
     pr_create_index = script.index("gh pr create")

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -34,6 +34,10 @@ def test_cost_calculation():
 
 
 def test_default_prices_cover_configured_gpt5_models():
+    assert DEFAULT_PRICES["gpt-5.6"] == {"input": 5.00, "output": 30.00}
+    assert DEFAULT_PRICES["gpt-5.6-sol"] == {"input": 5.00, "output": 30.00}
+    assert DEFAULT_PRICES["gpt-5.6-terra"] == {"input": 2.50, "output": 15.00}
+    assert DEFAULT_PRICES["gpt-5.6-luna"] == {"input": 1.00, "output": 6.00}
     assert DEFAULT_PRICES["gpt-5.5"] == {"input": 5.00, "output": 30.00}
     assert DEFAULT_PRICES["gpt-5.4"] == {"input": 2.50, "output": 15.00}
     assert DEFAULT_PRICES["gpt-5.4-mini"] == {"input": 0.75, "output": 4.50}
@@ -121,3 +125,34 @@ def test_write_json(tmp_path):
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["totals"]["total_tokens"] == 750
     assert data["models"]["gpt-4o-mini"]["calls"] == 1
+
+
+def test_write_json_can_merge_semantic_review_usage(tmp_path):
+    path = tmp_path / "usage.json"
+    translation = UsageTracker(prices=DEFAULT_PRICES)
+    translation.record("gpt-4o-mini", 1000, 100)
+    translation.record("gpt-5.6-terra", 500, 50)
+    translation.write_json(
+        str(path),
+        stage_name="translation_and_holistic_review",
+    )
+
+    semantic_review = UsageTracker(prices=DEFAULT_PRICES)
+    semantic_review.record("gpt-5.4-mini", 300, 30)
+    semantic_review.record("gpt-5.4-mini", 200, 20)
+    semantic_review.write_json(
+        str(path),
+        merge_existing=True,
+        stage_name="semantic_review",
+    )
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["models"]["gpt-4o-mini"]["calls"] == 1
+    assert data["models"]["gpt-5.6-terra"]["calls"] == 1
+    assert data["models"]["gpt-5.4-mini"]["calls"] == 2
+    assert data["totals"]["calls"] == 4
+    assert data["totals"]["total_tokens"] == 2200
+    assert data["totals"]["cost_complete"] is True
+    assert data["stages"]["translation_and_holistic_review"]["totals"]["calls"] == 2
+    assert data["stages"]["semantic_review"]["totals"]["calls"] == 2
+    assert data["stages"]["semantic_review"]["totals"]["total_tokens"] == 550

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -248,3 +248,20 @@ def test_write_json_can_merge_semantic_review_usage(tmp_path):
     assert data["stages"]["translation_and_holistic_review"]["totals"]["calls"] == 2
     assert data["stages"]["semantic_review"]["totals"]["calls"] == 2
     assert data["stages"]["semantic_review"]["totals"]["total_tokens"] == 550
+
+
+def test_write_json_preserves_stages_without_merging_usage(tmp_path):
+    path = tmp_path / "usage.json"
+    translation = UsageTracker(prices=DEFAULT_PRICES)
+    translation.record("gpt-4o-mini", 1000, 100)
+    translation.write_json(str(path), stage_name="translation")
+
+    semantic_review = UsageTracker(prices=DEFAULT_PRICES)
+    semantic_review.record("gpt-5.4-mini", 300, 30)
+    semantic_review.write_json(str(path), stage_name="semantic_review")
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["totals"]["calls"] == 1
+    assert data["totals"]["total_tokens"] == 330
+    assert data["stages"]["translation"]["totals"]["total_tokens"] == 1100
+    assert data["stages"]["semantic_review"]["totals"]["total_tokens"] == 330

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -3,7 +3,7 @@
 import json
 from types import SimpleNamespace
 
-from localize.usage_tracker import DEFAULT_PRICES, UsageTracker
+from localize.usage_tracker import DEFAULT_PRICES, UsageTracker, cost_for_tokens
 
 
 PRICES = {
@@ -51,6 +51,9 @@ def test_default_prices_cover_configured_gpt5_models():
         "cached_input": 0.25,
         "cache_write": 3.125,
         "output": 15.00,
+        "long_context_threshold": 272_000,
+        "long_context_input_multiplier": 2.0,
+        "long_context_output_multiplier": 1.5,
     }
     assert DEFAULT_PRICES["gpt-5.6-luna"] == {
         "input": 1.00,
@@ -142,9 +145,39 @@ def test_record_response_prices_cached_reads_and_writes_separately():
     model = t.summary()["models"]["gpt-5.6-terra"]
     assert model["cached_tokens"] == 400_000
     assert model["cache_write_tokens"] == 200_000
-    # 400K uncached * $2.50 + 400K cached * $0.25
-    # + 200K writes * $3.125 + 100K output * $15.00
-    assert model["estimated_cost_usd"] == 3.225
+    # The 1M-token prompt uses Terra's long-context rates for the full request.
+    assert model["estimated_cost_usd"] == 5.7
+
+
+def test_gpt56_long_context_pricing_boundary():
+    base_cost = cost_for_tokens(
+        "gpt-5.6-terra",
+        272_000,
+        100_000,
+        cached_tokens=100_000,
+        cache_write_tokens=50_000,
+    )
+    long_cost = cost_for_tokens(
+        "gpt-5.6-terra",
+        272_001,
+        100_000,
+        cached_tokens=100_000,
+        cache_write_tokens=50_000,
+    )
+
+    assert base_cost == 1.98625
+    assert long_cost == 3.222505
+
+
+def test_long_context_pricing_is_applied_per_call_not_aggregate():
+    tracker = UsageTracker(prices=DEFAULT_PRICES)
+
+    tracker.record("gpt-5.6-terra", 200_000, 10_000)
+    tracker.record("gpt-5.6-terra", 200_000, 10_000)
+
+    model = tracker.summary()["models"]["gpt-5.6-terra"]
+    assert model["prompt_tokens"] == 400_000
+    assert model["estimated_cost_usd"] == 1.3
 
 
 def test_record_response_handles_missing_usage():

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -34,14 +34,50 @@ def test_cost_calculation():
 
 
 def test_default_prices_cover_configured_gpt5_models():
-    assert DEFAULT_PRICES["gpt-5.6"] == {"input": 5.00, "output": 30.00}
-    assert DEFAULT_PRICES["gpt-5.6-sol"] == {"input": 5.00, "output": 30.00}
-    assert DEFAULT_PRICES["gpt-5.6-terra"] == {"input": 2.50, "output": 15.00}
-    assert DEFAULT_PRICES["gpt-5.6-luna"] == {"input": 1.00, "output": 6.00}
-    assert DEFAULT_PRICES["gpt-5.5"] == {"input": 5.00, "output": 30.00}
-    assert DEFAULT_PRICES["gpt-5.4"] == {"input": 2.50, "output": 15.00}
-    assert DEFAULT_PRICES["gpt-5.4-mini"] == {"input": 0.75, "output": 4.50}
-    assert DEFAULT_PRICES["gpt-5.4-nano"] == {"input": 0.20, "output": 1.25}
+    assert DEFAULT_PRICES["gpt-5.6"] == {
+        "input": 5.00,
+        "cached_input": 0.50,
+        "cache_write": 6.25,
+        "output": 30.00,
+    }
+    assert DEFAULT_PRICES["gpt-5.6-sol"] == {
+        "input": 5.00,
+        "cached_input": 0.50,
+        "cache_write": 6.25,
+        "output": 30.00,
+    }
+    assert DEFAULT_PRICES["gpt-5.6-terra"] == {
+        "input": 2.50,
+        "cached_input": 0.25,
+        "cache_write": 3.125,
+        "output": 15.00,
+    }
+    assert DEFAULT_PRICES["gpt-5.6-luna"] == {
+        "input": 1.00,
+        "cached_input": 0.10,
+        "cache_write": 1.25,
+        "output": 6.00,
+    }
+    assert DEFAULT_PRICES["gpt-5.5"] == {
+        "input": 5.00,
+        "cached_input": 0.50,
+        "output": 30.00,
+    }
+    assert DEFAULT_PRICES["gpt-5.4"] == {
+        "input": 2.50,
+        "cached_input": 0.25,
+        "output": 15.00,
+    }
+    assert DEFAULT_PRICES["gpt-5.4-mini"] == {
+        "input": 0.75,
+        "cached_input": 0.075,
+        "output": 4.50,
+    }
+    assert DEFAULT_PRICES["gpt-5.4-nano"] == {
+        "input": 0.20,
+        "cached_input": 0.02,
+        "output": 1.25,
+    }
     assert DEFAULT_PRICES["gpt-5.4-pro"] == {"input": 30.00, "output": 180.00}
 
 
@@ -86,6 +122,29 @@ def test_record_response_reads_usage():
     s = t.summary()
     assert s["models"]["gpt-4o-mini"]["prompt_tokens"] == 120
     assert s["models"]["gpt-4o-mini"]["completion_tokens"] == 30
+
+
+def test_record_response_prices_cached_reads_and_writes_separately():
+    t = UsageTracker(prices=DEFAULT_PRICES)
+    resp = SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=1_000_000,
+            completion_tokens=100_000,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=400_000,
+                cache_write_tokens=200_000,
+            ),
+        )
+    )
+
+    t.record_response("gpt-5.6-terra", resp)
+
+    model = t.summary()["models"]["gpt-5.6-terra"]
+    assert model["cached_tokens"] == 400_000
+    assert model["cache_write_tokens"] == 200_000
+    # 400K uncached * $2.50 + 400K cached * $0.25
+    # + 200K writes * $3.125 + 100K output * $15.00
+    assert model["estimated_cost_usd"] == 3.225
 
 
 def test_record_response_handles_missing_usage():

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -837,6 +837,7 @@ stage_and_submit_batch() {
     local QUALITY_REPORT_JSON="$report_dir/translation_quality_report-${branch}.json"
     local QUALITY_REPORT_MD="$report_dir/translation_quality_report-${branch}.md"
     local VALIDATION_SUMMARY="$report_dir/translation_validation_summary.json"
+    local TOKEN_USAGE_JSON="$report_dir/token_usage_summary.json"
     local QUALITY_AUDIT_SCOPE="${TRANSLATION_QUALITY_AUDIT_SCOPE:-}"
     local SEMANTIC_REVIEW_EXIT=0
     set +e
@@ -847,6 +848,7 @@ stage_and_submit_batch() {
             --input-folder "$ABSOLUTE_INPUT_FOLDER" \
             --config "$CONFIG_FILE" \
             --validation-summary "$VALIDATION_SUMMARY" \
+            --token-usage-summary "$TOKEN_USAGE_JSON" \
             --changed-files "${BATCH_FILES[@]}"
     )
     SEMANTIC_REVIEW_EXIT=$?
@@ -958,14 +960,15 @@ This PR is from branch \`$branch\` on the \`${FORK_OWNER}/${FORK_REPO_NAME_SHORT
         record_pipeline_event "skipped_files" "count=0"
     fi
 
-    # Append per-run token usage / estimated cost so reviewers see what the run cost.
-    local TOKEN_USAGE_JSON="$report_dir/token_usage_summary.json"
+    # Append per-run token usage / estimated cost so reviewers see what all AI stages cost.
     if [ -s "$TOKEN_USAGE_JSON" ]; then
         local COST_MD
         COST_MD=$(jq -r '
-            ["### Translation cost (estimated)",
+            ["### Translation cost (estimated, all AI stages)",
              "- Total: \(.totals.total_tokens) tokens, est. $\(.totals.estimated_cost_usd)"
                + (if .totals.cost_complete == false then " (partial — some models had no price set)" else "" end)]
+            + ((.stages // {}) | to_entries | map("- Stage \(.key | gsub(\"_\"; \" \")): "
+               + "\(.value.totals.total_tokens) tokens, est. $\(.value.totals.estimated_cost_usd)"))
             + (.models | to_entries | map("- \(.key): \(.value.total_tokens) tokens, est. "
                + (if .value.estimated_cost_usd == null then "n/a" else "$\(.value.estimated_cost_usd)" end)))
             | join("\n")


### PR DESCRIPTION
## Summary

- keep `gpt-4o-mini` for initial translation
- use `gpt-5.6-terra` for holistic review with `reasoning_effort: none`
- keep `gpt-5.4-mini` for semantic review and pin its effort to `none`
- update the OpenAI Python SDK lock from 1.99.1 to 2.50.0
- merge semantic-review usage into the PR cost artifact with per-stage subtotals

## Cost impact

Using the measured token mix from bisq-mobile PR #1654, replacing only the holistic `gpt-4o` pass with Terra raises the two-stage estimate from $0.199351 to $0.222896, about 11.8%. Future translation PRs will also report the previously omitted semantic-review subtotal and a complete all-stage total.

## Validation

- `pytest -q` (691 passed, 4 subtests passed)
- `ruff check .`
- `pip-audit -r requirements.txt`
- `pip-audit -r requirements-dev.txt`
- `bash -n update-translations.sh`
- production Docker image build
- Bisq and bisq-mobile profile doctor/smoke checks
- OpenAI 2.50.0 signature verification for `reasoning_effort` values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable reasoning-effort for holistic and semantic reviews, including environment-variable override support.
  * Reasoning-effort is sent only when the selected provider/model supports it.
  * Token-usage summaries now support stage-level totals, merge-on-write, and cached read/write token cost reporting (GPT-5.6 variants).

* **Documentation**
  * Updated README, environment-variable docs, and example/profile configurations to document the new settings.

* **Tests**
  * Expanded coverage for config/env validation, provider capability gating, semantic-review behavior, and usage-summary merging.

* **Chores**
  * Pinned tooling/dependencies updates (OpenAI version and Docker build tooling for reproducible binaries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->