### PR TITLE
Support indexed property placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.9] - 2026-08-27
+
+### Added
+
+- Add an opt-in `java-indexed` placeholder profile for `%0`, `%1`, and similar
+  tokens, with async-safe profile selection and unchanged default behavior.
+- Add `localization_layout.base_name` for suffix layouts whose source file also
+  carries a locale suffix, such as `Messages_en.properties`.
+
+### Fixed
+
+- Canonicalize Java property keys using `java.util.Properties` escape semantics
+  while preserving their original spelling during synchronization and
+  reassembly; malformed Unicode escapes remain recoverable instead of aborting
+  a run.
+- Enforce configured translation-glossary mappings after both model passes,
+  exclude metadata namespaces from locale data, and include explicit empty
+  target values in backlog runs.
+- Run the translation quality gate before the GitHub Action publishes a pull
+  request, and resolve subdirectory configs relative to the config file.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.9`.
+
 ## [0.1.8] - 2026-08-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.8
+      - uses: bisq-network/localize-pipeline@v0.1.9
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -158,6 +158,16 @@ localization_layout:
   source_locale: "en"
 ```
 
+Suffix layouts can set `base_name` when the source file also carries its locale:
+
+```yaml
+localization_layout:
+  id: "suffix"
+  base_name: "Messages"
+  source_locale: "en"
+placeholder_profile: "java-indexed" # opt-in support for %0, %1, ...
+```
+
 Mixed-format projects use profiles:
 
 ```yaml
@@ -181,9 +191,10 @@ Key settings:
 | `target_project_root` | Repository that contains the localization files. |
 | `input_folder` | Localization folder, absolute or relative to `target_project_root`. |
 | `localization_format` | Built-in format id for single-format projects. |
-| `localization_layout` | `suffix`, `locale_directory`, or `locale_filename`. |
+| `localization_layout` | `suffix`, `locale_directory`, or `locale_filename`; suffix layouts optionally accept `base_name`. |
 | `localization_formats` | Profile list for mixed-format projects. |
 | `translation_source` | `git` or `transifex`. New projects usually start with `git`. |
+| `placeholder_profile` | `standard` by default; use `java-indexed` for `%0`, `%1`, ... runtime tokens. |
 | `model_provider` | `aisuite` by default; `openai_compatible` is the direct SDK fallback. |
 | `model_name`, `review_model_name` | Translation and review models. |
 | `review_reasoning_effort` | Optional reasoning effort for the holistic review model. |
@@ -218,7 +229,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.8
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.9
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -238,7 +249,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.8
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.9
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -320,7 +331,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.8
+- uses: bisq-network/localize-pipeline@v0.1.9
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/action.yml
+++ b/action.yml
@@ -251,6 +251,117 @@ runs:
         fi
         python -m localize.cli run --config "$TRANSLATOR_CONFIG_FILE"
 
+    - name: Run translation quality gate
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        PYTHONPATH: ${{ github.action_path }}
+        TRANSLATOR_CONFIG_FILE: ${{ github.workspace }}/${{ inputs.config-file }}
+        ACTION_QUALITY_REPORT_DIR: ${{ github.action_path }}/logs
+      run: |
+        set -euo pipefail
+        gate_paths_file="$(mktemp)"
+        changed_files_file="$(mktemp)"
+        cleanup_quality_gate() {
+          rm -f "$gate_paths_file" "$changed_files_file"
+        }
+        trap cleanup_quality_gate EXIT
+        export LOCALIZE_GATE_PATHS_FILE="$gate_paths_file"
+        export LOCALIZE_GATE_CHANGED_FILES="$changed_files_file"
+
+        python - <<'PY'
+        import os
+        import subprocess
+        from pathlib import Path
+
+        import yaml
+
+        config_path = Path(os.environ["TRANSLATOR_CONFIG_FILE"]).resolve()
+        raw_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        config_dir = config_path.parent
+
+        repo_root = Path(str(raw_config.get("target_project_root") or ".")).expanduser()
+        if not repo_root.is_absolute():
+            repo_root = config_dir / repo_root
+        repo_root = repo_root.resolve()
+
+        input_folder = Path(str(raw_config.get("input_folder") or ".")).expanduser()
+        if not input_folder.is_absolute():
+            input_folder = repo_root / input_folder
+        input_folder = input_folder.resolve()
+        try:
+            input_relative = input_folder.relative_to(repo_root)
+        except ValueError as exc:
+            raise SystemExit(
+                f"Configured input_folder '{input_folder}' must be inside "
+                f"target_project_root '{repo_root}' for Action publication."
+            ) from exc
+
+        relative_text = input_relative.as_posix() or "."
+        subprocess.run(["git", "reset", "-q"], cwd=repo_root, check=True)
+        subprocess.run(
+            [
+                "git",
+                "add",
+                "-A",
+                "--",
+                relative_text,
+                f":(exclude,glob){relative_text}/archive/**",
+                f":(exclude,glob){relative_text}/**/archive/**",
+            ],
+            cwd=repo_root,
+            check=True,
+        )
+        changed = subprocess.run(
+            [
+                "git",
+                "diff",
+                "--cached",
+                "--name-only",
+                "--diff-filter=ACMRT",
+                "--",
+                relative_text,
+            ],
+            cwd=repo_root,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.splitlines()
+
+        Path(os.environ["LOCALIZE_GATE_PATHS_FILE"]).write_text(
+            f"{repo_root}\n{input_folder}\n",
+            encoding="utf-8",
+        )
+        Path(os.environ["LOCALIZE_GATE_CHANGED_FILES"]).write_text(
+            "".join(f"{path}\n" for path in changed),
+            encoding="utf-8",
+        )
+        PY
+
+        IFS= read -r repo_root < "$gate_paths_file"
+        input_folder="$(sed -n '2p' "$gate_paths_file")"
+        changed_files=()
+        while IFS= read -r changed_file; do
+          if [ -n "$changed_file" ]; then
+            changed_files+=("$changed_file")
+          fi
+        done < "$changed_files_file"
+
+        if [ "${#changed_files[@]}" -eq 0 ]; then
+          echo "No changed localization files; quality gate has nothing to check."
+          exit 0
+        fi
+
+        mkdir -p "$ACTION_QUALITY_REPORT_DIR"
+        python -m localize.cli quality-gate \
+          --repo-root "$repo_root" \
+          --input-folder "$input_folder" \
+          --config "$TRANSLATOR_CONFIG_FILE" \
+          --validation-summary "$ACTION_QUALITY_REPORT_DIR/translation_validation_summary.json" \
+          --output-json "$ACTION_QUALITY_REPORT_DIR/translation_quality_report.json" \
+          --output-markdown "$ACTION_QUALITY_REPORT_DIR/translation_quality_report.md" \
+          --changed-files "${changed_files[@]}"
+
     - name: Open pull request
       if: ${{ inputs.open-pr == 'true' }}
       shell: bash
@@ -332,7 +443,7 @@ runs:
 
         target_root = Path(str(config.get("target_project_root") or "."))
         if not target_root.is_absolute():
-            target_root = workspace / target_root
+            target_root = config_file.parent / target_root
         target_root = target_root.resolve()
 
         input_folder = Path(str(config.get("input_folder") or "."))
@@ -512,6 +623,8 @@ runs:
         path: |
           ${{ github.action_path }}/logs/translation_summary.json
           ${{ github.action_path }}/logs/translation_validation_summary.json
+          ${{ github.action_path }}/logs/translation_quality_report.json
+          ${{ github.action_path }}/logs/translation_quality_report.md
           ${{ github.action_path }}/logs/token_usage_summary.json
           ${{ github.action_path }}/logs/skipped_files_report.log
         if-no-files-found: ignore

--- a/action.yml
+++ b/action.yml
@@ -258,6 +258,8 @@ runs:
         PYTHONPATH: ${{ github.action_path }}
         TRANSLATOR_CONFIG_FILE: ${{ github.workspace }}/${{ inputs.config-file }}
         ACTION_QUALITY_REPORT_DIR: ${{ github.action_path }}/logs
+        LOCALIZE_ACTION_WORKSPACE: ${{ github.workspace }}
+        LOCALIZE_PLUGIN_MODULES: ${{ inputs.plugin-modules }}
       run: |
         set -euo pipefail
         gate_paths_file="$(mktemp)"
@@ -279,11 +281,19 @@ runs:
         config_path = Path(os.environ["TRANSLATOR_CONFIG_FILE"]).resolve()
         raw_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
         config_dir = config_path.parent
+        workspace = Path(os.environ["LOCALIZE_ACTION_WORKSPACE"]).resolve()
 
         repo_root = Path(str(raw_config.get("target_project_root") or ".")).expanduser()
         if not repo_root.is_absolute():
             repo_root = config_dir / repo_root
         repo_root = repo_root.resolve()
+        try:
+            repo_root.relative_to(workspace)
+        except ValueError as exc:
+            raise SystemExit(
+                f"Configured target_project_root '{repo_root}' must be inside "
+                f"the GitHub workspace '{workspace}' for Action publication."
+            ) from exc
 
         input_folder = Path(str(raw_config.get("input_folder") or ".")).expanduser()
         if not input_folder.is_absolute():

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,6 +25,13 @@ localization_format: "java_properties"
 localization_layout:
   id: "suffix"
   source_locale: "en"
+  # Optional when both source and targets carry locale suffixes, for example
+  # Messages_en.properties and Messages_de.properties.
+  # base_name: "Messages"
+
+# Placeholder detection is conservative by default. Opt into java-indexed only
+# when the application uses %0, %1, ... as runtime substitution tokens.
+placeholder_profile: "standard"
 
 # Mixed projects can replace the singular settings above with a profile list.
 # Every runtime sidecar uses the same profile list: parsing, validation, semantic

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.8
+      - uses: bisq-network/localize-pipeline@v0.1.9
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.8
+      - uses: bisq-network/localize-pipeline@v0.1.9
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -123,6 +123,17 @@ localization_format: "java_properties"
 localization_layout:
   id: "suffix"
   source_locale: "en"
+```
+
+Suffix layouts whose source file is also locale-suffixed can name the shared
+base explicitly. Projects using indexed percent placeholders opt in separately:
+
+```yaml
+localization_layout:
+  id: "suffix"
+  base_name: "Messages"
+  source_locale: "en"
+placeholder_profile: "java-indexed"
 ```
 
 JSON locale directories:
@@ -154,7 +165,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.8
+      - uses: bisq-network/localize-pipeline@v0.1.9
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -173,7 +184,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.8
+      - uses: bisq-network/localize-pipeline@v0.1.9
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -205,7 +216,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.8
+      - uses: bisq-network/localize-pipeline@v0.1.9
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.8
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.9
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -100,12 +100,26 @@ Generated configs default to `dry_run: true` so first runs can validate
 discovery, queueing, and reports without model calls. Set `dry_run: false` when
 you are ready to let the pipeline write translations.
 
+For suffix layouts where both source and target filenames carry locales, set a
+shared base name explicitly:
+
+```yaml
+localization_layout:
+  id: suffix
+  base_name: Messages
+  source_locale: en
+```
+
+Placeholder detection defaults to `standard`. Set
+`placeholder_profile: java-indexed` only for applications whose runtime treats
+`%0`, `%1`, and similar tokens as substitutions.
+
 ## Bootstrap Pull Requests
 
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.8
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.9
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -127,7 +141,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.8 \
+  --action-ref v0.1.9 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 
 from localize.ignore_keys import compile_ignore_key_patterns
 from localize.logging_config import setup_logger
