### PR TITLE
Prioritize sibling keys in translation context

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930
 ARG GH_VERSION=2.96.0
 ARG GH_COMMIT=b300f2ec7ec9dc9addc39b2ad88c54097ded7ca0
 ARG GRPC_VERSION=1.82.1
-ARG X_TEXT_VERSION=0.40.0
+ARG X_MOD_VERSION=0.40.0
+ARG X_TEXT_VERSION=0.41.0
 ENV CGO_ENABLED=0
 
 WORKDIR /src/gh
@@ -11,11 +12,14 @@ RUN git clone --depth 1 --branch "v${GH_VERSION}" \
         https://github.com/cli/cli.git . && \
     test "$(git rev-parse HEAD)" = "$GH_COMMIT" && \
     go get "google.golang.org/grpc@v${GRPC_VERSION}" && \
+    go get "golang.org/x/mod@v${X_MOD_VERSION}" && \
     go get "golang.org/x/text@v${X_TEXT_VERSION}" && \
     GH_VERSION="${GH_VERSION}" go run script/build.go bin/gh && \
     install -D bin/gh /out/gh
 RUN go version -m /out/gh > /tmp/gh-buildinfo && \
     grep -E "google[.]golang[.]org/grpc[[:space:]]+v${GRPC_VERSION}([[:space:]]|$)" \
+        /tmp/gh-buildinfo && \
+    grep -E "golang[.]org/x/mod[[:space:]]+v${X_MOD_VERSION}([[:space:]]|$)" \
         /tmp/gh-buildinfo && \
     grep -E "golang[.]org/x/text[[:space:]]+v${X_TEXT_VERSION}([[:space:]]|$)" \
         /tmp/gh-buildinfo

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -709,6 +709,22 @@ def count_tokens(text: str, model_name: Optional[str] = None) -> int:
     provider = MODEL_PROVIDER or _FALLBACK_PROVIDER
     return provider.count_tokens(text, model_name or MODEL_NAME)
 
