### PR TITLE
Accept ellipses and refresh model pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.10] - 2026-08-28
+
+### Fixed
+
+- Accept three-dot ellipses in natural-language Java property keys while still
+  rejecting malformed exact double dots.
+- Update GPT-5.6 Sol, Terra, and Luna usage estimates to the current OpenAI
+  token rates, including cache writes and long-context multipliers.
+
+### Changed
+
+- Use GPT-5.6 Terra with reasoning disabled as the generic scaffold and example
+  review default, matching the production quality profile while retaining
+  GPT-4o mini for the initial translation pass.
+- The default bootstrap action ref is now `v0.1.10`.
+
 ## [0.1.9] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.9
+      - uses: bisq-network/localize-pipeline@v0.1.10
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -229,7 +229,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.9
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.10
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -249,7 +249,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.9
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.10
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -331,7 +331,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.9
+- uses: bisq-network/localize-pipeline@v0.1.10
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -57,15 +57,15 @@ translation_source: "git"
 # --- Model / provider ---
 model_provider: "aisuite"           # Default AISuite-backed provider abstraction.
 model_name: "gpt-4o-mini"          # fast initial translation
-review_model_name: "gpt-4o"        # holistic review pass (set equal to model_name to save cost)
-# review_reasoning_effort: "none"   # reasoning-capable review models only
+review_model_name: "gpt-5.6-terra" # balanced holistic review pass
+review_reasoning_effort: "none"    # deterministic, low-latency review behavior
 
 # Optional semantic sidecar. If auto_apply_error_suggestions is true, only
 # error-level findings with concrete suggested_value are applied, and only after
 # deterministic placeholder/control-character checks pass.
 # semantic_review:
 #   enabled: true