+from localize.placeholder_rules import DEFAULT_PLACEHOLDER_PROFILE, validate_placeholder_profile
 from localize.localization_formats import (
     JAVA_PROPERTIES_FORMAT,
     LocalizationFormat,
@@ -109,6 +110,10 @@ class AppConfig:
     ))
     review_reasoning_effort: Optional[str] = None
 
+    # Placeholder-detection profile ("standard" or "java-indexed"). Runtime
+    # entry points activate it after loading so this loader remains state-free.
+    placeholder_profile: str = DEFAULT_PLACEHOLDER_PROFILE
+
 
 @dataclass(frozen=True)
 class ConfigIssue:
@@ -196,6 +201,21 @@ def validate_config(
         load_localization_profiles(config)
     except ValueError as exc:
         issues.append(ConfigIssue("error", str(exc)))
+
+    placeholder_profile = str(
+        config.get("placeholder_profile") or DEFAULT_PLACEHOLDER_PROFILE
+    ).strip()
+    try:
+        validate_placeholder_profile(placeholder_profile)
+    except ValueError as exc:
+        issues.append(ConfigIssue("error", str(exc)))
+
+    translation_source = str(config.get("translation_source") or "transifex").strip().lower()
+    if translation_source not in {"git", "transifex"}:
+        issues.append(ConfigIssue(
+            "error",
+            "translation_source must be either 'git' or 'transifex'.",
+        ))
 
     # style_rules referencing locales that are not declared is almost always a typo.
     style_rules = config.get("style_rules") or {}
@@ -662,6 +682,14 @@ def load_app_config() -> AppConfig:
         default=False,
     )
     ignore_key_patterns = compile_ignore_key_patterns(config.get('ignore_key_patterns') or [])
