### PR TITLE
Block incomplete model translations

### DIFF
--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -2575,6 +2575,8 @@ async def process_translation_queue(
             )
             failed_keys = set(per_key_summary["failed_keys"]).union(model_failed_keys)
             increment_run_metric(run_metrics, "model_translation_failed_count", len(failed_keys))
+            per_key_summary["model_translation_failed_count"] = len(model_failed_keys)
+            per_key_summary["model_translation_failed_keys"] = sorted(model_failed_keys)
             if validation_summary is not None:
                 validation_summary[translation_file] = per_key_summary
 

--- a/localize/translation_quality_gate.py
+++ b/localize/translation_quality_gate.py
@@ -482,6 +482,7 @@ def _aggregate_validation(
         "reverted_keys_count": 0,
         "control_character_findings_count": 0,
         "placeholder_failures_count": 0,
+        "model_translation_failed_count": 0,
     }
     for filename, file_summary in validation_summary.get("files", {}).items():
         if changed_relative_files and not _file_matches_changed_files(filename, changed_relative_files):
@@ -491,6 +492,9 @@ def _aggregate_validation(
             file_summary.get("control_character_findings_count", 0)
         )
         totals["placeholder_failures_count"] += int(file_summary.get("placeholder_failures_count", 0))
+        totals["model_translation_failed_count"] += int(
+            file_summary.get("model_translation_failed_count", 0)
+        )
     return totals
 
 
@@ -635,6 +639,8 @@ def build_quality_gate_report(
         blocking_reasons.append("Control-character artifacts require manual resolution.")
     if validation_totals["placeholder_failures_count"]:
         blocking_reasons.append("Placeholder parity failures require manual resolution.")
+    if validation_totals["model_translation_failed_count"]:
+        blocking_reasons.append("Model translation failures require manual resolution.")
 
     if config.block_on_semantic_qa_findings and semantic_stats.errors_count:
         blocking_reasons.append("Semantic translation QA findings require manual resolution.")
@@ -768,6 +774,7 @@ def render_quality_gate_markdown(report: Dict[str, Any]) -> str:
             f"| Reverted keys | {validation['reverted_keys_count']} |",
             f"| Control-character findings | {validation['control_character_findings_count']} |",
             f"| Placeholder failures | {validation['placeholder_failures_count']} |",
+            f"| Model translation failures | {validation.get('model_translation_failed_count', 0)} |",
             f"| Pipeline warnings | {report['pipeline_warnings_count']} |",
             "",
         ]

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -256,6 +256,7 @@ async def test_failed_model_translation_marks_ledger_and_skips_memory(integratio
     target_file_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
     ledger_path = os.path.join(env['input_folder'], 'ledger.json')
     memory_path = os.path.join(env['input_folder'], 'translation_memory.json')
+    validation_summary = {}
 
     with open(source_file_path, 'w', encoding='utf-8') as f:
         f.write("key.fail=Needs translation\n")
@@ -281,11 +282,14 @@ async def test_failed_model_translation_marks_ledger_and_skips_memory(integratio
         await localize.translate_localization_files.process_translation_queue(
             translation_queue_folder=env['translation_queue_folder'],
             translated_queue_folder=env['translated_queue_folder'],
-            glossary_file_path=env['mock_glossary_path_resolved']
+            glossary_file_path=env['mock_glossary_path_resolved'],
+            validation_summary=validation_summary,
         )
 
     ledger = localize.translate_localization_files.load_translation_key_ledger(ledger_path)
     assert ledger["app_de.properties"]["key.fail"]["status"] == "failed"
+    assert validation_summary["app_de.properties"]["model_translation_failed_count"] == 1
+    assert validation_summary["app_de.properties"]["model_translation_failed_keys"] == ["key.fail"]
 
     memory = load_translation_memory(memory_path)
     assert memory.lookup(

--- a/tests/unit/test_translation_quality_gate.py
+++ b/tests/unit/test_translation_quality_gate.py
@@ -507,6 +507,35 @@ def test_validation_control_and_placeholder_failures_are_blocking():
     assert any("Placeholder parity" in reason for reason in report["blocking_reasons"])
 
 
+def test_model_translation_failures_are_blocking():
+    report = build_quality_gate_report(
+        source_stats=analyze_source_identical_changes(
+            diff_text="",
+            repo_root=".",
+            input_folder="resources",
+            locale_codes=["es"],
+            brand_glossary=[],
+        ),
+        semantic_stats=None,
+        validation_summary={
+            "files": {
+                "mobile_es.properties": {
+                    "model_translation_failed_count": 1,
+                    "model_translation_failed_keys": ["mobile.example"],
+                }
+            },
+            "pipeline_warnings": [],
+        },
+        changed_files=["resources/mobile_es.properties"],
+        input_folder="resources",
+        config=QualityGateConfig(block_on_pipeline_warnings=False),
+    )
+
+    assert report["blocking"] is True
+    assert report["validation"]["model_translation_failed_count"] == 1
+    assert any("Model translation" in reason for reason in report["blocking_reasons"])
+
+
 def test_pipeline_warnings_are_filtered_to_current_batch():
     report = build_quality_gate_report(
         source_stats=analyze_source_identical_changes(
@@ -824,6 +853,7 @@ def test_quality_gate_markdown_contains_validation_summary():
     assert "Semantic QA Examples" in markdown
     assert "Reverted keys" in markdown
     assert "Control-character findings" in markdown
+    assert "| Model translation failures | 0 |" in markdown
 
 
 def test_quality_gate_markdown_escapes_semantic_review_text():


### PR DESCRIPTION
## Problem

The translation model can return explicit per-key failures while the generated
file still passes placeholder and encoding checks. The pipeline previously
reported those failures only in logs, so an incomplete automated translation
could still be proposed for merge.

## Change

- Record failed model keys in each file-validation result.
- Aggregate the failure count and affected keys in the quality-gate summary.
- Make any model translation failure a blocking gate condition.
- Keep Markdown rendering compatible with older validation reports.
- Cover the behavior at both unit and integration levels.

## Validation

- 698 tests passed, 4 subtests passed.
- The regression test failed before the gate implementation and passes now.