-#   model: "gpt-4o"
+#   model: "gpt-5.4-mini"
 #   reasoning_effort: "none"        # reasoning-capable semantic models only
 #   auto_apply_error_suggestions: false
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.9
+      - uses: bisq-network/localize-pipeline@v0.1.10
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.9
+      - uses: bisq-network/localize-pipeline@v0.1.10
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -165,7 +165,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.9
+      - uses: bisq-network/localize-pipeline@v0.1.10
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -184,7 +184,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.9
+      - uses: bisq-network/localize-pipeline@v0.1.10
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.9
+      - uses: bisq-network/localize-pipeline@v0.1.10
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.9
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.10
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -119,7 +119,7 @@ Placeholder detection defaults to `standard`. Set
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.9
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.10
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -141,7 +141,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.9 \
+  --action-ref v0.1.10 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.9"
+    action_ref: str = "v0.1.10"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -494,6 +494,7 @@ def _extract_plugin_args(raw_argv: Sequence[str]) -> tuple[list[str], list[str]]
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser and all supported subcommands."""
     parser = argparse.ArgumentParser(
         prog="localize",
         description="Validate and run the AI localization translation pipeline.",

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -579,7 +579,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.9", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.10", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/localize/init_config.py
+++ b/localize/init_config.py
@@ -2,7 +2,7 @@
 
 Auto-detects target locales from existing localization files and writes a small,
 generic config that defaults to the git translation source and OpenAI
-gpt-4o-mini/gpt-4o. The goal is a 5-minute first run without editing a 400-line
+gpt-4o-mini/GPT-5.6 Terra. The goal is a 5-minute first run without editing a 400-line
 example by hand.
 
 Usage::
@@ -388,7 +388,7 @@ def build_config(
     input_folder: str,
     locales: List[Dict[str, str]],
     model_name: str = "gpt-4o-mini",
-    review_model_name: str = "gpt-4o",
+    review_model_name: str = "gpt-5.6-terra",
     api_base_url: Optional[str] = None,
     localization_format: object = JAVA_PROPERTIES_FORMAT.id,
     localization_layout: object = SUFFIX_LAYOUT.id,
@@ -403,6 +403,7 @@ def build_config(
         "translation_source": "git",
         "model_name": model_name,
         "review_model_name": review_model_name,
+        "review_reasoning_effort": "none",
         "dry_run": dry_run,
         "translation_memory_enabled": True,
         "translation_memory_file_path": "logs/translation_memory.json",

--- a/localize/localization_adapters.py
+++ b/localize/localization_adapters.py
@@ -90,7 +90,7 @@ def lint_properties_file(file_path: str) -> List[str]:
                     raw_key, _separator_group, value = split_line
                     key = _unescape_key(raw_key)
 
-                    if '..' in key:
+                    if re.search(r'(?<!\.)\.\.(?!\.)', key):
                         errors.append(f"Linter Error: Malformed key '{key}' with double dots found on line {i}.")
 
                     value_to_check = value.rstrip('\r\n')

--- a/localize/usage_tracker.py
+++ b/localize/usage_tracker.py
@@ -18,22 +18,32 @@ from typing import Any, Dict, Optional
 
 from localize.atomic_io import write_json_atomic
 
-# USD per 1,000,000 tokens. Verify against current OpenAI pricing before relying.
+# USD per 1,000,000 tokens. GPT-5.6 rates verified against OpenAI's model
+# documentation on 2026-08-28; Sol pricing is promotional through 2026-11-21.
 DEFAULT_PRICES: Dict[str, Dict[str, float]] = {
     "gpt-5.6": {
-        "input": 5.00, "cached_input": 0.50, "cache_write": 6.25, "output": 30.00,
+        "input": 4.00, "cached_input": 0.40, "cache_write": 5.00, "output": 20.00,
+        "long_context_threshold": 272_000,
+        "long_context_input_multiplier": 2.0,
+        "long_context_output_multiplier": 1.5,
     },
     "gpt-5.6-sol": {
-        "input": 5.00, "cached_input": 0.50, "cache_write": 6.25, "output": 30.00,
+        "input": 4.00, "cached_input": 0.40, "cache_write": 5.00, "output": 20.00,
+        "long_context_threshold": 272_000,
+        "long_context_input_multiplier": 2.0,
+        "long_context_output_multiplier": 1.5,
     },
     "gpt-5.6-terra": {
-        "input": 2.50, "cached_input": 0.25, "cache_write": 3.125, "output": 15.00,
+        "input": 2.00, "cached_input": 0.20, "cache_write": 2.50, "output": 12.00,
         "long_context_threshold": 272_000,
         "long_context_input_multiplier": 2.0,
         "long_context_output_multiplier": 1.5,
     },
     "gpt-5.6-luna": {
-        "input": 1.00, "cached_input": 0.10, "cache_write": 1.25, "output": 6.00,
+        "input": 0.20, "cached_input": 0.02, "cache_write": 0.25, "output": 1.20,
+        "long_context_threshold": 272_000,
+        "long_context_input_multiplier": 2.0,
+        "long_context_output_multiplier": 1.5,
     },
     "gpt-5.5": {"input": 5.00, "cached_input": 0.50, "output": 30.00},
     "gpt-5.4": {"input": 2.50, "cached_input": 0.25, "output": 15.00},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.9"
+version = "0.1.10"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -33,6 +33,7 @@ def _init_repo(repo: Path) -> None:
 
 
 def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
+    """Bootstrap output uses the current release and remains executable."""
     repo = tmp_path / "target"
     _init_repo(repo)
 

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -65,7 +65,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.9" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.10" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -427,6 +427,7 @@ def test_cli_bootstrap_pr_delegates_to_onboarding_generator(capsys):
 
 
 def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
+    """The CLI forwards the latest released Action ref by default."""
     result = SimpleNamespace(
         branch_name="localize/onboarding",
         commit_sha="abc123",
@@ -587,6 +588,7 @@ def test_cli_memory_suggest_rejects_negative_limit(capsys):
 
 
 def test_pyproject_exposes_localize_console_script():
+    """Package metadata exposes the CLI and current package version."""
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -444,7 +444,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.9"
+    assert create.call_args.args[0].action_ref == "v0.1.10"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -590,7 +590,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.9"
+    assert pyproject["project"]["version"] == "0.1.10"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_init_config.py
+++ b/tests/unit/test_init_config.py
@@ -246,6 +246,7 @@ class TestCodeToName:
 
 class TestBuildConfig:
     def test_defaults_to_git_source(self):
+        """Generated configs use the production-proven two-pass model defaults."""
         cfg = build_config(
             target_project_root="/repo", input_folder="i18n",
             locales=[{"code": "de", "name": "German"}],

--- a/tests/unit/test_init_config.py
+++ b/tests/unit/test_init_config.py
@@ -254,7 +254,9 @@ class TestBuildConfig:
         assert cfg["target_project_root"] == "/repo"
         assert cfg["input_folder"] == "i18n"
         assert cfg["supported_locales"] == [{"code": "de", "name": "German"}]
-        assert "model_name" in cfg and "review_model_name" in cfg
+        assert cfg["model_name"] == "gpt-4o-mini"
+        assert cfg["review_model_name"] == "gpt-5.6-terra"
+        assert cfg["review_reasoning_effort"] == "none"
         assert cfg["dry_run"] is True
         assert cfg["localization_format"] == "java_properties"
         assert cfg["localization_layout"] == {"id": "suffix", "source_locale": "en"}

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -3,6 +3,8 @@
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from localize.usage_tracker import DEFAULT_PRICES, UsageTracker, cost_for_tokens
 
 
@@ -35,31 +37,40 @@ def test_cost_calculation():
 
 def test_default_prices_cover_configured_gpt5_models():
     assert DEFAULT_PRICES["gpt-5.6"] == {
-        "input": 5.00,
-        "cached_input": 0.50,
-        "cache_write": 6.25,
-        "output": 30.00,
+        "input": 4.00,
+        "cached_input": 0.40,
+        "cache_write": 5.00,
+        "output": 20.00,
+        "long_context_threshold": 272_000,
+        "long_context_input_multiplier": 2.0,
+        "long_context_output_multiplier": 1.5,
     }
     assert DEFAULT_PRICES["gpt-5.6-sol"] == {
-        "input": 5.00,
-        "cached_input": 0.50,
-        "cache_write": 6.25,
-        "output": 30.00,
+        "input": 4.00,
+        "cached_input": 0.40,
+        "cache_write": 5.00,
+        "output": 20.00,
+        "long_context_threshold": 272_000,
+        "long_context_input_multiplier": 2.0,
+        "long_context_output_multiplier": 1.5,
     }
     assert DEFAULT_PRICES["gpt-5.6-terra"] == {
-        "input": 2.50,
-        "cached_input": 0.25,
-        "cache_write": 3.125,
-        "output": 15.00,
+        "input": 2.00,
+        "cached_input": 0.20,
+        "cache_write": 2.50,
+        "output": 12.00,
         "long_context_threshold": 272_000,
         "long_context_input_multiplier": 2.0,
         "long_context_output_multiplier": 1.5,
     }
     assert DEFAULT_PRICES["gpt-5.6-luna"] == {
-        "input": 1.00,
-        "cached_input": 0.10,
-        "cache_write": 1.25,
-        "output": 6.00,
+        "input": 0.20,
+        "cached_input": 0.02,
+        "cache_write": 0.25,
+        "output": 1.20,
+        "long_context_threshold": 272_000,
+        "long_context_input_multiplier": 2.0,
+        "long_context_output_multiplier": 1.5,
     }
     assert DEFAULT_PRICES["gpt-5.5"] == {
         "input": 5.00,
@@ -146,7 +157,7 @@ def test_record_response_prices_cached_reads_and_writes_separately():
     assert model["cached_tokens"] == 400_000
     assert model["cache_write_tokens"] == 200_000
     # The 1M-token prompt uses Terra's long-context rates for the full request.
-    assert model["estimated_cost_usd"] == 5.7
+    assert model["estimated_cost_usd"] == 4.56
 
 
 def test_gpt56_long_context_pricing_boundary():
@@ -165,8 +176,18 @@ def test_gpt56_long_context_pricing_boundary():
         cache_write_tokens=50_000,
     )
 
-    assert base_cost == 1.98625
-    assert long_cost == 3.222505
+    assert base_cost == pytest.approx(1.589)
+    assert long_cost == pytest.approx(2.578004)
+
+
+def test_gpt56_long_context_pricing_covers_every_tier():
+    for model in ("gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+        base_cost = cost_for_tokens(model, 272_000, 100_000)
+        long_cost = cost_for_tokens(model, 272_001, 100_000)
+
+        assert base_cost is not None
+        assert long_cost is not None
+        assert long_cost > base_cost
 
 
 def test_long_context_pricing_is_applied_per_call_not_aggregate():
@@ -177,7 +198,7 @@ def test_long_context_pricing_is_applied_per_call_not_aggregate():
 
     model = tracker.summary()["models"]["gpt-5.6-terra"]
     assert model["prompt_tokens"] == 400_000
-    assert model["estimated_cost_usd"] == 1.3
+    assert model["estimated_cost_usd"] == 1.04
 
 
 def test_record_response_handles_missing_usage():

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -36,6 +36,7 @@ def test_cost_calculation():
 
 
 def test_default_prices_cover_configured_gpt5_models():
+    """The built-in price table covers every supported GPT-5 tier."""
     assert DEFAULT_PRICES["gpt-5.6"] == {
         "input": 4.00,
         "cached_input": 0.40,
@@ -139,6 +140,7 @@ def test_record_response_reads_usage():
 
 
 def test_record_response_prices_cached_reads_and_writes_separately():
+    """Cached reads and cache writes use their distinct token rates."""
     t = UsageTracker(prices=DEFAULT_PRICES)
     resp = SimpleNamespace(
         usage=SimpleNamespace(
@@ -161,6 +163,7 @@ def test_record_response_prices_cached_reads_and_writes_separately():
 
 
 def test_gpt56_long_context_pricing_boundary():
+    """The surcharge begins only above the documented token threshold."""
     base_cost = cost_for_tokens(
         "gpt-5.6-terra",
         272_000,
@@ -181,6 +184,7 @@ def test_gpt56_long_context_pricing_boundary():
 
 
 def test_gpt56_long_context_pricing_covers_every_tier():
+    """Every GPT-5.6 tier applies the documented long-context surcharge."""
     for model in ("gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
         base_cost = cost_for_tokens(model, 272_000, 100_000)
         long_cost = cost_for_tokens(model, 272_001, 100_000)
@@ -191,6 +195,7 @@ def test_gpt56_long_context_pricing_covers_every_tier():
 
 
 def test_long_context_pricing_is_applied_per_call_not_aggregate():
+    """Separate short calls do not trigger aggregate long-context pricing."""
     tracker = UsageTracker(prices=DEFAULT_PRICES)
 
     tracker.record("gpt-5.6-terra", 200_000, 10_000)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -91,6 +91,31 @@ class TestValidationLogic(unittest.TestCase):
 
         self.assertEqual(errors, [])
 
+    def test_linting_accepts_ellipsis_in_natural_language_keys(self):
+        """Display-string keys may contain ellipses without being malformed."""
+        content = (
+            r"Processing...=Обработка..." "\n"
+            r"Download\ referenced\ files\ (PDFs,\ ...)=Скачать связанные файлы (PDF, ...)" "\n"
+            r"key.one..bad=Still malformed" "\n"
+        )
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            delete=False,
+            suffix=".properties",
+            encoding="utf-8",
+        ) as properties_file:
+            properties_file.write(content)
+            temp_path = properties_file.name
+
+        try:
+            errors = lint_properties_file(temp_path)
+        finally:
+            os.remove(temp_path)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Malformed key 'key.one..bad'", errors[0])
+
     def test_linting_detects_multiple_malformed_suppress_comments(self):
         """Each malformed suppress comment should produce its own error."""
         content = (


### PR DESCRIPTION
## Summary
- accept natural-language Java property keys containing three-dot ellipses while retaining exact double-dot validation
- update GPT-5.6 Sol, Terra, and Luna token prices, cache-write rates, and long-context handling
- use GPT-5.6 Terra with reasoning disabled as the generic holistic-review default while retaining GPT-4o mini for initial translation
- release the changes as v0.1.10

## Production model decision
Production already uses GPT-4o mini for translation, GPT-5.6 Terra for holistic review, and GPT-5.4 mini for semantic review. Recorded usage shows that replacing the initial pass with Luna would have saved only about USD 0.32 cumulatively at identical token counts. The production model roles therefore remain unchanged pending a quality A/B test; this PR corrects cost reporting and aligns new-project defaults with the proven review configuration.

## Verification
- full suite: 769 passed
- Ruff: passed on changed Python files
- diff check: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for natural-language Java property keys containing ellipses while continuing to flag malformed double-dot sequences.
  * Updated default review configuration to use GPT-5.6 Terra with deterministic, low-latency reasoning settings.
  * Added long-context pricing support for GPT-5.6 models.

* **Bug Fixes**
  * Corrected GPT-5.6 usage estimates, including cached-token and long-context rates.

* **Documentation**
  * Updated examples and generated workflows to reference release v0.1.10.

* **Chores**
  * Bumped the application version to 0.1.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->