### PR TITLE
Remove unused GitPython dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.8] - 2026-08-27
+
 ### Fixed
 
 - Split generated translation PRs at 90 files instead of 150. CodeRabbit now
@@ -14,14 +16,17 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
   lead batch that merged with no review at all (`bisq-network/bisq2#4891`
   carried 150 files and 205 of 217 changed values past review). Deployments
   that pin `MAX_FILES_PER_PR` in `docker/.env` must lower it to match.
-- Require GitPython 3.1.55 or newer, refresh both lockfiles, and build GitHub
-  CLI 2.96.0 with gRPC-Go 1.82.1 so dependency and image audits reject the
-  July 2026 advisories.
+- Remove the unused GitPython dependency from the package, GitHub Action, and
+  production image so its current command-execution and denial-of-service
+  advisories are absent rather than suppressed.
+- Build GitHub CLI 2.96.0 with gRPC-Go 1.82.1 so dependency and image audits
+  reject the July 2026 advisories.
 - Reject Vietnamese horn-vowel contamination in non-Vietnamese Bisq locales,
   including canonically equivalent decomposed Unicode text.
 
 ### Changed
 
+- The default bootstrap action ref is now `v0.1.8`.
 - The translation system prompt now instructs the model to match the
   grammatical number of the English source and to keep singular/plural count
   templates (e.g. keys ending in `.single`/`.plural`) distinct, reducing

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.7
+      - uses: bisq-network/localize-pipeline@v0.1.8
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -218,7 +218,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.7
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.8
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -238,7 +238,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.7
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.8
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -320,7 +320,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.7
+- uses: bisq-network/localize-pipeline@v0.1.8
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.7
+      - uses: bisq-network/localize-pipeline@v0.1.8
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.7
+      - uses: bisq-network/localize-pipeline@v0.1.8
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -154,7 +154,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.7
+      - uses: bisq-network/localize-pipeline@v0.1.8
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -173,7 +173,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.7
+      - uses: bisq-network/localize-pipeline@v0.1.8
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -205,7 +205,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.7
+      - uses: bisq-network/localize-pipeline@v0.1.8
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.7
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.8
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -105,7 +105,7 @@ you are ready to let the pipeline write translations.
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.7
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.8
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -127,7 +127,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.7 \
+  --action-ref v0.1.8 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.7"
+    action_ref: str = "v0.1.8"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -579,7 +579,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.7", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.8", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.7"
+version = "0.1.8"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -22,7 +22,6 @@ classifiers = [
 dependencies = [
   "aiolimiter",
   "aisuite==0.1.14",
-  "GitPython>=3.1.55",
   "httpx",
   "jsonschema",
   "openai",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -167,14 +167,6 @@ filelock==3.20.3 \
     --hash=sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1 \
     --hash=sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1
     # via cachecontrol
-gitdb==4.0.12 \
-    --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
-    --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
-    # via gitpython
-gitpython==3.1.58 \
-    --hash=sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22 \
-    --hash=sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f
-    # via -r requirements.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
     --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
@@ -894,10 +886,6 @@ ruff==0.13.0 \
     --hash=sha256:dcd628101d9f7d122e120ac7c17e0a0f468b19bc925501dbe03c1cb7f5415b24 \
     --hash=sha256:fbc6b1934eb1c0033da427c805e27d164bb713f8e273a024a7e86176d7f462cf
     # via -r requirements-dev.in
-smmap==5.0.2 \
-    --hash=sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5 \
-    --hash=sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e
-    # via gitdb
 sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ openai
 aisuite==0.1.14
 python-dotenv
 PyYAML
-GitPython>=3.1.55
 httpx
 tiktoken
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -137,14 +137,6 @@ docstring-parser==0.15 \
     --hash=sha256:48ddc093e8b1865899956fcc03b03e66bb7240c310fac5af81814580c55bf682 \
     --hash=sha256:d1679b86250d269d06a99670924d6bce45adc00b08069dae8c47d98e89b667a9
     # via aisuite
-gitdb==4.0.12 \
-    --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
-    --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
-    # via gitpython
-gitpython==3.1.58 \
-    --hash=sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22 \
-    --hash=sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f
-    # via -r requirements.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
     --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
@@ -686,10 +678,6 @@ rpds-py==0.27.0 \
     # via
     #   jsonschema
     #   referencing
-smmap==5.0.2 \
-    --hash=sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5 \
-    --hash=sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e
-    # via gitdb
 sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -65,7 +65,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.7" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.8" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -444,7 +444,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.7"
+    assert create.call_args.args[0].action_ref == "v0.1.8"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -590,7 +590,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.7"
+    assert pyproject["project"]["version"] == "0.1.8"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -4,7 +4,6 @@ import re
 import tomllib
 import unicodedata
 
-from packaging.version import Version
 import pytest
 import yaml
 
@@ -46,21 +45,17 @@ def test_aisuite_is_packaged_as_primary_provider():
     assert txt_match.group(1) == in_match.group(1)
 
 
-def test_gitpython_security_floor_is_consistent():
+def test_unused_gitpython_dependency_is_absent():
     requirements_in = (PROJECT_ROOT / "requirements.in").read_text(encoding="utf-8")
     pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependency_texts = [
+        requirements_in,
+        "\n".join(pyproject["project"]["dependencies"]),
+        (PROJECT_ROOT / "requirements.txt").read_text(encoding="utf-8"),
+        (PROJECT_ROOT / "requirements-dev.txt").read_text(encoding="utf-8"),
+    ]
 
-    floor_match = re.search(r"^GitPython>=(\S+)$", requirements_in, flags=re.MULTILINE)
-    assert floor_match is not None
-    floor = Version(floor_match.group(1))
-    assert floor >= Version("3.1.55")
-    assert f"GitPython>={floor}" in pyproject["project"]["dependencies"]
-
-    for lockfile in ["requirements.txt", "requirements-dev.txt"]:
-        locked = (PROJECT_ROOT / lockfile).read_text(encoding="utf-8")
-        locked_match = re.search(r"^gitpython==([^\s\\]+)", locked, flags=re.MULTILINE)
-        assert locked_match is not None
-        assert Version(locked_match.group(1)) >= floor
+    assert all("gitpython" not in text.lower() for text in dependency_texts)
 
 
 def test_runtime_requirements_are_hash_pinned():

--- a/tests/unit/test_config_quality.py
+++ b/tests/unit/test_config_quality.py
@@ -50,6 +50,7 @@ def test_unused_gitpython_dependency_is_absent():
     pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     dependency_texts = [
         requirements_in,
+        (PROJECT_ROOT / "requirements-dev.in").read_text(encoding="utf-8"),
         "\n".join(pyproject["project"]["dependencies"]),
         (PROJECT_ROOT / "requirements.txt").read_text(encoding="utf-8"),
         (PROJECT_ROOT / "requirements-dev.txt").read_text(encoding="utf-8"),


### PR DESCRIPTION
## Summary

- remove unused GitPython from package manifests and both generated lockfiles
- prepare v0.1.8 and update the default Action/bootstrap documentation refs
- add a regression check that keeps GitPython out of all dependency surfaces

## Security

Removing the unused package eliminates exposure to GHSA-wvpp-8hx9-p66j and the newer GitPython advisories affecting releases through 3.1.59, rather than retaining code the project does not call.

## Validation

- `ruff check .`
- focused unit tests: 70 passed
- full suite: 705 passed, 4 subtests passed
- runtime and development `pip-audit`: no known vulnerabilities
- source distribution and wheel build; wheel metadata contains no GitPython dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated translation pull requests are now split after 90 files for easier review.
  * Non-Vietnamese Bisq locales now reject Vietnamese horn-vowel contamination.
  * GitHub CLI is built with gRPC-Go 1.82.1.
* **Bug Fixes**
  * Removed the unused GitPython dependency and related packages.
* **Documentation**
  * Updated workflow, CLI, and release examples to use localization pipeline version 0.1.8.
* **Chores**
  * Released version 0.1.8 with updated default action references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->