### PR TITLE
Patch pipeline security dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,26 @@ RUN /out/yq --version && \
     grep -E "golang[.]org/x/text[[:space:]]+v${X_TEXT_VERSION}([[:space:]]|$)" \
         /tmp/yq-buildinfo
 
+FROM golang:1.26.4-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d11e9c270a8f85106203d AS tx-builder
+
+ARG TX_VERSION=1.6.17
+ARG TX_COMMIT=30dac142446db7bd1919894e9eb93545f58cc980
+ARG GO_GIT_VERSION=5.19.2
+ENV CGO_ENABLED=0
+
+WORKDIR /src/tx
+RUN git clone --depth 1 --branch "v${TX_VERSION}" \
+        https://github.com/transifex/cli.git . && \
+    test "$(git rev-parse HEAD)" = "$TX_COMMIT" && \
+    go get "github.com/go-git/go-git/v5@v${GO_GIT_VERSION}" && \
+    go build -p=1 -trimpath \
+        -ldflags="-s -w -X github.com/transifex/cli/internal/txlib.Version=v${TX_VERSION}" \
+        -o /out/tx .
+RUN /out/tx --version && \
+    go version -m /out/tx > /tmp/tx-buildinfo && \
+    grep -E "github[.]com/go-git/go-git/v5[[:space:]]+v${GO_GIT_VERSION}([[:space:]]|$)" \
+        /tmp/tx-buildinfo
+
 FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 # Set SHELL to fail on pipeline errors
@@ -74,6 +94,9 @@ RUN gh --version
 COPY --from=yq-builder /out/yq /usr/bin/yq
 RUN yq --version
 
+COPY --from=tx-builder /out/tx /usr/local/bin/tx
+RUN tx --version
+
 # Download and install gosu for user switching
 RUN set -eux; \
     GOSU_VERSION=1.19; \
@@ -97,22 +120,6 @@ RUN groupadd --gid 9999 appuser && \
 
 # Make python3.11 the default python3
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-
-# Install Transifex CLI
-RUN TX_VERSION="v1.6.17" && \
-    CONTAINER_ARCH=$(dpkg --print-architecture) && \
-    if [ "$CONTAINER_ARCH" = "amd64" ]; then \
-        TX_ARCH="linux-amd64"; \
-        TX_SHA256="002dec5b9e71248a7e6a0808118e9da940205828d5a33ce88e04bb57a967164d"; \
-    elif [ "$CONTAINER_ARCH" = "arm64" ]; then \
-        TX_ARCH="linux-arm64"; \
-        TX_SHA256="c380ed9aece5d34316aa0fe2e5afa0633553656f98909f88cb72609e2fa13153"; \
-    else echo "Unsupported architecture for Transifex CLI: $CONTAINER_ARCH"; exit 1; fi && \
-    curl -Lf -O "https://github.com/transifex/cli/releases/download/${TX_VERSION}/tx-${TX_ARCH}.tar.gz" && \
-    echo "$TX_SHA256  tx-${TX_ARCH}.tar.gz" | sha256sum -c - && \
-    tar -xzf "tx-${TX_ARCH}.tar.gz" -C /usr/local/bin tx && \
-    rm "tx-${TX_ARCH}.tar.gz" && \
-    tx --version
 
 # Private deploy and GPG keys are mounted as runtime secrets and installed by
 # docker-entrypoint.sh so they never persist in image layers.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d11e9c270a8f85106203d AS gh-builder
+FROM golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36 AS gh-builder
 
 ARG GH_VERSION=2.96.0
 ARG GH_COMMIT=b300f2ec7ec9dc9addc39b2ad88c54097ded7ca0
@@ -20,7 +20,7 @@ RUN go version -m /out/gh > /tmp/gh-buildinfo && \
     grep -E "golang[.]org/x/text[[:space:]]+v${X_TEXT_VERSION}([[:space:]]|$)" \
         /tmp/gh-buildinfo
 
-FROM golang:1.26.4-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d11e9c270a8f85106203d AS yq-builder
+FROM golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36 AS yq-builder
 
 ARG YQ_VERSION=4.53.3
 ARG YQ_COMMIT=1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d
@@ -38,7 +38,7 @@ RUN /out/yq --version && \
     grep -E "golang[.]org/x/text[[:space:]]+v${X_TEXT_VERSION}([[:space:]]|$)" \
         /tmp/yq-buildinfo
 
-FROM golang:1.26.4-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d11e9c270a8f85106203d AS tx-builder
+FROM golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36 AS tx-builder
 
 ARG TX_VERSION=1.6.17
 ARG TX_COMMIT=30dac142446db7bd1919894e9eb93545f58cc980
@@ -57,6 +57,24 @@ RUN /out/tx --version && \
     go version -m /out/tx > /tmp/tx-buildinfo && \
     grep -E "github[.]com/go-git/go-git/v5[[:space:]]+v${GO_GIT_VERSION}([[:space:]]|$)" \
         /tmp/tx-buildinfo
