### PR TITLE
Resolve relative paths in the local runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.11] - 2026-08-28
+
+### Fixed
+
+- Resolve a relative `input_folder` against `target_project_root` in the local
+  runner preflight, matching the Python config loader and GitHub Action.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.11`.
+
 ## [0.1.10] - 2026-08-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.10
+      - uses: bisq-network/localize-pipeline@v0.1.11
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -229,7 +229,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.10
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.11
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -249,7 +249,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.10
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.11
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -331,7 +331,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.10
+- uses: bisq-network/localize-pipeline@v0.1.11
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.10
+      - uses: bisq-network/localize-pipeline@v0.1.11
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.10
+      - uses: bisq-network/localize-pipeline@v0.1.11
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -165,7 +165,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.10
+      - uses: bisq-network/localize-pipeline@v0.1.11
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -184,7 +184,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.10
+      - uses: bisq-network/localize-pipeline@v0.1.11
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.10
+      - uses: bisq-network/localize-pipeline@v0.1.11
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.10
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.11
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -119,7 +119,7 @@ Placeholder detection defaults to `standard`. Set
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.10
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.11
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -141,7 +141,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.10 \
+  --action-ref v0.1.11 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.10"
+    action_ref: str = "v0.1.11"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -580,7 +580,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.10", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.11", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.10"
+version = "0.1.11"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/run-local-translation.sh
+++ b/run-local-translation.sh
@@ -90,6 +90,16 @@ if [ -z "$TARGET_ROOT" ] || [ -z "$INPUT_FOLDER" ]; then
     exit 1
 fi
 
+# Match the Python loader: a relative target root is based at the config file,
+# then a relative input folder is based at the resolved target project root.
+CONFIG_BASE_DIR=$(cd "$(dirname "$CONFIG_FILE_PATH")" &>/dev/null && pwd)
+if [[ "$TARGET_ROOT" != /* ]]; then
+    TARGET_ROOT="$CONFIG_BASE_DIR/$TARGET_ROOT"
+fi
+if [[ "$INPUT_FOLDER" != /* ]]; then
+    INPUT_FOLDER="$TARGET_ROOT/$INPUT_FOLDER"
+fi
+
 if [ ! -d "$TARGET_ROOT" ] || [ ! -d "$INPUT_FOLDER" ]; then
     echo "[error] Target project root or input folder not found. Check paths in $CONFIG_FILE_PATH"
     echo "  - target_project_root: $TARGET_ROOT"

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -66,7 +66,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.10" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.11" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -445,7 +445,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.10"
+    assert create.call_args.args[0].action_ref == "v0.1.11"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -592,7 +592,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.10"
+    assert pyproject["project"]["version"] == "0.1.11"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_shell_packaging_scripts.py
+++ b/tests/unit/test_shell_packaging_scripts.py
@@ -166,6 +166,7 @@ def test_dockerfile_rebuilds_transifex_cli_instead_of_using_vendor_binary():
 
 
 def test_run_local_translation_resolves_config_before_chdir():
+    """The wrapper mirrors config-relative target and input path semantics."""
     script = (REPO_ROOT / "run-local-translation.sh").read_text(encoding="utf-8")
 
     assert 'CALLER_CWD=$(pwd)' in script
@@ -173,6 +174,9 @@ def test_run_local_translation_resolves_config_before_chdir():
     assert 'CONFIG_FILE_PATH=$(resolve_to_absolute "$1")' in script
     assert 'CONFIG_FILE_PATH=$(resolve_to_absolute "$TRANSLATOR_CONFIG_FILE")' in script
     assert 'if [ -n "${1:-}" ]; then' in script
+    assert 'CONFIG_BASE_DIR=$(cd "$(dirname "$CONFIG_FILE_PATH")"' in script
+    assert 'TARGET_ROOT="$CONFIG_BASE_DIR/$TARGET_ROOT"' in script
+    assert 'INPUT_FOLDER="$TARGET_ROOT/$INPUT_FOLDER"' in script
     assert "TRANSLATOR_CONFIG_FILE" in script
     assert "./setup.sh" not in script
 


### PR DESCRIPTION
## Summary
- make the local shell runner resolve relative target roots from the config directory
- resolve relative input folders from the resulting target project root
- match the already-supported Python loader and GitHub Action semantics
- release the correction as v0.1.11

## Why
A valid external-project config passed localize check but failed the shell wrapper before any API call because its relative input_folder was tested against the pipeline checkout.

## Verification
- regression test failed before the fix and passes after it
- full suite: 769 passed
- bash syntax check: passed
- Ruff and diff checks: passed