+    placeholder_profile = str(
+        config.get('placeholder_profile') or DEFAULT_PLACEHOLDER_PROFILE
+    ).strip()
+    try:
+        validate_placeholder_profile(placeholder_profile)
+    except ValueError as exc:
+        logger.critical("CRITICAL: %s", exc)
+        sys.exit(1)
     quality_gate_config = config.get('quality_gate', {}) or {}
     quality_gate = QualityGateConfig(
         source_identical_min_block_count=_as_positive_int(
@@ -820,4 +848,5 @@ def load_app_config() -> AppConfig:
         localization_layout=localization_layout,
         localization_profiles=localization_profiles,
         review_reasoning_effort=review_reasoning_effort,
+        placeholder_profile=placeholder_profile,
     )

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.8"
+    action_ref: str = "v0.1.9"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -579,7 +579,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.8", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.9", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/localize/init_config.py
+++ b/localize/init_config.py
@@ -424,10 +424,13 @@ def build_config(
 
 
 def _layout_config(layout: LocalizationLayout) -> Dict[str, str]:
-    return {
+    config = {
         "id": layout.id,
         "source_locale": layout.source_locale,
     }
+    if layout.base_name:
+        config["base_name"] = layout.base_name
+    return config
 
 
 def _profile_config_entry(

--- a/localize/localization_adapters.py
+++ b/localize/localization_adapters.py
@@ -14,6 +14,7 @@ from localize.localization_formats import (
     unregister_localization_format,
 )
 from localize.properties_parser import (
+    _escape_key,
     _has_unescaped_trailing_backslash,
     _split_property_line,
     _unescape_key,
@@ -148,7 +149,7 @@ def _escape_messageformat_if_needed(src_text: str, value: str) -> str:
 
 
 def _build_properties_review_content(translations: Translations, keys: Sequence[str]) -> str:
-    return "\n".join([f"{key}={translations.get(key, '')}" for key in keys])
+    return "\n".join([f"{_escape_key(key)}={translations.get(key, '')}" for key in keys])
 
 
 def _json_pointer_escape(segment: str) -> str:

--- a/localize/localization_layouts.py
+++ b/localize/localization_layouts.py
@@ -43,6 +43,7 @@ class LocalizationLayout:
 
     id: str
     source_locale: str = "en"
+    base_name: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.id not in {"suffix", "locale_directory", "locale_filename"}:
@@ -52,6 +53,17 @@ class LocalizationLayout:
             )
         if not self.source_locale:
             raise ValueError("localization_layout.source_locale must not be empty.")
+        if self.base_name is not None and self.id != "suffix":
+            raise ValueError("localization_layout.base_name is only supported by the suffix layout.")
+
+    def _named_suffix_filename(
+        self,
+        locale: str,
+        localization_format: LocalizationFormat,
+    ) -> Optional[str]:
+        if not self.base_name:
+            return None
+        return f"{self.base_name}_{locale}{localization_format.file_extension}"
 
     def extract_locale(
         self,
@@ -63,6 +75,16 @@ class LocalizationLayout:
         path = _as_posix(relative_path)
         supported = sorted((str(code) for code in supported_codes), key=len, reverse=True)
         if self.id == "suffix":
+            if self.base_name:
+                filename = PurePath(path).name
+                return next(
+                    (
+                        code
+                        for code in supported
+                        if filename == self._named_suffix_filename(code, localization_format)
+                    ),
+                    None,
+                )
             return localization_format.extract_supported_locale_suffix(PurePath(path).name, list(supported))
         if self.id == "locale_directory":
             match = _locale_directory_segment(path, supported)
@@ -95,6 +117,11 @@ class LocalizationLayout:
         if not localization_format.is_supported_file(path):
             return False
         if self.id == "suffix":
+            if self.base_name:
+                return PurePath(path).name == self._named_suffix_filename(
+                    self.source_locale,
+                    localization_format,
+                )
             return localization_format.extract_locale_suffix(PurePath(path).name) is None
         if self.id == "locale_directory":
             return _locale_directory_segment(path, [self.source_locale]) is not None
@@ -112,6 +139,9 @@ class LocalizationLayout:
         path = _as_posix(relative_path)
         pure_path = PurePath(path)
         if self.id == "suffix":
+            if self.base_name:
+                source_name = self._named_suffix_filename(self.source_locale, localization_format)
+                return pure_path.with_name(str(source_name)).as_posix()
             source_name = localization_format.source_filename(pure_path.name, list(supported_codes))
             return pure_path.with_name(source_name).as_posix()
         if self.id == "locale_directory":
@@ -153,10 +183,19 @@ def load_localization_layout(raw_value: Any, *, source_locale: str = "en") -> Lo
         return LocalizationLayout(id=base.id, source_locale=source_locale)
 
     if isinstance(raw_value, Mapping):
+        supported_keys = {"id", "source_locale", "base_name"}
+        unknown_keys = sorted(set(raw_value) - supported_keys)
+        if unknown_keys:
+            raise ValueError(
+                "Unsupported localization_layout key(s): " + ", ".join(unknown_keys) + "."
+            )
         layout_id = str(raw_value.get("id") or SUFFIX_LAYOUT.id)
+        raw_base_name = raw_value.get("base_name")
+        base_name = str(raw_base_name).strip() if raw_base_name is not None else None
         return LocalizationLayout(
             id=layout_id,
             source_locale=str(raw_value.get("source_locale") or source_locale),
+            base_name=base_name or None,
         )
 
     raise ValueError("localization_layout must be a string id or mapping.")

--- a/localize/placeholder_rules.py
+++ b/localize/placeholder_rules.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import re
 import uuid
 from collections import Counter
-from typing import Dict, Match, Tuple
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Dict, Iterator, Match, Tuple
 
 
 _HTML_TAG = r"</?[A-Za-z][^<>\n]*>"
@@ -14,26 +16,89 @@ _I18NEXT_TOKEN = r"\{\{[^{}\n]+\}\}"
 _BRACE_TOKEN = r"\{[A-Za-z0-9_][^{}\n]*\}"
 _PYTHON_NAMED_PRINTF = r"%\([^)]+\)[#0 +\-]*(?:\d+|\*)?(?:\.(?:\d+|\*))?[a-zA-Z]"
 _POSITIONAL_PRINTF = r"%(?!%)(?:\d+\$)?[#0+\-,(<]*(?:\d+|\*)?(?:\.(?:\d+|\*))?[bBhHsScCdoxXeEfgGaAtT%n]"
+# Java-style indexed placeholders (`%0`, `%1`, …) used by some localization
+# libraries. Ordered after the printf alternatives so `%(name)s` and
+# `%1$s` keep winning. Opt-in via the "java-indexed" placeholder profile only:
+# percent-then-digit prose (fee/price copy like "5%0") cannot be ruled out in
+# other projects, so this must never be on globally.
+_JAVA_INDEXED_PRINTF = r"%\d+"
+# In `%0%1`, the positional-printf rule would otherwise consume `%0%` as one
+# token. This lookahead lets the Java profile protect each adjacent indexed
+# placeholder without changing the standard profile's established behavior.
+_JAVA_INDEXED_ADJACENT = r"%\d+(?=%\d)"
 
-PLACEHOLDER_PATTERN = re.compile(
-    "|".join(
-        [
-            _PLACEHOLDER_TAG,
-            _HTML_TAG,
-            _I18NEXT_TOKEN,
-            _BRACE_TOKEN,
-            _PYTHON_NAMED_PRINTF,
-            _POSITIONAL_PRINTF,
-        ]
-    )
+_STANDARD_ALTERNATIVES = [
+    _PLACEHOLDER_TAG,
+    _HTML_TAG,
+    _I18NEXT_TOKEN,
+    _BRACE_TOKEN,
+    _PYTHON_NAMED_PRINTF,
+    _POSITIONAL_PRINTF,
+]
+
+_PROFILE_PATTERNS = {
+    "standard": re.compile("|".join(_STANDARD_ALTERNATIVES)),
+    "java-indexed": re.compile("|".join(
+        _STANDARD_ALTERNATIVES[:-1]
+        + [_JAVA_INDEXED_ADJACENT, _POSITIONAL_PRINTF, _JAVA_INDEXED_PRINTF]
+    )),
+}
+
+DEFAULT_PLACEHOLDER_PROFILE = "standard"
+
+# Backward-compatible alias; always the standard-profile pattern. Internal
+# helpers consult _active_pattern() instead so the profile switch applies.
+PLACEHOLDER_PATTERN = _PROFILE_PATTERNS[DEFAULT_PLACEHOLDER_PROFILE]
+
+_ACTIVE_PROFILE: ContextVar[str] = ContextVar(
+    "placeholder_profile",
+    default=DEFAULT_PLACEHOLDER_PROFILE,
 )
+
+
+def validate_placeholder_profile(profile_name: str) -> None:
+    """Raise when ``profile_name`` is not a registered placeholder profile."""
+    if profile_name not in _PROFILE_PATTERNS:
+        valid_profiles = ", ".join(sorted(_PROFILE_PATTERNS))
+        raise ValueError(
+            f"Unknown placeholder profile '{profile_name}'. Valid profiles: {valid_profiles}."
+        )
+
+
+def set_placeholder_profile(profile_name: str) -> str:
+    """Select the placeholder-detection profile; returns the previous profile.
+
+    Valid profiles: "standard" (default, Bisq behavior) and "java-indexed"
+    (adds `%N` tokens for projects that use indexed percent placeholders).
+    Runtime entry points call this once after loading config; tests use
+    placeholder_profile() instead.
+    """
+    validate_placeholder_profile(profile_name)
+    previous_profile = _ACTIVE_PROFILE.get()
+    _ACTIVE_PROFILE.set(profile_name)
+    return previous_profile
+
+
+@contextmanager
+def placeholder_profile(profile_name: str) -> Iterator[None]:
+    """Temporarily activate a placeholder profile (restores the previous one)."""
+    validate_placeholder_profile(profile_name)
+    context_token = _ACTIVE_PROFILE.set(profile_name)
+    try:
+        yield
+    finally:
+        _ACTIVE_PROFILE.reset(context_token)
+
+
+def _active_pattern() -> re.Pattern[str]:
+    return _PROFILE_PATTERNS[_ACTIVE_PROFILE.get()]
 
 
 def extract_placeholder_tokens(text: str) -> Counter[str]:
     """Return placeholder/tag tokens in ``text`` with multiplicity."""
     if not isinstance(text, str):
         raise ValueError("Input text must be a string.")
-    return Counter(match.group(0) for match in PLACEHOLDER_PATTERN.finditer(text))
+    return Counter(match.group(0) for match in _active_pattern().finditer(text))
 
 
 def protect_placeholders(text: str) -> Tuple[str, Dict[str, str]]:
@@ -51,7 +116,7 @@ def protect_placeholders(text: str) -> Tuple[str, Dict[str, str]]:
         placeholder_mapping[placeholder_token] = full_match
         return placeholder_token
 
-    return PLACEHOLDER_PATTERN.sub(replace_placeholder, text), placeholder_mapping
+    return _active_pattern().sub(replace_placeholder, text), placeholder_mapping
 
 
 def restore_placeholders(text: str, placeholder_mapping: Dict[str, str]) -> str:

--- a/localize/properties_parser.py
+++ b/localize/properties_parser.py
@@ -3,16 +3,16 @@ r"""Parse and reassemble Java ``.properties`` files.
 Parsing follows the Java properties separator rules used by this project:
 ``=``, ``:``, and unescaped whitespace can separate keys from values. Escaped
 key separators are unescaped for dictionary access and re-escaped on output
-when a line is rewritten. Unicode escape sequences such as ``\uXXXX`` are left
-as-is; duplicate keys keep the last parsed value in the returned translation
-mapping.
+when a line is rewritten. Valid Java character and Unicode escapes are decoded
+for canonical key comparison while the original raw spelling is retained for
+byte-stable reassembly; duplicate keys keep the last parsed value in the
+returned translation mapping.
 
 Line continuations are collapsed for translation values. Unchanged multiline
 entries keep their original physical-line formatting when reassembled; changed
 entries are serialized as a single logical value.
 """
 
-import re
 from typing import Dict, List, Tuple
 
 
@@ -55,15 +55,92 @@ def _strip_unescaped_boundary_whitespace(raw_key: str) -> str:
     return raw_key[start:end]
 
 
+_JAVA_CHARACTER_ESCAPES = {
+    't': '\t',
+    'n': '\n',
+    'r': '\r',
+    'f': '\f',
+}
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _combine_surrogate_pairs(value: str) -> str:
+    """Normalize adjacent UTF-16 surrogate escapes to a Python scalar value."""
+    normalized: list[str] = []
+    index = 0
+    while index < len(value):
+        codepoint = ord(value[index])
+        if 0xD800 <= codepoint <= 0xDBFF and index + 1 < len(value):
+            low = ord(value[index + 1])
+            if 0xDC00 <= low <= 0xDFFF:
+                normalized.append(chr(0x10000 + ((codepoint - 0xD800) << 10) + (low - 0xDC00)))
+                index += 2
+                continue
+        normalized.append(value[index])
+        index += 1
+    return ''.join(normalized)
+
+
 def _unescape_key(raw_key: str) -> str:
+    """Return the Java logical key while tolerating malformed Unicode escapes.
+
+    Valid escapes mirror ``java.util.Properties.loadConvert``. Unlike Java,
+    malformed ``\\uXXXX`` input is preserved literally so one bad upstream key
+    cannot abort an otherwise recoverable localization run.
+    """
     stripped_key = _strip_unescaped_boundary_whitespace(raw_key)
-    return re.sub(r'\\([:=\s\\])', r'\1', stripped_key)
+    unescaped: list[str] = []
+    index = 0
+    while index < len(stripped_key):
+        char = stripped_key[index]
+        if char != '\\':
+            unescaped.append(char)
+            index += 1
+            continue
+
+        if index + 1 >= len(stripped_key):
+            # loadConvert discards a trailing lone backslash.
+            index += 1
+            continue
+
+        next_char = stripped_key[index + 1]
+        if next_char in _JAVA_CHARACTER_ESCAPES:
+            unescaped.append(_JAVA_CHARACTER_ESCAPES[next_char])
+            index += 2
+            continue
+
+        if next_char == 'u':
+            digits = stripped_key[index + 2:index + 6]
+            if len(digits) == 4 and all(digit in _HEX_DIGITS for digit in digits):
+                unescaped.append(chr(int(digits, 16)))
+                index += 6
+                continue
+            # Fault-tolerant divergence: Java raises for malformed Unicode
+            # escapes; retain the literal spelling and let validation/reporting
+            # continue instead of taking down the whole run.
+            unescaped.extend(('\\', 'u'))
+            index += 2
+            continue
+
+        # loadConvert drops the backslash for every other escaped character.
+        unescaped.append(next_char)
+        index += 2
+
+    return _combine_surrogate_pairs(''.join(unescaped))
 
 
 def _escape_key(key: str) -> str:
     escaped = []
     for char in key:
-        if char in ('\\', ':', '=') or char.isspace():
+        if char == '\t':
+            escaped.append('\\t')
+        elif char == '\n':
+            escaped.append('\\n')
+        elif char == '\r':
+            escaped.append('\\r')
+        elif char == '\f':
+            escaped.append('\\f')
+        elif char in ('\\', ':', '=') or char.isspace():
             escaped.append('\\' + char)
         else:
             escaped.append(char)
@@ -183,7 +260,10 @@ def parse_properties_file(file_path: str) -> Tuple[List[Dict], Dict[str, str]]:
                 })
             else:
                 # Handle lines without a separator (e.g., a key with no value)
-                key_raw = line.strip()
+                # Preserve escaped boundary whitespace. _unescape_key removes
+                # only unescaped syntactic padding, so `key\ ` remains the
+                # logical key "key " just as java.util.Properties requires.
+                key_raw = line
                 key = _unescape_key(key_raw)
                 if key:  # only if it is not a blank line
                     target_translations[key] = ''

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -51,6 +51,7 @@ from localize.placeholder_rules import (
     extract_placeholder_tokens,
     protect_placeholders,
     restore_placeholders as restore_protected_placeholders,
+    set_placeholder_profile,
 )
 from localize.pipeline_core import (
     RUN_METRIC_KEYS,
@@ -68,14 +69,15 @@ from localize.translation_memory import (
 from localize.translation_validator import (
     check_placeholder_parity,
     check_encoding_and_mojibake,
+    find_glossary_mismatches,
     find_disallowed_control_characters,
 )
-
 # --- Constants and Globals ---
 # Load application configuration
 # TODO: Move configuration loading behind the runtime entry point so importing
 # this module no longer reads files or environment variables as a side effect.
 config = load_app_config()
+set_placeholder_profile(config.placeholder_profile)
 
 # Create a dedicated logger for this script to avoid conflicts with the root logger.
 logger = logging.getLogger("translation_script")
@@ -166,7 +168,21 @@ def load_glossary(glossary_file_path: str) -> Dict[str, Dict[str, str]]:
         return {}
     try:
         with open(glossary_file_path, 'r', encoding='utf-8') as f:
-            glossary = json.load(f)
+            payload = json.load(f)
+        if not isinstance(payload, dict):
+            logger.error("Glossary file '%s' must contain a JSON object.", glossary_file_path)
+            return {}
+        glossary: Dict[str, Dict[str, str]] = {}
+        for locale, mappings in payload.items():
+            if str(locale).startswith('_'):
+                continue
+            if not isinstance(mappings, dict) or not all(
+                isinstance(source, str) and isinstance(target, str)
+                for source, target in mappings.items()
+            ):
+                logger.warning("Ignoring invalid glossary locale namespace '%s'.", locale)
+                continue
+            glossary[str(locale)] = dict(mappings)
         return glossary
     except json.JSONDecodeError as json_exc:
         logger.error(f"Error decoding JSON glossary file: {json_exc}")
@@ -467,7 +483,8 @@ def extract_texts_to_translate(
     2. The key was newly synchronized in this run and currently equals the source.
        This includes keys added by file key synchronization and keys changed in
        the current git working tree (e.g., inserted by ``tx pull -t -f``).
-    3. (Optional legacy mode) Existing keys with source-identical values are also
+    3. The source is non-empty but the existing target value is empty.
+    4. (Optional legacy mode) Existing keys with source-identical values are also
        translated when ``retranslate_identical_existing`` is enabled.
 
     Args:
@@ -512,6 +529,7 @@ def extract_texts_to_translate(
             current_source_hash = compute_ledger_hash(source_value)
             current_target_hash = compute_ledger_hash(target_value)
             should_translate_newly_added = key in newly_added_keys
+            should_translate_empty_target = bool(source_value.strip()) and not target_value.strip()
             should_translate_legacy_mode = is_source_identical and retranslate_identical_existing
             should_translate_changed_source = (
                 previous_source_hash is not None and previous_source_hash != current_source_hash
@@ -525,6 +543,8 @@ def extract_texts_to_translate(
             should_translate_existing = (
                 # New keys synchronized in this run should always be translated.
                 should_translate_newly_added
+                # Explicitly empty locale values are part of the translation backlog.
+                or should_translate_empty_target
                 # Legacy behavior: also retranslate any source-identical existing key.
                 or should_translate_legacy_mode
                 # Source text changed since the last run for this key.
@@ -1036,6 +1056,7 @@ def run_post_translation_validation(
         localization_format: Optional[LocalizationFormat] = None,
         ignore_key_patterns: Optional[List[Pattern[str]]] = None,
         changed_keys_for_run: Optional[Set[str]] = None,
+        translation_glossary: Optional[Mapping[str, str]] = None,
 ) -> bool:
     """
     Runs a series of validation checks on the final translated file content.
@@ -1055,6 +1076,7 @@ def run_post_translation_validation(
     effective_format = localization_format or LOCALIZATION_FORMAT
     adapter = get_localization_adapter(effective_format)
     ignore_key_patterns = ignore_key_patterns or []
+    translation_glossary = translation_glossary or {}
     try:
         # Create a temporary file with delete=False to control its lifecycle.
         with tempfile.NamedTemporaryFile(
@@ -1100,6 +1122,33 @@ def run_post_translation_validation(
                         logger.error(message)
                     else:
                         logger.warning("Pre-existing post-validation issue ignored for unchanged key: %s", message)
+                    continue
+
+                if normalize_value(source_value) == normalize_value(target_value):
+                    # A failed generated value may have been deliberately
+                    # reverted to its source fallback by per-key validation.
+                    # It is already reported as failed; it is not a generated
+                    # translation that claims glossary compliance.
+                    continue
+                glossary_mismatches = find_glossary_mismatches(
+                    source_value,
+                    target_value,
+                    translation_glossary,
+                )
+                if glossary_mismatches:
+                    required = ", ".join(
+                        f"{source_term!r}→{target_term!r}"
+                        for source_term, target_term in glossary_mismatches
+                    )
+                    message = (
+                        f"Post-translation validation failed for '{filename}': "
+                        f"Glossary mismatch for key '{key}'; required {required}."
+                    )
+                    if changed_keys_for_run is None or key in changed_keys_for_run:
+                        is_valid = False
+                        logger.error(message)
+                    else:
+                        logger.warning("Pre-existing post-validation issue ignored for unchanged key: %s", message)
         except Exception:
             is_valid = False
             logger.exception(
@@ -1134,6 +1183,7 @@ def run_per_key_validation_with_summary(
         source_translations: Dict[str, str],
         filename: str,
         ignore_key_patterns: Optional[List[Pattern[str]]] = None,
+        translation_glossary: Optional[Mapping[str, str]] = None,
 ) -> Tuple[Dict[str, str], Dict[str, object]]:
     """
     Validates each translation key individually and selectively reverts failed keys.
@@ -1158,7 +1208,9 @@ def run_per_key_validation_with_summary(
     control_character_keys = []
     placeholder_mismatch_keys = []
     empty_target_keys = []
+    glossary_mismatch_keys = []
     ignore_key_patterns = ignore_key_patterns or []
+    translation_glossary = translation_glossary or {}
 
     for key, target_value in final_translations.items():
         source_value = source_translations.get(key, "")
@@ -1186,6 +1238,27 @@ def run_per_key_validation_with_summary(
                 f"{' ...' if len(control_character_findings) > 3 else ''}.\n"
                 f"  Source: {source_value}\n"
                 f"  Translation: {target_value}"
+            )
+            valid_translations[key] = source_value
+            continue
+
+        glossary_mismatches = find_glossary_mismatches(
+            source_value,
+            target_value,
+            translation_glossary,
+        )
+        if glossary_mismatches:
+            failed_keys.append(key)
+            glossary_mismatch_keys.append(key)
+            required = ", ".join(
+                f"{source_term!r}→{target_term!r}"
+                for source_term, target_term in glossary_mismatches
+            )
+            logger.warning(
+                "Key '%s' failed glossary validation in '%s' - reverting to source; required %s.",
+                key,
+                filename,
+                required,
             )
             valid_translations[key] = source_value
             continue
@@ -1231,10 +1304,12 @@ def run_per_key_validation_with_summary(
         "control_character_keys": control_character_keys,
         "placeholder_mismatch_keys": placeholder_mismatch_keys,
         "empty_target_keys": empty_target_keys,
+        "glossary_mismatch_keys": glossary_mismatch_keys,
         "reverted_keys_count": len(failed_keys),
         "control_character_findings_count": len(control_character_keys),
         "placeholder_failures_count": len(placeholder_mismatch_keys),
         "empty_target_failures_count": len(empty_target_keys),
+        "glossary_failures_count": len(glossary_mismatch_keys),
     }
     return valid_translations, summary
 
@@ -1244,6 +1319,7 @@ def run_per_key_validation(
         source_translations: Dict[str, str],
         filename: str,
         ignore_key_patterns: Optional[List[Pattern[str]]] = None,
+        translation_glossary: Optional[Mapping[str, str]] = None,
 ) -> Tuple[Dict[str, str], List[str]]:
     """
     Backward-compatible wrapper returning only the failed key list.
@@ -1253,6 +1329,7 @@ def run_per_key_validation(
         source_translations,
         filename,
         ignore_key_patterns=ignore_key_patterns,
+        translation_glossary=translation_glossary,
     )
     return valid_translations, list(summary["failed_keys"])
 
@@ -1363,7 +1440,7 @@ Provide the translation **of the Value only**, following the instructions above.
                                 brand_glossary_text=brand_glossary_text,
                                 glossary_text=glossary_text,
                                 context_examples_text=context_examples_text,
-                                key=key,
+                                key=_display_translation_key(key),
                                 processed_text=processed_text
                             ))
                         ],
@@ -1410,9 +1487,19 @@ def _build_holistic_review_system_prompt(
         translated_content: str,
         style_rules_text: str,  # Pass pre-computed rules
         localization_format: LocalizationFormat = LOCALIZATION_FORMAT,
+        translation_glossary: Optional[Mapping[str, str]] = None,
 ) -> str:
     """Builds the system prompt for the holistic review API call."""
-    keys_to_review_text = "\n".join([f"- {k}" for k in keys_to_review])
+    keys_to_review_text = "\n".join([f"- {_display_translation_key(k)}" for k in keys_to_review])
+    glossary_rules = "\n".join(
+        f'- When the English source contains "{source_term}", the translation must contain "{target_term}".'
+        for source_term, target_term in (translation_glossary or {}).items()
+    )
+    glossary_section = (
+        "**Mandatory Translation Glossary**:\n" + glossary_rules + "\n\n"
+        if glossary_rules
+        else ""
+    )
 
     return f"""
 You are a lead editor and quality assurance specialist for software localization. Your task is to review a list of newly translated keys within a {localization_format.display_name} file for {target_language}. You are given the full source and translated files for context, but you MUST only review and return the keys specified.
@@ -1433,7 +1520,7 @@ You are a lead editor and quality assurance specialist for software localization
 6.  **Output JSON Only**: Your final output **must** be a single, valid JSON object that adheres to the required schema. This object should contain ONLY the keys listed in the "Strictly Limited Scope" section above, with their final, corrected translations as the values.
 7.  **Do Not Add Explanations**: Do not output any text, markdown, or explanations before or after the JSON object.
 
-{style_rules_text}
+{glossary_section}{style_rules_text}
 
 **JSON Output Example**:
 ```json
@@ -1443,6 +1530,28 @@ You are a lead editor and quality assurance specialist for software localization
 }}
 ```
 """
+
+
+def _display_translation_key(key: str) -> str:
+    """Render control characters visibly without changing ordinary prompt keys."""
+    if any(character in key for character in ("\t", "\n", "\r", "\f")):
+        return json.dumps(key, ensure_ascii=False)[1:-1]
+    return key
+
+
+def _prefer_glossary_compliant_draft(
+    source_value: str,
+    draft_value: str,
+    reviewed_value: str,
+    translation_glossary: Mapping[str, str],
+) -> str:
+    """Keep a compliant draft when holistic review breaks a required mapping."""
+    if (
+        find_glossary_mismatches(source_value, reviewed_value, translation_glossary)
+        and not find_glossary_mismatches(source_value, draft_value, translation_glossary)
+    ):
+        return draft_value
+    return reviewed_value
 
 
 def _build_holistic_review_user_prompt(
@@ -1483,6 +1592,7 @@ async def holistic_review_async(
         rate_limiter: AsyncLimiter,
         style_rules_text: str,
         localization_format: Optional[LocalizationFormat] = None,
+        translation_glossary: Optional[Mapping[str, str]] = None,
 ) -> Optional[Dict[str, str]]:
     """
     Performs a holistic review of an entire translated file and returns corrections
@@ -1523,6 +1633,7 @@ async def holistic_review_async(
             translated_content=protected_translated,
             style_rules_text=style_rules_text,
             localization_format=localization_format or LOCALIZATION_FORMAT,
+            translation_glossary=translation_glossary,
         )
         review_user_prompt = _build_holistic_review_user_prompt(
             target_language=target_language,
@@ -2214,6 +2325,12 @@ async def process_translation_queue(
                 logger.warning(f"Skipping file {translation_file}: unsupported language code '{language_code}'.")
                 continue
             style_rules_text_for_review = PRECOMPUTED_STYLE_RULES_TEXT.get(language_code, "")
+            raw_language_glossary = glossary.get(language_code, {})
+            language_glossary = (
+                raw_language_glossary
+                if isinstance(raw_language_glossary, Mapping)
+                else {}
+            )
             memory_context_fingerprint = translation_memory_context_fingerprint(
                 locale=language_code,
                 glossary=glossary,
@@ -2334,6 +2451,7 @@ async def process_translation_queue(
                             localization_format,
                             ignore_key_patterns=IGNORE_KEY_PATTERNS,
                             changed_keys_for_run=set(ignored_keys_requiring_output),
+                            translation_glossary=language_glossary,
                     ):
                         logger.error(
                             "Skipping write for '%s' because post-translation validation failed.",
@@ -2500,6 +2618,7 @@ async def process_translation_queue(
                     rate_limiter=rate_limiter,
                     style_rules_text=style_rules_text_for_review,
                     localization_format=localization_format,
+                    translation_glossary=language_glossary,
                 ) for key_chunk in key_chunks],
                 return_exceptions=True,
             )
@@ -2526,11 +2645,23 @@ async def process_translation_queue(
                         continue
                     if corrected_chunk:
                         key_chunk_set = set(key_chunk)
-                        scoped = {
-                            key: value
-                            for key, value in corrected_chunk.items()
-                            if key in key_chunk_set
-                        }
+                        scoped = {}
+                        for key, value in corrected_chunk.items():
+                            if key not in key_chunk_set:
+                                continue
+                            selected_value = _prefer_glossary_compliant_draft(
+                                source_translations.get(key, ""),
+                                draft_translations.get(key, ""),
+                                value,
+                                language_glossary,
+                            )
+                            if selected_value != value:
+                                logger.warning(
+                                    "Holistic review broke a required glossary mapping for key '%s'; "
+                                    "keeping the compliant draft.",
+                                    key,
+                                )
+                            scoped[key] = selected_value
                         dropped = set(corrected_chunk) - key_chunk_set
                         if dropped:
                             logger.warning(
@@ -2614,6 +2745,7 @@ async def process_translation_queue(
                 source_translations,
                 translation_file,
                 ignore_key_patterns=IGNORE_KEY_PATTERNS,
+                translation_glossary=language_glossary,
             )
             failed_keys = set(per_key_summary["failed_keys"]).union(model_failed_keys)
             increment_run_metric(run_metrics, "model_translation_failed_count", len(failed_keys))
@@ -2653,6 +2785,7 @@ async def process_translation_queue(
                     localization_format,
                     ignore_key_patterns=IGNORE_KEY_PATTERNS,
                     changed_keys_for_run=set(keys_to_translate),
+                    translation_glossary=language_glossary,
             ):
                 logger.error("Skipping write for '%s' because post-translation validation failed.", translation_file)
                 skipped_files[translation_file] = ["Post-translation validation failed."]

--- a/localize/translation_semantic_reviewer.py
+++ b/localize/translation_semantic_reviewer.py
@@ -27,6 +27,11 @@ from localize.model_provider import (
     create_model_provider,
     normalize_reasoning_effort,
 )
+from localize.placeholder_rules import (
+    DEFAULT_PLACEHOLDER_PROFILE,
+    set_placeholder_profile,
+    validate_placeholder_profile,
+)
 from localize.semantic_quality import (
     TranslationChange,
     iter_translation_changes_from_diff,
@@ -388,6 +393,15 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
 async def _run(argv: Optional[Sequence[str]]) -> int:
     args = _parse_args(argv)
     config = _load_config(args.config)
+    placeholder_profile = str(
+        config.get("placeholder_profile") or DEFAULT_PLACEHOLDER_PROFILE
+    ).strip()
+    try:
+        validate_placeholder_profile(placeholder_profile)
+    except ValueError as exc:
+        logging.getLogger(__name__).error("Semantic review configuration failed: %s", exc)
+        return 1
+    set_placeholder_profile(placeholder_profile)
     semantic_review_config = config.get("semantic_review", {}) or {}
     if not bool(semantic_review_config.get("enabled", False)):
         return 0

--- a/localize/translation_validator.py
+++ b/localize/translation_validator.py
@@ -87,6 +87,13 @@ def check_placeholder_parity(base_string: str, target_string: str) -> bool:
     return extract_placeholder_tokens(base_string) == extract_placeholder_tokens(target_string)
 
 
+def _glossary_term_pattern(term: str) -> re.Pattern[str]:
+    """Compile the boundary-aware, case-insensitive glossary matching rule."""
+    prefix = r"(?<!\w)" if term[0].isalnum() or term[0] == "_" else ""
+    suffix = r"(?!\w)" if term[-1].isalnum() or term[-1] == "_" else ""
+    return re.compile(prefix + re.escape(term) + suffix, re.IGNORECASE)
+
+
 def find_glossary_mismatches(
     source_value: str,
     target_value: str,
@@ -103,10 +110,7 @@ def find_glossary_mismatches(
     for source_term, target_term in glossary.items():
         if not source_term or not target_term:
             continue
-        escaped = re.escape(source_term)
-        prefix = r"(?<!\w)" if source_term[0].isalnum() or source_term[0] == "_" else ""
-        suffix = r"(?!\w)" if source_term[-1].isalnum() or source_term[-1] == "_" else ""
-        pattern = re.compile(prefix + escaped + suffix, re.IGNORECASE)
+        pattern = _glossary_term_pattern(source_term)
         for match in pattern.finditer(source_value):
             candidates.append((match.start(), match.end(), source_term, target_term))
 
@@ -122,11 +126,10 @@ def find_glossary_mismatches(
         pair = (source_term, target_term)
         required_counts[pair] = required_counts.get(pair, 0) + 1
 
-    folded_target = target_value.casefold()
     return [
         pair
         for pair, required_count in sorted(required_counts.items(), key=lambda item: item[0][0].casefold())
-        if folded_target.count(pair[1].casefold()) < required_count
+        if len(_glossary_term_pattern(pair[1]).findall(target_value)) < required_count
     ]
 
 def _find_insertion_index_for_missing_key(

--- a/localize/translation_validator.py
+++ b/localize/translation_validator.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set, Tuple, List
+from typing import Dict, List, Mapping, Set, Tuple
 import re
 from localize.properties_parser import parse_properties_file, reassemble_file
 from localize.placeholder_rules import extract_placeholder_tokens
@@ -85,6 +85,49 @@ def check_placeholder_parity(base_string: str, target_string: str) -> bool:
         True if the set of placeholders in both strings is identical, False otherwise.
     """
     return extract_placeholder_tokens(base_string) == extract_placeholder_tokens(target_string)
+
+
+def find_glossary_mismatches(
+    source_value: str,
+    target_value: str,
+    glossary: Mapping[str, str],
+) -> List[Tuple[str, str]]:
+    """Return applicable EN→target mappings missing from ``target_value``.
+
+    Matching is case-insensitive and respects word boundaries. When glossary
+    source terms overlap, the longest term wins so a phrase such as
+    ``AI functionality`` does not also require the standalone ``functionality``
+    mapping.
+    """
+    candidates: List[Tuple[int, int, str, str]] = []
+    for source_term, target_term in glossary.items():
+        if not source_term or not target_term:
+            continue
+        escaped = re.escape(source_term)
+        prefix = r"(?<!\w)" if source_term[0].isalnum() or source_term[0] == "_" else ""
+        suffix = r"(?!\w)" if source_term[-1].isalnum() or source_term[-1] == "_" else ""
+        pattern = re.compile(prefix + escaped + suffix, re.IGNORECASE)
+        for match in pattern.finditer(source_value):
+            candidates.append((match.start(), match.end(), source_term, target_term))
+
+    selected: List[Tuple[int, int, str, str]] = []
+    for candidate in sorted(candidates, key=lambda item: (-(item[1] - item[0]), item[0])):
+        start, end, _source_term, _target_term = candidate
+        if any(start < selected_end and end > selected_start for selected_start, selected_end, *_ in selected):
+            continue
+        selected.append(candidate)
+
+    required_counts: Dict[Tuple[str, str], int] = {}
+    for _start, _end, source_term, target_term in selected:
+        pair = (source_term, target_term)
+        required_counts[pair] = required_counts.get(pair, 0) + 1
+
+    folded_target = target_value.casefold()
+    return [
+        pair
+        for pair, required_count in sorted(required_counts.items(), key=lambda item: item[0][0].casefold())
+        if folded_target.count(pair[1].casefold()) < required_count
+    ]
 
 def _find_insertion_index_for_missing_key(
         key: str,
@@ -210,6 +253,10 @@ def synchronize_keys(target_file_path: str, source_file_path: str) -> Tuple[Set[
         final_parsed_lines.insert(insertion_index, {
             'type': 'entry',
             'key': key,
+            # Preserve the source spelling (`\n`, `\uXXXX`, optional escapes,
+            # etc.). The canonical key is Java-decoded for comparison, while
+            # reassembly must not invent a different logical key.
+            'raw_key': source_entry.get('raw_key'),
             'value': source_translations[key],
             'original_value': source_translations[key],
             'line_number': source_entry.get('line_number', insertion_index),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.8"
+version = "0.1.9"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/fixtures/external_layout/app/src/main/resources/l10n/Messages_de.properties
+++ b/tests/fixtures/external_layout/app/src/main/resources/l10n/Messages_de.properties
@@ -1,0 +1,3 @@
+account.title=Konto
+account.settings=Einstellungen
+account.balance=Guthaben: {0}

--- a/tests/fixtures/external_layout/app/src/main/resources/l10n/Messages_en.properties
+++ b/tests/fixtures/external_layout/app/src/main/resources/l10n/Messages_en.properties
@@ -1,0 +1,3 @@
+account.title=Account
+account.settings=Settings
+account.balance=Balance: {0}

--- a/tests/fixtures/external_layout/translations/config.yaml
+++ b/tests/fixtures/external_layout/translations/config.yaml
@@ -1,0 +1,33 @@
+# External-layout contract fixture.
+#
+# Exercises the layout where the pipeline config does NOT live at the target
+# repository root: it sits in a subdirectory (`translations/`) and points back up
+# via `target_project_root: ".."`. Every relative path must then resolve against
+# the right base — `input_folder` against the target project root, and
+# `glossary_file_path` against the directory holding this file.
+#
+# Regression guarded: a config in a subdirectory that leaves
+# `target_project_root: "."` silently resolves `input_folder` and
+# `glossary_file_path` under `translations/`, producing paths that do not exist.
+target_project_root: ".."
+input_folder: "app/src/main/resources/l10n"
+
+localization_format: "java_properties"
+localization_layout:
+  id: "suffix"
+  base_name: "Messages"
+  source_locale: "en"
+
+translation_source: "git"
+glossary_file_path: "glossary.json"
+
+project_context: "Translate concise UI text for a software product."
+
+model_provider: "aisuite"
+model_name: "gpt-4o-mini"
+review_model_name: "gpt-4o"
+
+dry_run: false
+supported_locales:
+  - code: "de"
+    name: "German"

--- a/tests/fixtures/external_layout/translations/glossary.json
+++ b/tests/fixtures/external_layout/translations/glossary.json
@@ -1,0 +1,6 @@
+{
+  "de": {
+    "account": "Konto",
+    "settings": "Einstellungen"
+  }
+}

--- a/tests/integration/test_external_layout_config.py
+++ b/tests/integration/test_external_layout_config.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from localize.app_config import load_app_config
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LAYOUT_ROOT = PROJECT_ROOT / "tests" / "fixtures" / "external_layout"
+LAYOUT_CONFIG = LAYOUT_ROOT / "translations" / "config.yaml"
+
+
+def test_subdirectory_config_resolves_existing_external_layout(monkeypatch):
+    """A config in a subdirectory must resolve every relative path to a real location.
+
+    ``input_folder`` resolves against ``target_project_root`` while
+    ``glossary_file_path`` resolves against the config file's own directory. A
+    config that leaves ``target_project_root`` as ``"."`` resolves both under
+    ``translations/`` instead, yielding paths that do not exist.
+    """
+    monkeypatch.setenv("TRANSLATOR_CONFIG_FILE", str(LAYOUT_CONFIG))
+    config = load_app_config()
+
+    assert Path(config.target_project_root) == LAYOUT_ROOT
+    assert Path(config.target_project_root).is_dir()
+
+    assert Path(config.input_folder) == LAYOUT_ROOT / "app" / "src" / "main" / "resources" / "l10n"
+    assert Path(config.input_folder).is_dir()
+
+    assert Path(config.glossary_file_path) == LAYOUT_ROOT / "translations" / "glossary.json"
+    assert Path(config.glossary_file_path).is_file()
+    assert config.localization_layout.base_name == "Messages"
+    assert config.localization_layout.is_source_file(
+        "Messages_en.properties",
+        ["de"],
+        config.localization_format,
+    )
+    assert config.localization_layout.source_path_for_target(
+        "Messages_de.properties",
+        ["de"],
+        config.localization_format,
+    ) == "Messages_en.properties"

--- a/tests/integration/test_github_action_quality_gate.py
+++ b/tests/integration/test_github_action_quality_gate.py
@@ -1,0 +1,103 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+ACTION = PROJECT_ROOT / "action.yml"
+
+
+def _run(command, *, cwd, env=None):
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def test_action_gate_blocks_seeded_violation_before_publication(tmp_path):
+    repo = tmp_path / "target"
+    input_folder = repo / "l10n"
+    config_folder = repo / "translations"
+    report_folder = tmp_path / "reports"
+    input_folder.mkdir(parents=True)
+    config_folder.mkdir()
+
+    (input_folder / "app.properties").write_text(
+        "existing=Existing\nnew.key=Needs translation\n",
+        encoding="utf-8",
+    )
+    target_file = input_folder / "app_de.properties"
+    target_file.write_text("existing=Vorhanden\n", encoding="utf-8")
+    config_path = config_folder / "config.yaml"
+    config_path.write_text(
+        """
+target_project_root: ".."
+input_folder: "l10n"
+localization_format: "java_properties"
+localization_layout:
+  id: "suffix"
+  source_locale: "en"
+supported_locales:
+  - { code: "de", name: "German" }
+quality_gate:
+  source_identical_min_block_count: 1
+  source_identical_max_count: 0
+  source_identical_max_ratio: 0.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    _run(["git", "init", "-q"], cwd=repo)
+    _run(["git", "config", "user.name", "Action Test"], cwd=repo)
+    _run(["git", "config", "user.email", "action@example.invalid"], cwd=repo)
+    _run(["git", "config", "commit.gpgSign", "false"], cwd=repo)
+    _run(["git", "add", "."], cwd=repo)
+    _run(["git", "commit", "-q", "-m", "Seed target repository"], cwd=repo)
+
+    target_file.write_text(
+        "existing=Vorhanden\nnew.key=Needs translation\n",
+        encoding="utf-8",
+    )
+
+    action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+    gate_step = next(
+        step for step in action["runs"]["steps"]
+        if step["name"] == "Run translation quality gate"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{PROJECT_ROOT / 'venv' / 'bin'}{os.pathsep}{os.environ['PATH']}",
+            "PYTHONPATH": str(PROJECT_ROOT),
+            "TRANSLATOR_CONFIG_FILE": str(config_path),
+            "ACTION_QUALITY_REPORT_DIR": str(report_folder),
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-c", gate_step["run"]],
+        cwd=repo,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    report_path = report_folder / "translation_quality_report.json"
+    assert report_path.exists(), (
+        f"quality gate produced no report\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    report = json.loads(
+        report_path.read_text(encoding="utf-8")
+    )
+    assert report["blocking"] is True
+    assert report["source_identical"]["unexpected_source_identical_count"] == 1

--- a/tests/integration/test_github_action_quality_gate.py
+++ b/tests/integration/test_github_action_quality_gate.py
@@ -79,6 +79,7 @@ quality_gate:
             "PYTHONPATH": str(PROJECT_ROOT),
             "TRANSLATOR_CONFIG_FILE": str(config_path),
             "ACTION_QUALITY_REPORT_DIR": str(report_folder),
+            "LOCALIZE_ACTION_WORKSPACE": str(repo),
         }
     )
     result = subprocess.run(
@@ -101,3 +102,59 @@ quality_gate:
     )
     assert report["blocking"] is True
     assert report["source_identical"]["unexpected_source_identical_count"] == 1
+
+
+def test_action_gate_rejects_target_repository_outside_workspace_before_git_reset(tmp_path):
+    workspace = tmp_path / "workspace"
+    config_folder = workspace / "translations"
+    outside_repo = tmp_path / "outside"
+    outside_input = outside_repo / "l10n"
+    config_folder.mkdir(parents=True)
+    outside_input.mkdir(parents=True)
+
+    tracked = outside_input / "app.properties"
+    tracked.write_text("key=Original\n", encoding="utf-8")
+    _run(["git", "init", "-q"], cwd=outside_repo)
+    _run(["git", "config", "user.name", "Action Test"], cwd=outside_repo)
+    _run(["git", "config", "user.email", "action@example.invalid"], cwd=outside_repo)
+    _run(["git", "config", "commit.gpgSign", "false"], cwd=outside_repo)
+    _run(["git", "add", "."], cwd=outside_repo)
+    _run(["git", "commit", "-q", "-m", "Seed outside repository"], cwd=outside_repo)
+    tracked.write_text("key=Staged\n", encoding="utf-8")
+    _run(["git", "add", "."], cwd=outside_repo)
+
+    config_path = config_folder / "config.yaml"
+    config_path.write_text(
+        f"target_project_root: {outside_repo}\ninput_folder: l10n\n",
+        encoding="utf-8",
+    )
+
+    action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+    gate_step = next(
+        step for step in action["runs"]["steps"]
+        if step["name"] == "Run translation quality gate"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{PROJECT_ROOT / 'venv' / 'bin'}{os.pathsep}{os.environ['PATH']}",
+            "PYTHONPATH": str(PROJECT_ROOT),
+            "TRANSLATOR_CONFIG_FILE": str(config_path),
+            "ACTION_QUALITY_REPORT_DIR": str(tmp_path / "reports"),
+            "LOCALIZE_ACTION_WORKSPACE": str(workspace),
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-c", gate_step["run"]],
+        cwd=workspace,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "must be inside the GitHub workspace" in result.stderr
+    staged = _run(["git", "diff", "--cached", "--name-only"], cwd=outside_repo)
+    assert staged.stdout.splitlines() == ["l10n/app.properties"]

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -356,6 +356,55 @@ class TestLoadAppConfig:
         assert config.localization_layout.source_locale == "en"
         assert config.localization_profiles[0].localization_format.id == "custom_json"
 
+    def test_load_config_records_profile_without_mutating_placeholder_state(self):
+        import localize.placeholder_rules as placeholder_rules
+
+        mock_config = {
+            "dry_run": True,
+            "placeholder_profile": "java-indexed",
+        }
+
+        with placeholder_rules.placeholder_profile("standard"):
+            with patch("localize.app_config._load_yaml_config", return_value=mock_config):
+                with patch("os.path.exists", return_value=False):
+                    with patch("localize.app_config.setup_logger") as mock_logger:
+                        mock_logger.return_value = MagicMock()
+                        with patch.dict(os.environ, {}, clear=True):
+                            config = load_app_config()
+
+            assert config.placeholder_profile == "java-indexed"
+            from collections import Counter
+
+            from localize.placeholder_rules import extract_placeholder_tokens
+
+            assert extract_placeholder_tokens("%0 of %1") == Counter()
+
+    def test_load_config_defaults_to_standard_placeholder_profile(self):
+        mock_config = {"dry_run": True}
+
+        with patch("localize.app_config._load_yaml_config", return_value=mock_config):
+            with patch("os.path.exists", return_value=False):
+                with patch("localize.app_config.setup_logger") as mock_logger:
+                    mock_logger.return_value = MagicMock()
+                    with patch.dict(os.environ, {}, clear=True):
+                        config = load_app_config()
+
+        assert config.placeholder_profile == "standard"
+
+    def test_load_config_rejects_unknown_placeholder_profile(self):
+        mock_config = {
+            "dry_run": True,
+            "placeholder_profile": "no-such-profile",
+        }
+
+        with patch("localize.app_config._load_yaml_config", return_value=mock_config):
+            with patch("os.path.exists", return_value=False):
+                with patch("localize.app_config.setup_logger") as mock_logger:
+                    mock_logger.return_value = MagicMock()
+                    with patch.dict(os.environ, {}, clear=True):
+                        with pytest.raises(SystemExit):
+                            load_app_config()
+
     def test_load_config_compiles_ignore_key_patterns(self):
         mock_config = {
             "dry_run": True,
@@ -752,6 +801,20 @@ class TestValidateConfig:
     def test_valid_config_has_no_errors(self):
         issues = validate_config(self.GOOD, path_exists=lambda p: True)
         assert self._errors(issues) == []
+
+    def test_unknown_placeholder_profile_is_validation_error(self):
+        config = {**self.GOOD, "placeholder_profile": "no-such-profile"}
+
+        errors = self._errors(validate_config(config, path_exists=lambda p: True))
+
+        assert any("Unknown placeholder profile" in error for error in errors)
+
+    def test_unknown_translation_source_is_validation_error(self):
+        config = {**self.GOOD, "translation_source": "crowdin"}
+
+        errors = self._errors(validate_config(config, path_exists=lambda p: True))
+
+        assert any("translation_source" in error for error in errors)
 
     def test_missing_required_paths_are_errors(self):
         issues = validate_config({"supported_locales": self.GOOD["supported_locales"]},

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -65,7 +65,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.8" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.9" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -444,7 +444,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.8"
+    assert create.call_args.args[0].action_ref == "v0.1.9"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -590,7 +590,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.8"
+    assert pyproject["project"]["version"] == "0.1.9"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -597,6 +597,27 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(indices, [0])
         self.assertEqual(keys, ['key_existing'])
 
+    def test_extract_texts_to_translate_includes_nonempty_source_with_empty_target(self):
+        parsed_lines = [
+            {'type': 'entry', 'key': 'needs.translation', 'value': '', 'line_number': 0},
+            {'type': 'entry', 'key': 'intentionally.empty', 'value': '', 'line_number': 1},
+        ]
+        target_translations = {'needs.translation': '', 'intentionally.empty': ''}
+        source_translations = {
+            'needs.translation': 'Copy citation key',
+            'intentionally.empty': '',
+        }
+
+        texts, indices, keys = extract_texts_to_translate(
+            parsed_lines,
+            source_translations,
+            target_translations,
+        )
+
+        self.assertEqual(texts, ['Copy citation key'])
+        self.assertEqual(indices, [0])
+        self.assertEqual(keys, ['needs.translation'])
+
     def test_extract_texts_to_translate_includes_existing_key_when_source_hash_changed(self):
         """Existing keys should be translated when source text changed since last run."""
         parsed_lines = [

--- a/tests/unit/test_github_action.py
+++ b/tests/unit/test_github_action.py
@@ -77,6 +77,31 @@ def test_action_runs_preflight_check_before_translation(action):
     assert 'python -m localize.cli check --config "$TRANSLATOR_CONFIG_FILE"' in steps[preflight_index]["run"]
 
 
+def test_action_runs_quality_gate_before_opening_pr(action):
+    steps = action["runs"]["steps"]
+    translate_index = next(i for i, step in enumerate(steps) if step["name"] == "Translate changed strings")
+    gate_index = next(i for i, step in enumerate(steps) if step["name"] == "Run translation quality gate")
+    publish_index = next(i for i, step in enumerate(steps) if step["name"] == "Open pull request")
+    gate = steps[gate_index]
+
+    assert translate_index < gate_index < publish_index
+    assert gate["env"]["TRANSLATOR_CONFIG_FILE"] == "${{ github.workspace }}/${{ inputs.config-file }}"
+    assert gate["env"]["ACTION_QUALITY_REPORT_DIR"] == "${{ github.action_path }}/logs"
+    assert "python -m localize.cli quality-gate" in gate["run"]
+    assert "translation_quality_report.json" in gate["run"]
+    assert "translation_quality_report.md" in gate["run"]
+
+
+def test_action_resolves_target_root_relative_to_config_file(action):
+    publish = next(
+        step for step in action["runs"]["steps"]
+        if step["name"] == "Open pull request"
+    )
+
+    assert "target_root = config_file.parent / target_root" in publish["run"]
+    assert "target_root = workspace / target_root" not in publish["run"]
+
+
 def test_action_rejects_unsafe_pr_contexts_before_setup(action):
     steps = action["runs"]["steps"]
     guard = next(step for step in steps if step["name"] == "Validate workflow context")
@@ -222,6 +247,8 @@ def test_generated_pr_uses_summary_body_and_uploads_artifacts(action):
     paths = upload["with"]["path"]
     assert "translation_summary.json" in paths
     assert "translation_validation_summary.json" in paths
+    assert "translation_quality_report.json" in paths
+    assert "translation_quality_report.md" in paths
     assert "token_usage_summary.json" in paths
     assert "skipped_files_report.log" in paths
     assert upload["with"]["if-no-files-found"] == "ignore"

--- a/tests/unit/test_github_action.py
+++ b/tests/unit/test_github_action.py
@@ -87,9 +87,12 @@ def test_action_runs_quality_gate_before_opening_pr(action):
     assert translate_index < gate_index < publish_index
     assert gate["env"]["TRANSLATOR_CONFIG_FILE"] == "${{ github.workspace }}/${{ inputs.config-file }}"
     assert gate["env"]["ACTION_QUALITY_REPORT_DIR"] == "${{ github.action_path }}/logs"
+    assert gate["env"]["LOCALIZE_ACTION_WORKSPACE"] == "${{ github.workspace }}"
+    assert gate["env"]["LOCALIZE_PLUGIN_MODULES"] == "${{ inputs.plugin-modules }}"
     assert "python -m localize.cli quality-gate" in gate["run"]
     assert "translation_quality_report.json" in gate["run"]
     assert "translation_quality_report.md" in gate["run"]
+    assert "repo_root.relative_to(workspace)" in gate["run"]
 
 
 def test_action_resolves_target_root_relative_to_config_file(action):

--- a/tests/unit/test_glossary_enforcement.py
+++ b/tests/unit/test_glossary_enforcement.py
@@ -17,6 +17,30 @@ def test_glossary_compliance_requires_verbatim_target_mapping():
     ]
 
 
+def test_glossary_compliance_requires_target_mapping_at_word_boundaries():
+    glossary = {"entry": "Eintrag"}
+
+    assert find_glossary_mismatches("Delete entry", "Eintragsdetails löschen", glossary) == [
+        ("entry", "Eintrag")
+    ]
+    assert find_glossary_mismatches("Delete entry", "(Eintrag) löschen", glossary) == []
+
+
+def test_glossary_compliance_counts_repeated_target_mappings_at_boundaries():
+    glossary = {"entry": "Eintrag"}
+
+    assert find_glossary_mismatches(
+        "Merge entry into entry",
+        "Eintrag mit Eintragsdetails zusammenführen",
+        glossary,
+    ) == [("entry", "Eintrag")]
+    assert find_glossary_mismatches(
+        "Merge entry into entry",
+        "Eintrag mit Eintrag zusammenführen",
+        glossary,
+    ) == []
+
+
 def test_glossary_compliance_is_case_insensitive_at_word_boundaries():
     glossary = {"merge": "zusammenführen"}
 

--- a/tests/unit/test_glossary_enforcement.py
+++ b/tests/unit/test_glossary_enforcement.py
@@ -1,0 +1,107 @@
+from localize.translation_validator import find_glossary_mismatches
+from localize.translate_localization_files import (
+    _build_holistic_review_system_prompt,
+    _prefer_glossary_compliant_draft,
+    load_glossary,
+    run_post_translation_validation,
+    run_per_key_validation_with_summary,
+)
+
+
+def test_glossary_compliance_requires_verbatim_target_mapping():
+    glossary = {"entry": "Eintrag"}
+
+    assert find_glossary_mismatches("Delete entry", "Eintrag löschen", glossary) == []
+    assert find_glossary_mismatches("Delete entry", "Element löschen", glossary) == [
+        ("entry", "Eintrag")
+    ]
+
+
+def test_glossary_compliance_is_case_insensitive_at_word_boundaries():
+    glossary = {"merge": "zusammenführen"}
+
+    assert find_glossary_mismatches("Merge entries", "Einträge zusammenführen", glossary) == []
+    assert find_glossary_mismatches("Merged entries", "Einträge wurden zusammengeführt", glossary) == []
+
+
+def test_glossary_compliance_prefers_longest_overlapping_source_term():
+    glossary = {
+        "AI functionality": "KI-Funktionen",
+        "functionality": "Funktionen",
+    }
+
+    assert find_glossary_mismatches(
+        "Enable AI functionality",
+        "KI-Funktionen aktivieren",
+        glossary,
+    ) == []
+
+
+def test_per_key_validation_blocks_review_output_that_breaks_glossary():
+    source = {"Delete entry": "Delete entry"}
+
+    validated, summary = run_per_key_validation_with_summary(
+        {"Delete entry": "Element löschen"},
+        source,
+        "Messages_de.properties",
+        translation_glossary={"entry": "Eintrag"},
+    )
+
+    assert validated == source
+    assert summary["glossary_mismatch_keys"] == ["Delete entry"]
+    assert summary["glossary_failures_count"] == 1
+
+
+def test_holistic_review_prompt_receives_mandatory_glossary():
+    prompt = _build_holistic_review_system_prompt(
+        target_language="Russian",
+        keys_to_review=["Delete entry"],
+        source_content="Delete entry=Delete entry",
+        translated_content="Delete entry=Eintrag löschen",
+        style_rules_text="",
+        translation_glossary={"entry": "Eintrag"},
+    )
+
+    assert "Mandatory Translation Glossary" in prompt
+    assert '"entry"' in prompt
+    assert '"Eintrag"' in prompt
+
+
+def test_compliant_draft_wins_when_review_breaks_glossary():
+    assert _prefer_glossary_compliant_draft(
+        "Delete entry",
+        "Eintrag löschen",
+        "Element löschen",
+        {"entry": "Eintrag"},
+    ) == "Eintrag löschen"
+
+
+def test_post_validation_rejects_noncompliant_generated_value_but_allows_source_fallback():
+    source = {"Delete entry": "Delete entry"}
+    glossary = {"entry": "Eintrag"}
+
+    assert not run_post_translation_validation(
+        "Delete\\ entry=Element löschen\n",
+        source,
+        "Messages_de.properties",
+        changed_keys_for_run={"Delete entry"},
+        translation_glossary=glossary,
+    )
+    assert run_post_translation_validation(
+        "Delete\\ entry=Delete entry\n",
+        source,
+        "Messages_de.properties",
+        changed_keys_for_run={"Delete entry"},
+        translation_glossary=glossary,
+    )
+
+
+def test_load_glossary_excludes_metadata_and_quarantine_namespaces(tmp_path):
+    glossary_path = tmp_path / "glossary.json"
+    glossary_path.write_text(
+        '{"_comment":"metadata","de":{"entry":"Eintrag"},'
+        '"_quarantine_de":{"citation":{"de":"Zitat"}}}',
+        encoding="utf-8",
+    )
+
+    assert load_glossary(str(glossary_path)) == {"de": {"entry": "Eintrag"}}

--- a/tests/unit/test_init_config.py
+++ b/tests/unit/test_init_config.py
@@ -279,6 +279,24 @@ class TestBuildConfig:
 
         assert cfg["localization_layout"] == {"id": "locale_directory", "source_locale": "en"}
 
+    def test_preserves_suffix_base_name(self):
+        cfg = build_config(
+            target_project_root="/repo",
+            input_folder="i18n",
+            locales=[{"code": "de", "name": "German"}],
+            localization_layout={
+                "id": "suffix",
+                "source_locale": "en",
+                "base_name": "Messages",
+            },
+        )
+
+        assert cfg["localization_layout"] == {
+            "id": "suffix",
+            "source_locale": "en",
+            "base_name": "Messages",
+        }
+
     def test_optional_base_url_included_when_provided(self):
         cfg = build_config(
             target_project_root="/repo", input_folder="i18n", locales=[],

--- a/tests/unit/test_localization_layouts.py
+++ b/tests/unit/test_localization_layouts.py
@@ -24,6 +24,25 @@ def test_suffix_layout_keeps_existing_properties_conventions():
     ) == "nested/messages.properties"
 
 
+def test_suffix_layout_supports_source_locale_suffix_with_base_name():
+    layout = load_localization_layout({
+        "id": "suffix",
+        "base_name": "Messages",
+        "source_locale": "en",
+    })
+
+    assert layout.extract_locale("Messages_de.properties", ["de"], JAVA_PROPERTIES_FORMAT) == "de"
+    assert layout.is_target_file("Messages_de.properties", ["de"], JAVA_PROPERTIES_FORMAT)
+    assert not layout.is_target_file("Other_de.properties", ["de"], JAVA_PROPERTIES_FORMAT)
+    assert layout.is_source_file("Messages_en.properties", ["de"], JAVA_PROPERTIES_FORMAT)
+    assert not layout.is_source_file("Messages.properties", ["de"], JAVA_PROPERTIES_FORMAT)
+    assert layout.source_path_for_target(
+        "Messages_de.properties",
+        ["de"],
+        JAVA_PROPERTIES_FORMAT,
+    ) == "Messages_en.properties"
+
+
 def test_locale_directory_layout_maps_locale_segment_to_source_locale():
     layout = LocalizationLayout(id="locale_directory", source_locale="en")
 

--- a/tests/unit/test_placeholder_rules.py
+++ b/tests/unit/test_placeholder_rules.py
@@ -1,8 +1,17 @@
 """Tests for reusable placeholder token rules."""
 
+import asyncio
 from collections import Counter
 
-from localize.placeholder_rules import extract_placeholder_tokens, protect_placeholders, restore_placeholders
+import pytest
+
+from localize.placeholder_rules import (
+    extract_placeholder_tokens,
+    placeholder_profile,
+    protect_placeholders,
+    restore_placeholders,
+    set_placeholder_profile,
+)
 from localize.translation_validator import check_placeholder_parity
 
 
@@ -58,6 +67,148 @@ def test_json_structural_braces_are_not_placeholders():
 
     assert extract_placeholder_tokens(source) == Counter()
     assert check_placeholder_parity(source, target)
+
+
+def test_default_profile_ignores_java_indexed_tokens():
+    # Bisq behavior must be unchanged: %0-style tokens are not placeholders
+    # unless the java-indexed profile is opted into.
+    assert extract_placeholder_tokens("%0 of %1 entries cleaned up.") == Counter()
+
+
+def test_java_indexed_profile_detects_percent_number_tokens():
+    with placeholder_profile("java-indexed"):
+        assert extract_placeholder_tokens("%0 of %1 entries cleaned up.") == Counter(
+            {"%0": 1, "%1": 1}
+        )
+        assert extract_placeholder_tokens("Push to %0 was rejected (%1). %2 %3") == Counter(
+            {"%0": 1, "%1": 1, "%2": 1, "%3": 1}
+        )
+        assert extract_placeholder_tokens("[Search documentation](%0)") == Counter({"%0": 1})
+
+
+def test_java_indexed_profile_keeps_existing_syntaxes_winning():
+    with placeholder_profile("java-indexed"):
+        text = "Hello {0}, {{name}}, %1$d, %(amount).2f, %s, <b>bold</b>"
+        assert extract_placeholder_tokens(text) == Counter(
+            {
+                "{0}": 1,
+                "{{name}}": 1,
+                "%1$d": 1,
+                "%(amount).2f": 1,
+                "%s": 1,
+                "<b>": 1,
+                "</b>": 1,
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("%0e", Counter({"%0e": 1})),
+        ("%0d", Counter({"%0d": 1})),
+        ("%1x", Counter({"%1x": 1})),
+        ("%10", Counter({"%10": 1})),
+        ("%0%1", Counter({"%0": 1, "%1": 1})),
+        ("%%0", Counter({"%0": 1})),
+        ("50%0", Counter({"%0": 1})),
+        ("%0.5", Counter({"%0": 1})),
+        ("final %", Counter()),
+        ('<b data-value="%0">text</b>', Counter({'<b data-value="%0">': 1, "</b>": 1})),
+        ("{{value %0}}", Counter({"{{value %0}}": 1})),
+    ],
+)
+def test_java_indexed_profile_adjacency_and_outer_token_precedence(text, expected):
+    with placeholder_profile("java-indexed"):
+        assert extract_placeholder_tokens(text) == expected
+
+
+def test_standard_profile_keeps_legacy_percent_edge_behavior():
+    assert extract_placeholder_tokens("%0e %0d %1x %10 %0%1 %%0 50%0 %0.5 final %") == Counter(
+        {"%0e": 1, "%0d": 1, "%1x": 1, "%0%": 1}
+    )
+
+
+def test_java_indexed_profile_handles_adjacent_indexed_tokens():
+    with placeholder_profile("java-indexed"):
+        assert extract_placeholder_tokens("%0%1") == Counter({"%0": 1, "%1": 1})
+        protected, mapping = protect_placeholders("%0%1")
+
+    assert set(mapping.values()) == {"%0", "%1"}
+    assert restore_placeholders(protected, mapping) == "%0%1"
+
+
+def test_java_indexed_profile_leaves_literal_percent_prose_alone():
+    with placeholder_profile("java-indexed"):
+        assert extract_placeholder_tokens("Discount 50% off") == Counter()
+        assert extract_placeholder_tokens("100%") == Counter()
+        assert extract_placeholder_tokens("greater than -10% of market price") == Counter()
+
+
+def test_java_indexed_profile_parity_catches_dropped_token():
+    with placeholder_profile("java-indexed"):
+        assert check_placeholder_parity("%0 of %1 entries", "%0 von %1 Einträgen")
+        assert not check_placeholder_parity("%0 of %1 entries", "von %1 Einträgen")
+
+
+def test_java_indexed_profile_protects_and_restores_tokens():
+    with placeholder_profile("java-indexed"):
+        original = "Push to %0 was rejected (%1)."
+        protected, mapping = protect_placeholders(original)
+        assert "%0" not in protected
+        assert "%1" not in protected
+        assert set(mapping.values()) == {"%0", "%1"}
+        assert restore_placeholders(protected, mapping) == original
+
+
+def test_java_indexed_profile_preserves_placeholder_multiplicity_round_trip():
+    original = "%0 then %0 and finally %1"
+
+    with placeholder_profile("java-indexed"):
+        assert extract_placeholder_tokens(original) == Counter({"%0": 2, "%1": 1})
+        protected, mapping = protect_placeholders(original)
+
+    assert list(mapping.values()).count("%0") == 2
+    assert restore_placeholders(protected, mapping) == original
+
+
+def test_placeholder_profile_resets_after_context_exit():
+    with placeholder_profile("java-indexed"):
+        assert extract_placeholder_tokens("%0") == Counter({"%0": 1})
+    assert extract_placeholder_tokens("%0") == Counter()
+
+
+def test_placeholder_profile_resets_after_exception():
+    with pytest.raises(RuntimeError):
+        with placeholder_profile("java-indexed"):
+            raise RuntimeError("boom")
+
+    assert extract_placeholder_tokens("%0") == Counter()
+
+
+@pytest.mark.asyncio
+async def test_placeholder_profiles_are_isolated_between_async_tasks():
+    ready = asyncio.Event()
+
+    async def java_task():
+        with placeholder_profile("java-indexed"):
+            ready.set()
+            await asyncio.sleep(0)
+            return extract_placeholder_tokens("%0")
+
+    async def standard_task():
+        await ready.wait()
+        return extract_placeholder_tokens("%0")
+
+    java_tokens, standard_tokens = await asyncio.gather(java_task(), standard_task())
+
+    assert java_tokens == Counter({"%0": 1})
+    assert standard_tokens == Counter()
+
+
+def test_set_placeholder_profile_rejects_unknown_profile():
+    with pytest.raises(ValueError):
+        set_placeholder_profile("no-such-profile")
 
 
 def test_protect_and_restore_common_placeholder_tokens():

--- a/tests/unit/test_properties_parser.py
+++ b/tests/unit/test_properties_parser.py
@@ -54,6 +54,103 @@ def test_parse_preserves_escaped_space_before_separator(tmp_path):
     assert reassemble_file(parsed_lines) == r"key\ =value" + "\n"
 
 
+def test_parse_preserves_escaped_trailing_space_in_key_only_line(tmp_path):
+    properties_file = tmp_path / "messages.properties"
+    properties_file.write_text("key\\ \n", encoding="utf-8")
+
+    parsed_lines, translations = parse_properties_file(str(properties_file))
+
+    assert translations == {"key ": ""}
+    assert parsed_lines[0]["raw_key"] == r"key\ "
+    assert reassemble_file(parsed_lines) == "key\\ \n"
+
+
+def test_unescape_key_mirrors_java_loadconvert_for_unrecognized_escapes(tmp_path):
+    # java.util.Properties.loadConvert drops the backslash on any escape it
+    # doesn't recognize, so `\"` and `"` are the same logical key. Locale
+    # files may disagree on these optional escapes; both spellings must parse
+    # to the same canonical key or the pipeline re-emits translated keys as
+    # duplicates.
+    en_file = tmp_path / "messages_en.properties"
+    ru_file = tmp_path / "messages_ru.properties"
+    en_file.write_text(
+        "Field\\ name\\ \\\"%0\\\"\\ already\\ exists=en1\n"
+        "The\\ marked\\ area\\ does\\ not\\ contain\\ any\\ legible\\ text!=en2\n"
+        "Sort\\ subgroups\\ by\\ #\\ of\\ entries=en3\n"
+        "Unable\\ to\\ change\\ field\\ name\\.\\ Try\\ again=en4\n",
+        encoding="utf-8",
+    )
+    ru_file.write_text(
+        "Field\\ name\\ \"%0\"\\ already\\ exists=ru1\n"
+        "The\\ marked\\ area\\ does\\ not\\ contain\\ any\\ legible\\ text\\!=ru2\n"
+        "Sort\\ subgroups\\ by\\ \\#\\ of\\ entries=ru3\n"
+        "Unable\\ to\\ change\\ field\\ name.\\ Try\\ again=ru4\n",
+        encoding="utf-8",
+    )
+
+    _, en_translations = parse_properties_file(str(en_file))
+    _, ru_translations = parse_properties_file(str(ru_file))
+
+    assert set(en_translations) == set(ru_translations)
+    assert 'Field name "%0" already exists' in en_translations
+
+
+def test_unescape_key_decodes_recognized_java_escape_sequences(tmp_path):
+    properties_file = tmp_path / "messages.properties"
+    properties_file.write_text(
+        r"line\nbreak\tkey\rwith\fform\u2014=value" + "\n",
+        encoding="utf-8",
+    )
+
+    parsed_lines, translations = parse_properties_file(str(properties_file))
+
+    assert translations == {"line\nbreak\tkey\rwith\fform—": "value"}
+    assert reassemble_file(parsed_lines) == r"line\nbreak\tkey\rwith\fform\u2014=value" + "\n"
+
+
+def test_unicode_escape_and_literal_utf8_canonicalize_to_same_key(tmp_path):
+    escaped_file = tmp_path / "escaped.properties"
+    literal_file = tmp_path / "literal.properties"
+    escaped_file.write_text(r"dash\u2014key=value" + "\n", encoding="utf-8")
+    literal_file.write_text("dash—key=value\n", encoding="utf-8")
+
+    _, escaped = parse_properties_file(str(escaped_file))
+    _, literal = parse_properties_file(str(literal_file))
+
+    assert escaped == literal == {"dash—key": "value"}
+
+
+def test_malformed_unicode_escape_is_preserved_tolerantly(tmp_path):
+    properties_file = tmp_path / "messages.properties"
+    properties_file.write_text(r"bad\u12G4key=value" + "\n", encoding="utf-8")
+
+    parsed_lines, translations = parse_properties_file(str(properties_file))
+
+    assert translations == {r"bad\u12G4key": "value"}
+    assert reassemble_file(parsed_lines) == r"bad\u12G4key=value" + "\n"
+
+
+def test_trailing_lone_backslash_is_dropped_like_java(tmp_path):
+    properties_file = tmp_path / "messages.properties"
+    properties_file.write_text("trailing\\\n", encoding="utf-8")
+
+    parsed_lines, translations = parse_properties_file(str(properties_file))
+
+    assert translations == {"trailing": ""}
+    assert reassemble_file(parsed_lines) == "trailing\\\n"
+
+
+def test_unescape_key_existing_escapes_still_work(tmp_path):
+    # The previously supported escapes must keep behaving identically.
+    properties_file = tmp_path / "messages.properties"
+    properties_file.write_text(r"a\:b\=c\ key\\d=value" + "\n", encoding="utf-8")
+
+    parsed_lines, translations = parse_properties_file(str(properties_file))
+
+    assert translations == {r"a:b=c key\d": "value"}
+    assert reassemble_file(parsed_lines) == r"a\:b\=c\ key\\d=value" + "\n"
+
+
 def test_reassemble_preserves_untouched_multiline_formatting(tmp_path):
     original = "long.value=first \\\n    second part \\\n\tthird part\n"
     properties_file = tmp_path / "messages.properties"

--- a/tests/unit/test_translation_validator.py
+++ b/tests/unit/test_translation_validator.py
@@ -248,6 +248,37 @@ class TestTranslationValidator(unittest.TestCase):
             os.remove(source_path)
             os.remove(target_path)
 
+    def test_key_synchronization_preserves_source_raw_java_escapes(self):
+        source_content = (
+            r"Quick\nreference=value" "\n"
+            r"dash\u2014key=value" "\n"
+        )
+        target_content = "existing=translated\n"
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as f_source:
+            f_source.write(source_content)
+            source_path = f_source.name
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as f_target:
+            f_target.write(target_content)
+            target_path = f_target.name
+
+        try:
+            synchronize_keys(target_path, source_path)
+            with open(target_path, 'r', encoding='utf-8') as target_file:
+                synchronized = target_file.read()
+
+            self.assertIn(r"Quick\nreference=value", synchronized)
+            self.assertIn(r"dash\u2014key=value", synchronized)
+            self.assertNotIn(r"Quick\\nreference", synchronized)
+            self.assertNotIn(r"dash\\u2014key", synchronized)
+
+            _, translations = parse_properties_file(target_path)
+            self.assertIn("Quick\nreference", translations)
+            self.assertIn("dash—key", translations)
+        finally:
+            os.remove(source_path)
+            os.remove(target_path)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- add an opt-in `java-indexed` placeholder profile for `%0`, `%1`, and adjacent indexed tokens while keeping the standard profile unchanged
- canonicalize Java property keys using `java.util.Properties` escape behavior, preserve raw key spelling, and tolerate malformed Unicode escapes
- support suffix layouts with locale-suffixed source files through `localization_layout.base_name`
- enforce per-locale glossary mappings through review and final validation, and include explicit empty values in backlog runs
- run the quality gate before Action publication, preserve custom plugins, constrain target repositories to the caller workspace, and resolve subdirectory configs relative to their config file
- prepare the `v0.1.9` release and update public configuration documentation

## Verification

- 764 tests and 4 subtests pass for the isolated release tree; the complete mixed local worktree passes 767 tests
- 105 focused unit/integration tests cover placeholder profiles, Java keys, named layouts, external configs, glossary enforcement, and Action publication blocking
- Ruff, YAML parsing, and `git diff --check` pass
- targeted mutations make adjacent `%N` handling and Java unknown-escape canonicalization tests fail for the expected reasons
- CodeRabbit's two actionable findings are fixed, confirmed by the bot, and resolved

## Compatibility

The default placeholder profile remains `standard`. Existing configurations retain their previous token behavior unless they explicitly select `java-indexed`.