+
+FROM golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36 AS gosu-builder
+
+ARG GOSU_VERSION=1.19
+ARG GOSU_COMMIT=6456aaa0f3c854d199d0f037f068eb97515b7513
+ARG X_SYS_VERSION=0.46.0
+ENV CGO_ENABLED=0
+
+WORKDIR /src/gosu
+RUN git clone --depth 1 --branch "${GOSU_VERSION}" \
+        https://github.com/tianon/gosu.git . && \
+    test "$(git rev-parse HEAD)" = "$GOSU_COMMIT" && \
+    go get "golang.org/x/sys@v${X_SYS_VERSION}" && \
+    go build -trimpath -ldflags="-s -w" -o /out/gosu .
+RUN /out/gosu --version && \
+    go version -m /out/gosu > /tmp/gosu-buildinfo && \
+    grep -E "golang[.]org/x/sys[[:space:]]+v${X_SYS_VERSION}([[:space:]]|$)" \
+        /tmp/gosu-buildinfo
 
 FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
@@ -97,21 +115,8 @@ RUN yq --version
 COPY --from=tx-builder /out/tx /usr/local/bin/tx
 RUN tx --version
 
-# Download and install gosu for user switching
-RUN set -eux; \
-    GOSU_VERSION=1.19; \
-    GOSU_ARCH="$(dpkg --print-architecture)"; \
-    curl -sSL -o /usr/sbin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$GOSU_ARCH"; \
-    if [ "$GOSU_ARCH" = "amd64" ]; then \
-        GOSU_SHA256="52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0"; \
-    elif [ "$GOSU_ARCH" = "arm64" ]; then \
-        GOSU_SHA256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44"; \
-    else \
-        echo "Unsupported architecture: $GOSU_ARCH" >&2; \
-        exit 1; \
-    fi; \
-    echo "$GOSU_SHA256 /usr/sbin/gosu" | sha256sum -c -; \
-    chmod +x /usr/sbin/gosu
+COPY --from=gosu-builder /out/gosu /usr/sbin/gosu
+RUN gosu --version
 
 # Create a non-root user 'appuser' with a fixed, non-conflicting UID/GID.
 # The home directory is created at /home/appuser.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -171,9 +171,9 @@ gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
     # via gitpython
-gitpython==3.1.55 \
-    --hash=sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f \
-    --hash=sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e
+gitpython==3.1.58 \
+    --hash=sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22 \
+    --hash=sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f
     # via -r requirements.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -141,9 +141,9 @@ gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
     # via gitpython
-gitpython==3.1.55 \
-    --hash=sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f \
-    --hash=sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e
+gitpython==3.1.58 \
+    --hash=sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22 \
+    --hash=sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f
     # via -r requirements.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \

--- a/tests/unit/test_shell_packaging_scripts.py
+++ b/tests/unit/test_shell_packaging_scripts.py
@@ -101,23 +101,34 @@ def test_dockerfile_uses_orchestration_default_command():
 def test_dockerfile_builds_go_tools_with_fixed_dependencies():
     dockerfile = (REPO_ROOT / "docker" / "Dockerfile").read_text(encoding="utf-8")
 
+    go_builder = (
+        "FROM golang:1.26.6-bookworm@"
+        "sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36"
+    )
+    assert dockerfile.count(go_builder) == 4
     assert "ARG GH_VERSION=2.96.0" in dockerfile
     assert "ARG GH_COMMIT=b300f2ec7ec9dc9addc39b2ad88c54097ded7ca0" in dockerfile
     assert "ARG YQ_VERSION=4.53.3" in dockerfile
     assert "ARG YQ_COMMIT=1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d" in dockerfile
     assert "ARG TX_VERSION=1.6.17" in dockerfile
     assert "ARG TX_COMMIT=30dac142446db7bd1919894e9eb93545f58cc980" in dockerfile
+    assert "ARG GOSU_VERSION=1.19" in dockerfile
+    assert "ARG GOSU_COMMIT=6456aaa0f3c854d199d0f037f068eb97515b7513" in dockerfile
+    assert "ARG X_SYS_VERSION=0.46.0" in dockerfile
     assert "ARG GRPC_VERSION=1.82.1" in dockerfile
     assert "ARG GO_GIT_VERSION=5.19.2" in dockerfile
     assert "ARG X_TEXT_VERSION=0.40.0" in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$GH_COMMIT"' in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$YQ_COMMIT"' in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$TX_COMMIT"' in dockerfile
+    assert 'test "$(git rev-parse HEAD)" = "$GOSU_COMMIT"' in dockerfile
     assert 'go get "google.golang.org/grpc@v${GRPC_VERSION}"' in dockerfile
     assert 'go get "github.com/go-git/go-git/v5@v${GO_GIT_VERSION}"' in dockerfile
