### PR TITLE
Exclude commercial material and genericize examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,6 +52,15 @@ claudedocs/
 docs/llm/
 docs/requirements/
 
+# Local-only commercial material. Mirrors .gitignore: this is a published image,
+# so prospect research and outreach drafts must not be baked into it.
+outreach/
+docs/business-strategy.md
+docs/codex-prompt-ignore-keys.md
+docs/customer-development-action-plan.md
+docs/customer-discovery-targets.md
+docs/*-dossier.md
+
 # Documentation & Tests (if not needed in image)
 # docs/
 # tests/

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ build/
 /logs/*
 !/logs/.gitkeep
 
+# Test-generated logs. Loading a config writes 'logs/' next to the config file,
+# so any fixture config leaves one behind when a test loads it.
+/tests/**/logs/
+
 # Secrets
 # This directory contains sensitive information like API keys and should never be committed.
 # Ignore contents of secrets, but not the directory itself, so .gitkeep can be tracked.
@@ -51,3 +55,13 @@ docker/docker-compose.override.*.yaml
 /CLAUDE.md
 /.claude/
 /claudedocs/
+
+# Local-only commercial material: prospect research, outreach drafts and staged
+# per-project artifacts. This is a published Action, so none of it belongs in the
+# repository. Kept ignored rather than relocated so 'git add -A' cannot sweep it in.
+/outreach/
+/docs/business-strategy.md
+/docs/codex-prompt-ignore-keys.md
+/docs/customer-development-action-plan.md
+/docs/customer-discovery-targets.md
+/docs/*-dossier.md

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -97,7 +97,7 @@ brand_technical_glossary:
 # and "/nav/settings"; Java properties use the dotted property key. Matching
 # keys are never sent to the model and are copied from the source locale.
 # ignore_key_patterns:
-#   - "^/#\\d+$"  # RoboSats-style JSON pseudo-comments: "#1", "#2", ...
+#   - "^/#\\d+$"  # JSON pseudo-comment keys: "#1", "#2", ...
 
 # If true, the script logs actions without calling the API or writing files.
 dry_run: false

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -631,7 +631,7 @@ async def test_process_translation_queue_preserves_ignored_json_comment_keys(int
     assert provider.estimate_run_cost.call_args.kwargs["num_keys"] == 2
     assert all('"#1"' not in prompt for prompt in seen_prompt_texts)
     assert all('"#2"' not in prompt for prompt in seen_prompt_texts)
-    assert all("Phrases in basic" not in prompt for prompt in seen_prompt_texts)
+    assert all("Phrases in app" not in prompt for prompt in seen_prompt_texts)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -551,9 +551,9 @@ async def test_process_translation_queue_preserves_ignored_json_comment_keys(int
     env = integration_test_environment
     layout = LocalizationLayout(id="locale_filename", source_locale="en")
     source_content = {
-        "#1": "Phrases in basic/Main.tsx",
-        "#2": "Phrases in basic/BookPage/index.tsx",
-        "welcome": "Welcome to RoboSats",
+        "#1": "Phrases in app/Main.tsx",
+        "#2": "Phrases in app/SettingsPage/index.tsx",
+        "welcome": "Welcome to Acme",
         "amount": "Amount {{amount}} sats",
     }
     target_content = {}
@@ -574,13 +574,13 @@ async def test_process_translation_queue_preserves_ignored_json_comment_keys(int
             return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
                 content=json.dumps({
                     "/amount": "Betrag {{amount}} sats",
-                    "/welcome": "Willkommen bei RoboSats",
+                    "/welcome": "Willkommen bei Acme",
                 })
             ))])
         if "Key: /amount" in prompt_text:
             content = "Betrag {{amount}} sats"
         elif "Key: /welcome" in prompt_text:
-            content = "Willkommen bei RoboSats"
+            content = "Willkommen bei Acme"
         else:
             raise AssertionError(f"Unexpected model prompt: {prompt_text}")
         return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
@@ -623,9 +623,9 @@ async def test_process_translation_queue_preserves_ignored_json_comment_keys(int
     assert skipped_files == {}
     assert total_keys == 2
     assert final_payload == {
-        "#1": "Phrases in basic/Main.tsx",
-        "#2": "Phrases in basic/BookPage/index.tsx",
-        "welcome": "Willkommen bei RoboSats",
+        "#1": "Phrases in app/Main.tsx",
+        "#2": "Phrases in app/SettingsPage/index.tsx",
+        "welcome": "Willkommen bei Acme",
         "amount": "Betrag {{amount}} sats",
     }
     assert provider.estimate_run_cost.call_args.kwargs["num_keys"] == 2
@@ -639,8 +639,8 @@ async def test_process_translation_queue_writes_only_ignored_json_keys(integrati
     env = integration_test_environment
     layout = LocalizationLayout(id="locale_filename", source_locale="en")
     source_content = {
-        "#1": "Phrases in basic/Main.tsx",
-        "#2": "Phrases in basic/BookPage/index.tsx",
+        "#1": "Phrases in app/Main.tsx",
+        "#2": "Phrases in app/SettingsPage/index.tsx",
     }
     source_file_path = os.path.join(env['input_folder'], 'en.json')
     target_file_path = os.path.join(env['translation_queue_folder'], 'de.json')

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -397,15 +397,15 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
     def test_extract_texts_to_translate_skips_ignored_keys(self):
         """Ignored keys should never be selected for model translation."""
         parsed_lines = [
-            {'type': 'entry', 'key': '/#1', 'value': 'Phrases in basic/Main.tsx', 'line_number': 0},
+            {'type': 'entry', 'key': '/#1', 'value': 'Phrases in app/Main.tsx', 'line_number': 0},
             {'type': 'entry', 'key': '/welcome', 'value': 'Welcome', 'line_number': 1},
         ]
         target_translations = {
-            '/#1': 'Phrases in basic/Main.tsx',
+            '/#1': 'Phrases in app/Main.tsx',
             '/welcome': 'Welcome',
         }
         source_translations = {
-            '/#1': 'Phrases in basic/Main.tsx',
+            '/#1': 'Phrases in app/Main.tsx',
             '/welcome': 'Welcome',
         }
 
@@ -424,15 +424,15 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
     def test_extract_texts_to_translate_is_unchanged_without_ignore_patterns(self):
         """Unset ignore_key_patterns should preserve existing selection behavior."""
         parsed_lines = [
-            {'type': 'entry', 'key': '/#1', 'value': 'Phrases in basic/Main.tsx', 'line_number': 0},
+            {'type': 'entry', 'key': '/#1', 'value': 'Phrases in app/Main.tsx', 'line_number': 0},
             {'type': 'entry', 'key': '/welcome', 'value': 'Welcome', 'line_number': 1},
         ]
         target_translations = {
-            '/#1': 'Phrases in basic/Main.tsx',
+            '/#1': 'Phrases in app/Main.tsx',
             '/welcome': 'Welcome',
         }
         source_translations = {
-            '/#1': 'Phrases in basic/Main.tsx',
+            '/#1': 'Phrases in app/Main.tsx',
             '/welcome': 'Welcome',
         }
 
@@ -457,7 +457,7 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
         """Empty ignore_key_patterns should be byte-for-byte inert."""
         content = textwrap.dedent("""\
             # Existing target file
-            comment.1=Phrases in basic/Main.tsx
+            comment.1=Phrases in app/Main.tsx
             welcome=Willkommen
         """)
         with tempfile.NamedTemporaryFile('w', delete=False, encoding='utf-8') as temp_file:
@@ -472,7 +472,7 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
                 parsed_lines,
                 target_translations,
                 {
-                    'comment.1': 'Phrases in basic/Main.tsx',
+                    'comment.1': 'Phrases in app/Main.tsx',
                     'welcome': 'Welcome',
                 },
                 [],
@@ -486,12 +486,12 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
     def test_per_key_validation_excludes_ignored_keys_from_failures(self):
         valid_translations, summary = run_per_key_validation_with_summary(
             {
-                '/#1': 'Phrases in basic/Main.tsx',
+                '/#1': 'Phrases in app/Main.tsx',
                 '/welcome': 'Willkommen',
                 '/broken': 'Hallo',
             },
             {
-                '/#1': 'Phrases in basic/Main.tsx {{name}}',
+                '/#1': 'Phrases in app/Main.tsx {{name}}',
                 '/welcome': 'Welcome',
                 '/broken': 'Hello {{name}}',
             },
@@ -499,7 +499,7 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
             ignore_key_patterns=compile_ignore_key_patterns([r'^/#\d+$']),
         )
 
-        self.assertEqual(valid_translations['/#1'], 'Phrases in basic/Main.tsx {{name}}')
+        self.assertEqual(valid_translations['/#1'], 'Phrases in app/Main.tsx {{name}}')
         self.assertEqual(valid_translations['/welcome'], 'Willkommen')
         self.assertEqual(valid_translations['/broken'], 'Hello {{name}}')
         self.assertEqual(summary['failed_keys'], ['/broken'])

--- a/tests/unit/test_translation_quality_gate.py
+++ b/tests/unit/test_translation_quality_gate.py
@@ -128,20 +128,20 @@ def test_source_identical_gate_excludes_ignored_json_pointer_keys(tmp_path):
     _write_json(
         input_folder / "en.json",
         {
-            "#1": "Phrases in basic/Main.tsx",
+            "#1": "Phrases in app/Main.tsx",
             "title": "Open trades",
         },
     )
     _write_json(
         input_folder / "de.json",
         {
-            "#1": "Phrases in basic/Main.tsx",
+            "#1": "Phrases in app/Main.tsx",
             "title": "Open trades",
         },
     )
     diff_text = """diff --git a/locales/de.json b/locales/de.json
 +++ b/locales/de.json
-+  "#1": "Phrases in basic/Main.tsx",
++  "#1": "Phrases in app/Main.tsx",
 +  "title": "Open trades",
 """
 


### PR DESCRIPTION
## Why

This repository is published as a GitHub Action and a Docker image. Two
classes of material were reaching, or could reach, those artifacts:

1. **Local-only commercial material** — prospect research, outreach drafts
   and staged per-project artifacts living in tracked directories
   (`outreach/`, several `docs/*.md`). None of it is committed, but it sits
   in tracked directories, so a single `git add -A` would have committed the
   whole set. It also entered locally-built Docker images: `.dockerignore`
   mirrored `.gitignore` for `claudedocs/` and `docs/requirements/` but had
   no entry for these, and the Dockerfile copies the build context wholesale
   (`COPY . .`). Verified on an image built from a working tree containing
   the material — `/app/outreach/` and the customer-discovery docs were
   present.

   **Scope, stated precisely:** production is not affected. Both server
   deployments are clean clones of `main`, so their images never contained
   this material — confirmed on the running images. This change is
   preventive: it closes the `git add -A` path and stops the material
   entering any image built from a working tree that has it.

2. **A named third-party project** in the example config and test
   fixtures — by product name and by that project's own source paths.
   Naming one adopter couples the examples to it and discloses who the
   pipeline has been trialled with.

## What changed

- `.gitignore` / `.dockerignore`: exclude `outreach/` and the commercial
  docs. Dossiers are matched by pattern (`docs/*-dossier.md`) so the rules
  name no third party themselves. Ignored in place — nothing relocated.
- `.gitignore`: also ignore test-generated logs. Loading a config writes
  `logs/` next to the config file, so any fixture config leaves one behind
  when a test loads it (this is why `tests/integration/logs/` had been
  sitting untracked-but-unignored).
- Example config and test fixtures now use the `Acme` placeholder already
  used elsewhere in the suite, plus generic source paths. Fixture text
  only — no behaviour change.
- Fixed a vacuous assertion the rename introduced (CodeRabbit): the
  ignored-key test checked for a string the fixture no longer contained.

## Testing

- `venv/bin/pytest` — 703 passed, 4 subtests. Identical to the pre-change
  baseline; no pre-existing test modified for this to pass.
- Docker image rebuilt and run locally, since both edited files enter it
  via `COPY . .`: `/app/outreach` no longer exists and
  `python3 -m localize.cli formats` still works.
- Confirmed `git add -A` no longer stages any commercial material, and no
  third-party name remains anywhere in the tracked tree.
- Confirmed the corrected assertion is not vacuous: the captured prompt
  list is non-empty and contains other fixture text, so a leak would fail
  it.