### PR TITLE
Preserve the Telebirr brand name

### DIFF
--- a/profiles/bisq/config.yaml
+++ b/profiles/bisq/config.yaml
@@ -686,6 +686,7 @@ brand_technical_glossary:
   - SWIFT
   - SWIFT International Wire Transfer
   - Swish
+  - Telebirr
   - Tikkie
   - Tor
   - UPI

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -460,6 +460,18 @@ def test_preimage_is_a_protected_brand_technical_term():
     assert {"Lightning", "Lightning Escrow", "Submarine Swaps"}.issubset(set(brand_glossary))
 
 
+def test_telebirr_is_a_protected_brand_term():
+    """Keep the Telebirr payment-method name in its official spelling.
+
+    bisq2#4904 transliterated Telebirr in thirteen locales even though the
+    source value is a brand name. The protected glossary must make exact
+    source-identical values intentional and keep the model from rewriting it.
+    """
+    config = yaml.safe_load(BISQ_PROFILE_CONFIG.read_text(encoding="utf-8"))
+
+    assert "Telebirr" in config["brand_technical_glossary"]
+
+
 _NETWORK_RULE_IDS = {
     "network-seed-node-not-seed-phrase",
     "network-transport-not-physical-transport",


### PR DESCRIPTION
## Problem

Recent automated Bisq 2 translations transliterated the official Telebirr
payment-method brand in 13 locales. Telebirr is a proper product name and must
remain unchanged, just like Bisq, MuSig, Lightning, I2P, and Tor.

## Change

- Add Telebirr to the Bisq profile's protected brand glossary.
- Add a regression assertion so future configuration edits cannot remove it.

## Validation

- 698 tests passed.
- The regression test failed before the glossary change and passes now.