+def _shared_key_prefix_length(key_a: str, key_b: str) -> int:
+    """Return the number of leading dot-separated segments two keys share.
+
+    Used to rank existing translations by how closely related they are to the
+    key currently being translated, so that sibling keys establishing a
+    concept's terminology are preferred when the context window is
+    size-limited.
+    """
+    shared = 0
+    for segment_a, segment_b in zip(key_a.split("."), key_b.split(".")):
+        if segment_a != segment_b:
+            break
+        shared += 1
+    return shared
+
+
 def build_context(
         existing_translations: Dict[str, str],
         source_translations: Dict[str, str],
@@ -716,6 +732,7 @@ def build_context(
         max_tokens: int,
         model_name: str,
         system_prompt_text: str = "",
+        current_key: Optional[str] = None,
 ) -> Tuple[str, str]:
     """
     Build the context and glossary text for the translation prompt.
@@ -726,6 +743,9 @@ def build_context(
         language_glossary (Dict[str, str]): The glossary for the language.
         max_tokens (int): Maximum allowed tokens.
         model_name (str): The model name.
+        current_key (Optional[str]): The key being translated. When provided,
+            sibling keys sharing a dotted prefix with it are surfaced first so
+            established terminology survives the context-window truncation.
 
     Returns:
         Tuple[str, str]: The context examples text and glossary text.
@@ -743,8 +763,26 @@ def build_context(
     reserved_tokens = 1000 + count_tokens(system_prompt_text, model_name)
     available_tokens = max_tokens - glossary_tokens - reserved_tokens
 
+    # Order existing translations so keys most closely related to the key being
+    # translated come first. The context window is bounded by available_tokens
+    # and is frequently too small to hold every existing translation, so without
+    # prioritisation the sibling keys that establish a concept's terminology
+    # (for example ...pairingCode.textField / ...pairingCode.invalid relative to
+    # ...pairingCode.unsupportedVersion) get truncated away, and the model then
+    # retranslates the shared term independently and drifts from the established
+    # wording. A stable sort by shared dotted-prefix length keeps siblings near
+    # the top while preserving the original order among unrelated keys.
+    ordered_translations = list(existing_translations.items())
+    if current_key:
+        ordered_translations.sort(
+            key=lambda item: _shared_key_prefix_length(item[0], current_key),
+            reverse=True,
+        )
+
     # Iterate over existing translations
-    for key, translated_value in existing_translations.items():
+    for key, translated_value in ordered_translations:
+        if current_key is not None and key == current_key:
+            continue  # Never feed the key its own prior translation back as context
         source_value = source_translations.get(key)
         if not source_value:
             continue  # Skip if source value is missing
@@ -1283,6 +1321,7 @@ async def translate_text_async(
             MAX_MODEL_TOKENS,
             MODEL_NAME,
             system_prompt_text=system_prompt,
+            current_key=key,
         )
 
         # Extract and protect placeholders

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -799,7 +799,10 @@ def build_context(
         example = f"{key} = \"{translated_value}\""
         example_tokens = count_tokens(example, model_name)
         if total_tokens + example_tokens > available_tokens:
-            break
+            # A long sibling can exceed the remaining budget while a later,
+            # shorter sibling still fits. Keep searching instead of hiding all
+            # remaining terminology context behind the first oversized entry.
+            continue
         context_examples.append(example)
         total_tokens += example_tokens
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,7 +5,8 @@
 
 pytest>=9.0.3
 pytest-asyncio>=1.2
-pip-tools
+pip>=26.2
+pip-tools>=7.6.1
 ruff
 pip-audit
 setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -397,9 +397,9 @@ pip-requirements-parser==32.0.1 \
     --hash=sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526 \
     --hash=sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3
     # via pip-audit
-pip-tools==7.5.0 \
-    --hash=sha256:30639f50961bb09f49d22f4389e8d7d990709677c094ce1114186b1f2e9b5821 \
-    --hash=sha256:69758e4e5a65f160e315d74db46246fdbb30d549f1ed0c4236d057122c9b0f18
+pip-tools==7.6.1 \
+    --hash=sha256:6111c8b4b07fd14b7223ca921485b0e96cf66e20bf94da95eeed9845f510cb8f \
+    --hash=sha256:695556edeb647eb94ee8345cc7108657fdb7fb16b3876623a399b4f61bbede01
     # via -r requirements-dev.in
 platformdirs==4.4.0 \
     --hash=sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85 \
@@ -981,10 +981,11 @@ wheel==0.46.2 \
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.2 \
-    --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
-    --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
+pip==26.2.1 \
+    --hash=sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e \
+    --hash=sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f
     # via
+    #   -r requirements-dev.in
     #   pip-api
     #   pip-tools
 setuptools==83.0.0 \

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -277,6 +277,51 @@ class TestCoreLogic(unittest.TestCase):
             self.assertIn("key1", context_text)
             self.assertNotIn("key2", context_text)
 
+    def test_build_context_prioritizes_sibling_keys(self):
+        """
+        Tests that build_context surfaces sibling keys (sharing a dotted prefix
+        with the key being translated) even when the token budget only fits one
+        example, and never feeds the key its own prior translation back.
+        """
+        def mock_count_tokens(text: str, model_name: str) -> int:
+            return len(text)
+
+        with patch('localize.translate_localization_files.count_tokens', side_effect=mock_count_tokens):
+            # The sibling terminology key is deliberately last in insertion order.
+            existing_translations = {
+                "app.unrelated.first": "translationA",
+                "app.unrelated.second": "translationB",
+                "trusted.pairingCode.unsupportedVersion": "old value",
+                "trusted.pairingCode.textField": "Kode pasangan",
+            }
+            source_translations = {
+                "app.unrelated.first": "sourceA",
+                "app.unrelated.second": "sourceB",
+                "trusted.pairingCode.unsupportedVersion": "Old value source",
+                "trusted.pairingCode.textField": "Pairing code",
+            }
+            language_glossary = {}
+            model_name = "test-model"
+            sibling_example = 'trusted.pairingCode.textField = "Kode pasangan"'
+            reserved_len = 1000
+            # Budget for exactly one example beyond the reserved block.
+            max_tokens = reserved_len + mock_count_tokens(sibling_example, model_name) + 1
+
+            context_text, _ = build_context(
+                existing_translations,
+                source_translations,
+                language_glossary,
+                max_tokens,
+                model_name,
+                current_key="trusted.pairingCode.unsupportedVersion",
+            )
+
+            self.assertEqual(context_text.count("="), 1)
+            self.assertIn("trusted.pairingCode.textField", context_text)
+            self.assertNotIn("app.unrelated.first", context_text)
+            # The key being translated is never fed back as its own context.
+            self.assertNotIn("trusted.pairingCode.unsupportedVersion", context_text)
+
     def test_normalize_value_logic(self):
         """Tests the `normalize_value` helper function."""
         self.assertEqual(normalize_value("hello\nworld"), "hello<newline>world")

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -322,6 +322,34 @@ class TestCoreLogic(unittest.TestCase):
             # The key being translated is never fed back as its own context.
             self.assertNotIn("trusted.pairingCode.unsupportedVersion", context_text)
 
+    def test_build_context_skips_oversized_sibling_and_keeps_searching(self):
+        """An oversized high-priority sibling must not hide later siblings."""
+        def mock_count_tokens(text: str, model_name: str) -> int:
+            return len(text)
+
+        with patch('localize.translate_localization_files.count_tokens', side_effect=mock_count_tokens):
+            existing_translations = {
+                "trusted.pairingCode.longExplanation": "x" * 200,
+                "trusted.pairingCode.textField": "Kode pasangan",
+            }
+            source_translations = {
+                "trusted.pairingCode.longExplanation": "Long explanation",
+                "trusted.pairingCode.textField": "Pairing code",
+            }
+            short_example = 'trusted.pairingCode.textField = "Kode pasangan"'
+            max_tokens = 1000 + mock_count_tokens(short_example, "test-model") + 1
+
+            context_text, _ = build_context(
+                existing_translations,
+                source_translations,
+                {},
+                max_tokens,
+                "test-model",
+                current_key="trusted.pairingCode.unsupportedVersion",
+            )
+
+            self.assertEqual(context_text, short_example)
+
     def test_normalize_value_logic(self):
         """Tests the `normalize_value` helper function."""
         self.assertEqual(normalize_value("hello\nworld"), "hello<newline>world")

--- a/tests/unit/test_shell_packaging_scripts.py
+++ b/tests/unit/test_shell_packaging_scripts.py
@@ -116,16 +116,20 @@ def test_dockerfile_builds_go_tools_with_fixed_dependencies():
     assert "ARG GOSU_COMMIT=6456aaa0f3c854d199d0f037f068eb97515b7513" in dockerfile
     assert "ARG X_SYS_VERSION=0.46.0" in dockerfile
     assert "ARG GRPC_VERSION=1.82.1" in dockerfile
+    assert "ARG X_MOD_VERSION=0.40.0" in dockerfile
     assert "ARG GO_GIT_VERSION=5.19.2" in dockerfile
+    assert "ARG X_TEXT_VERSION=0.41.0" in dockerfile
     assert "ARG X_TEXT_VERSION=0.40.0" in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$GH_COMMIT"' in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$YQ_COMMIT"' in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$TX_COMMIT"' in dockerfile
     assert 'test "$(git rev-parse HEAD)" = "$GOSU_COMMIT"' in dockerfile
     assert 'go get "google.golang.org/grpc@v${GRPC_VERSION}"' in dockerfile
+    assert 'go get "golang.org/x/mod@v${X_MOD_VERSION}"' in dockerfile
     assert 'go get "github.com/go-git/go-git/v5@v${GO_GIT_VERSION}"' in dockerfile
     assert 'go get "golang.org/x/sys@v${X_SYS_VERSION}"' in dockerfile
     assert dockerfile.count('go get "golang.org/x/text@v${X_TEXT_VERSION}"') == 2
+    assert "golang[.]org/x/mod[[:space:]]+v${X_MOD_VERSION}" in dockerfile
     assert "COPY --from=yq-builder /out/yq /usr/bin/yq" in dockerfile
     assert "COPY --from=tx-builder /out/tx /usr/local/bin/tx" in dockerfile
     assert "COPY --from=gosu-builder /out/gosu /usr/sbin/gosu" in dockerfile


### PR DESCRIPTION
## Status

**Ready for review.** The relevance-ranking change and its token-budget edge
case are covered by regression tests, the full suite passes, and the package
build succeeds.

## Problem

The per-key context supplied to the translation model is capped by
`max_model_tokens`. Existing translations were previously considered in file
order, so sibling keys that establish a concept's terminology could fall
outside the context window. This caused recurring terminology drift, observed
in `bisq-mobile#1735` for localized “pairing code” strings.

## Change

- Rank existing translations by shared dotted-key prefix so the closest
  siblings are considered first.
- Exclude the key currently being translated from its own context.
- Preserve insertion order among equally related keys and preserve the legacy
  order when no current key is supplied.
- If a high-priority example is too large for the remaining token budget, keep
  searching for a shorter sibling instead of stopping context construction.

The last item closes an edge case found during final review of this PR: one
oversized sibling could otherwise hide every useful example after it.

The refreshed CI run also exposed a newly published advisory for the pinned
development `pip` release. The development input now requires `pip>=26.2` and
`pip-tools>=7.6.1`; the regenerated lock pins compatible, audited releases.
The subsequent container scan disclosed two `golang.org/x/mod` vulnerabilities
inside the pinned GitHub CLI binary. Its build now pins the fixed `v0.40.0`
module and verifies the embedded module version before copying the binary.

## Validation

- `.venv311/bin/ruff check .` — passed
- `.venv311/bin/pytest` — **703 passed**
- `.venv311/bin/pip-audit -r requirements.txt` — no known vulnerabilities
- `.venv311/bin/pip-audit -r requirements-dev.txt` — no known vulnerabilities
- `.venv311/bin/python -m build` — sdist and wheel built successfully
- GitHub CLI Docker builder stage — built successfully with embedded
  `golang.org/x/mod v0.40.0` verified from binary metadata
- Regression coverage verifies sibling priority, self-exclusion, token-budget
  enforcement, and skipping oversized siblings while retaining shorter ones

The secret-free local Docker build reached the base-image package-install step
but the upstream Ubuntu/PPA mirrors rejected their own repository signatures.
The GitHub Docker build remains the authoritative clean-environment check for
the pushed head.

## Trade-off

This does not increase `max_model_tokens`; it spends the existing budget on
more relevant examples. In a saturated budget it may scan more candidates,
but it performs no additional model or network calls.
