### PR TITLE
Guard French seed-node label against seed phrase

### DIFF
--- a/profiles/bisq-mobile/config.yaml
+++ b/profiles/bisq-mobile/config.yaml
@@ -86,12 +86,12 @@ semantic_quality_rules:
     source: "bisq-mobile#1484 CodeRabbit"
   - id: "network-seed-node-not-seed-phrase"
     message: "On the Network connections screen 'Seed' labels a seed node (bootstrap peer), not a wallet recovery phrase; do not translate it as seed phrase/words."
-    locales: ["cs", "es", "ru", "id", "it", "vi"]
+    locales: ["cs", "es", "ru", "id", "it", "vi", "fr"]
     keys: ["mobile.networkInfo.connections.seed"]
-    forbidden_target_regex: "(Slova|Frase|фраза|Kata|Parole|khóa)"
+    forbidden_target_regex: "(Slova|Frase|фраза|Kata|Parole|khóa|Récupération)"
     regex_ignorecase: true
     severity: "error"
-    source: "bisq-mobile#1606 CodeRabbit"
+    source: "bisq-mobile#1606, #1669 CodeRabbit"
   - id: "network-transport-not-physical-transport"
     message: "On the Network screens 'Transport' is the network transport (e.g. Tor/clearnet), not physical transportation/shipping."
     locales: ["af_ZA", "cs", "vi"]

--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -208,12 +208,12 @@ semantic_quality_rules:
     source: "bisq2#4835 CodeRabbit"
   - id: "network-seed-node-not-seed-phrase"
     message: "On the Network connections screen 'Seed' labels a seed node (bootstrap peer), not a wallet recovery phrase; do not translate it as seed phrase/words."
-    locales: ["cs", "es", "ru", "id", "it", "vi"]
+    locales: ["cs", "es", "ru", "id", "it", "vi", "fr"]
     keys: ["mobile.networkInfo.connections.seed"]
-    forbidden_target_regex: "(Slova|Frase|фраза|Kata|Parole|khóa)"
+    forbidden_target_regex: "(Slova|Frase|фраза|Kata|Parole|khóa|Récupération)"
     regex_ignorecase: true
     severity: "error"
-    source: "bisq-mobile#1606 CodeRabbit"
+    source: "bisq-mobile#1606, #1669 CodeRabbit"
   - id: "network-transport-not-physical-transport"
     message: "On the Network screens 'Transport' is the network transport (e.g. Tor/clearnet), not physical transportation/shipping."
     locales: ["af_ZA", "cs", "vi"]

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -484,7 +484,6 @@ def test_network_terminology_rules_from_1606_are_encoded(config_path):
     assert _NETWORK_RULE_IDS.issubset(rules_by_id)
     for rule_id in _NETWORK_RULE_IDS:
         rule = rules_by_id[rule_id]
-        assert "bisq-mobile#1606" in rule["source"]
         assert rule["severity"] == "error"
         assert set(rule["locales"]) <= supported
 
@@ -496,6 +495,8 @@ def test_network_terminology_rules_from_1606_are_encoded(config_path):
     assert "#1669" in seed_rule["source"]
     assert "fr" in seed_rule["locales"]
     transport_rule = rules_by_id["network-transport-not-physical-transport"]
+    assert seed_rule["source"] == "bisq-mobile#1606, #1669 CodeRabbit"
+    assert transport_rule["source"] == "bisq-mobile#1606 CodeRabbit"
     assert set(transport_rule["keys"]) == {
         "mobile.networkInfo.myNode.transport",
         "mobile.networkInfo.overview.transport",

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -484,12 +484,17 @@ def test_network_terminology_rules_from_1606_are_encoded(config_path):
     assert _NETWORK_RULE_IDS.issubset(rules_by_id)
     for rule_id in _NETWORK_RULE_IDS:
         rule = rules_by_id[rule_id]
-        assert rule["source"] == "bisq-mobile#1606 CodeRabbit"
+        assert "bisq-mobile#1606" in rule["source"]
         assert rule["severity"] == "error"
         assert set(rule["locales"]) <= supported
 
     seed_rule = rules_by_id["network-seed-node-not-seed-phrase"]
     assert seed_rule["keys"] == ["mobile.networkInfo.connections.seed"]
+    # French was added after the #1669 regression (glossary term
+    # "seed phrase" -> "Mots de Récupération" leaked into the seed-node label);
+    # keep provenance and locale coverage in lock-step so fr cannot be dropped.
+    assert "#1669" in seed_rule["source"]
+    assert "fr" in seed_rule["locales"]
     transport_rule = rules_by_id["network-transport-not-physical-transport"]
     assert set(transport_rule["keys"]) == {
         "mobile.networkInfo.myNode.transport",
@@ -530,6 +535,8 @@ def test_network_terminology_rules_flag_the_real_1606_mistranslations():
         _seed("id", "Kata Seed"),
         _seed("it", "Parole Seed"),
         _seed("vi", "Từ khóa seed"),
+        # bisq-mobile#1669: French leaked the "seed phrase" glossary term.
+        _seed("fr", "Mots de Récupération"),
         _transport("af_ZA", "Vervoer"),
         _transport("cs", "Doprava"),
         _transport("vi", "Vận chuyển"),
@@ -550,6 +557,7 @@ def test_network_terminology_rules_flag_the_real_1606_mistranslations():
         _seed("vi", "Nút seed"),
         _seed("de", "Seed"),
         _seed("pcm", "Seed node"),
+        _seed("fr", "Nœud seed"),
         _transport("af_ZA", "Transport"),
         _transport("cs", "Přenos"),
         _transport("de", "Transport"),


### PR DESCRIPTION
## Problem

Bisq Mobile PR #1669 translated the French seed-node connection label as
`Mots de Récupération` (recovery words), confusing a network bootstrap peer
with a wallet seed phrase. The valid inline finding is documented in the
[review thread](https://github.com/bisq-network/bisq-mobile/pull/1669#discussion_r3680212955).

## Root cause and change

The existing semantic guard covered several locales but not French. Add `fr`
to the mirrored Bisq/Bisq Mobile rule and reject `Récupération` only for the
seed-node label. Extend the regression test with both the observed bad value
and the reviewed `Nœud seed` wording, and record #1669 as the rule provenance.

## Validation

- Config-quality tests: 27 passed.
- Full suite: 697 passed, 4 subtests passed.

The gate audits changed values, so the already-merged app value is corrected
in a separate Bisq Mobile follow-up; this PR prevents recurrence.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved French localization quality checks for network seed-node terminology.
  * Prevented the recovery-term translation “Récupération” from being incorrectly used in seed-node messaging.
* **Tests**
  * Added regression coverage to validate the corrected French wording and associated source references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->