+    assert 'go get "golang.org/x/sys@v${X_SYS_VERSION}"' in dockerfile
     assert dockerfile.count('go get "golang.org/x/text@v${X_TEXT_VERSION}"') == 2
     assert "COPY --from=yq-builder /out/yq /usr/bin/yq" in dockerfile
     assert "COPY --from=tx-builder /out/tx /usr/local/bin/tx" in dockerfile
+    assert "COPY --from=gosu-builder /out/gosu /usr/sbin/gosu" in dockerfile
 
 
 def test_dockerignore_excludes_local_configs_and_agent_scratch():

--- a/tests/unit/test_shell_packaging_scripts.py
+++ b/tests/unit/test_shell_packaging_scripts.py
@@ -105,13 +105,19 @@ def test_dockerfile_builds_go_tools_with_fixed_dependencies():
     assert "ARG GH_COMMIT=b300f2ec7ec9dc9addc39b2ad88c54097ded7ca0" in dockerfile
     assert "ARG YQ_VERSION=4.53.3" in dockerfile
     assert "ARG YQ_COMMIT=1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d" in dockerfile
+    assert "ARG TX_VERSION=1.6.17" in dockerfile
+    assert "ARG TX_COMMIT=30dac142446db7bd1919894e9eb93545f58cc980" in dockerfile
     assert "ARG GRPC_VERSION=1.82.1" in dockerfile
+    assert "ARG GO_GIT_VERSION=5.19.2" in dockerfile
     assert "ARG X_TEXT_VERSION=0.40.0" in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$GH_COMMIT"' in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$YQ_COMMIT"' in dockerfile
+    assert 'test "$(git rev-parse HEAD)" = "$TX_COMMIT"' in dockerfile
     assert 'go get "google.golang.org/grpc@v${GRPC_VERSION}"' in dockerfile
+    assert 'go get "github.com/go-git/go-git/v5@v${GO_GIT_VERSION}"' in dockerfile
     assert dockerfile.count('go get "golang.org/x/text@v${X_TEXT_VERSION}"') == 2
     assert "COPY --from=yq-builder /out/yq /usr/bin/yq" in dockerfile
+    assert "COPY --from=tx-builder /out/tx /usr/local/bin/tx" in dockerfile
 
 
 def test_dockerignore_excludes_local_configs_and_agent_scratch():
@@ -136,13 +142,12 @@ def test_dockerignore_excludes_local_configs_and_agent_scratch():
         assert pattern in dockerignore
 
 
-def test_dockerfile_verifies_transifex_cli_tarball_checksum():
+def test_dockerfile_rebuilds_transifex_cli_instead_of_using_vendor_binary():
     dockerfile = (REPO_ROOT / "docker" / "Dockerfile").read_text(encoding="utf-8")
 
-    assert "TX_SHA256" in dockerfile
-    assert "002dec5b9e71248a7e6a0808118e9da940205828d5a33ce88e04bb57a967164d" in dockerfile
-    assert "c380ed9aece5d34316aa0fe2e5afa0633553656f98909f88cb72609e2fa13153" in dockerfile
-    assert 'echo "$TX_SHA256  tx-${TX_ARCH}.tar.gz" | sha256sum -c -' in dockerfile
+    assert "TX_SHA256" not in dockerfile
+    assert "github.com/transifex/cli.git" in dockerfile
+    assert "go version -m /out/tx" in dockerfile
 
 
 def test_run_local_translation_resolves_config_before_chdir():


### PR DESCRIPTION
## Problem

The current image installs the latest official Transifex CLI release (v1.6.17),
but that vendor binary embeds `go-git` v5.3.0. Trivy now reports
CVE-2026-71556 as high severity; the fixed version is v5.19.2. Transifex has not
published a newer release and still pins v5.3.0 on its development branch.

This newly disclosed finding blocks the Python 3.11 Docker/Trivy job on every
open pipeline PR. Conversely, the standalone GitPython update fails its Docker
job on this Transifex finding, so the two security updates must land together.

## Change

- Rebuild the same pinned Transifex v1.6.17 source tag with the current pinned
  Go builder and `go-git` v5.19.2.
- Verify the Transifex source commit before building.
- Verify the patched dependency in the resulting binary with `go version -m`.
- Replace the vendor-tarball regression test with source-build provenance and
  dependency assertions.
- Upgrade GitPython from 3.1.55 to 3.1.58, incorporating Dependabot PR #140.
- Move all source-built helpers to the patched, digest-pinned Go 1.26.6 image.
- Rebuild the pinned gosu 1.19 source with current `x/sys` instead of installing
  the vendor binary built with vulnerable Go 1.24.6.

## Validation

- 697 tests passed, 4 subtests passed.
- The source-build regression test failed before the Dockerfile change.
- Local Docker compilation resolved and compiled the patched dependency but
  the developer Docker VM exhausted its image-store capacity before the final
  link; GitHub CI performs the authoritative clean image build and Trivy scan.
