### PR TITLE
Delegate local preflight to the config loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.12] - 2026-08-28
+
+### Fixed
+
+- Delegate local-runner config validation to the typed Python loader so quoted
+  YAML values and all supported config shapes use the runtime's exact semantics.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.12`.
+
 ## [0.1.11] - 2026-08-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.11
+      - uses: bisq-network/localize-pipeline@v0.1.12
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -229,7 +229,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.11
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.12
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -249,7 +249,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.11
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.12
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -331,7 +331,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.11
+- uses: bisq-network/localize-pipeline@v0.1.12
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.11
+      - uses: bisq-network/localize-pipeline@v0.1.12
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.11
+      - uses: bisq-network/localize-pipeline@v0.1.12
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -165,7 +165,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.11
+      - uses: bisq-network/localize-pipeline@v0.1.12
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -184,7 +184,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.11
+      - uses: bisq-network/localize-pipeline@v0.1.12
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.11
+      - uses: bisq-network/localize-pipeline@v0.1.12
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.11
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.12
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -119,7 +119,7 @@ Placeholder detection defaults to `standard`. Set
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.11
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.12
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -141,7 +141,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.11 \
+  --action-ref v0.1.12 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.11"
+    action_ref: str = "v0.1.12"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -580,7 +580,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.11", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.12", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.11"
+version = "0.1.12"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/run-local-translation.sh
+++ b/run-local-translation.sh
@@ -41,28 +41,10 @@ PIP_SYNC_BIN="$VENV_DIR/bin/pip-sync"
 
 echo "[info] Using configuration file: $CONFIG_FILE_PATH"
 
-# Helper function to parse simple key: value pairs from the YAML config file.
-yaml_get() {
-    local key="$1"
-    # This parser is intentionally simple. It handles unquoted, single-quoted,
-    # and double-quoted values, strips inline comments, and trims whitespace.
-    local value
-    value=$(grep -E "^[[:space:]]*${key}:" "$CONFIG_FILE_PATH" | head -1 |
-      sed -nE "s/^[[:space:]]*${key}:[[:space:]]*(\"([^\"]*)\"|'([^']*)'|([^#]*))([[:space:]]*#.*)?$/\2\3\4/p" |
-      sed -E 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    echo "$value"
-}
-
 # --- Pre-flight Checks ---
 if [ ! -f "$CONFIG_FILE_PATH" ]; then
     echo "[error] Configuration file not found: $CONFIG_FILE_PATH"
     exit 1
-fi
-
-# Read the optional glob filter from the config and export it for the Python script
-TRANSLATION_FILTER_GLOB="$(yaml_get "translation_file_filter_glob" || echo "")"
-if [ -n "$TRANSLATION_FILTER_GLOB" ] && [ "$TRANSLATION_FILTER_GLOB" != "null" ]; then
-  export TRANSLATION_FILTER_GLOB
 fi
 
 if [ ! -d "$VENV_DIR" ]; then
@@ -82,30 +64,10 @@ if ! "$PIP_SYNC_BIN" requirements-dev.txt --quiet; then
     exit 1
 fi
 
-TARGET_ROOT="$(yaml_get "target_project_root" || echo "")"
-INPUT_FOLDER="$(yaml_get "input_folder" || echo "")"
-
-if [ -z "$TARGET_ROOT" ] || [ -z "$INPUT_FOLDER" ]; then
-    echo "[error] 'target_project_root' or 'input_folder' not defined in $CONFIG_FILE_PATH"
-    exit 1
-fi
-
-# Match the Python loader: a relative target root is based at the config file,
-# then a relative input folder is based at the resolved target project root.
-CONFIG_BASE_DIR=$(cd "$(dirname "$CONFIG_FILE_PATH")" &>/dev/null && pwd)
-if [[ "$TARGET_ROOT" != /* ]]; then
-    TARGET_ROOT="$CONFIG_BASE_DIR/$TARGET_ROOT"
-fi
-if [[ "$INPUT_FOLDER" != /* ]]; then
-    INPUT_FOLDER="$TARGET_ROOT/$INPUT_FOLDER"
-fi
-
-if [ ! -d "$TARGET_ROOT" ] || [ ! -d "$INPUT_FOLDER" ]; then
-    echo "[error] Target project root or input folder not found. Check paths in $CONFIG_FILE_PATH"
-    echo "  - target_project_root: $TARGET_ROOT"
-    echo "  - input_folder: $INPUT_FOLDER"
-    exit 1
-fi
+# Use the same typed YAML loader and validation path as the runtime. This keeps
+# quoted values, relative paths, provider settings, and future config keys in
+# one implementation instead of duplicating YAML semantics in shell.
+"$VENV_PYTHON" -m localize.cli check --config "$CONFIG_FILE_PATH"
 
 # --- Script Execution ---
 echo "[info] Starting translation process..."

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -66,7 +66,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.11" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.12" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -445,7 +445,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.11"
+    assert create.call_args.args[0].action_ref == "v0.1.12"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -592,7 +592,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.11"
+    assert pyproject["project"]["version"] == "0.1.12"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_shell_packaging_scripts.py
+++ b/tests/unit/test_shell_packaging_scripts.py
@@ -158,6 +158,7 @@ def test_dockerignore_excludes_local_configs_and_agent_scratch():
 
 
 def test_dockerfile_rebuilds_transifex_cli_instead_of_using_vendor_binary():
+    """The image builds a pinned, auditable Transifex CLI from source."""
     dockerfile = (REPO_ROOT / "docker" / "Dockerfile").read_text(encoding="utf-8")
 
     assert "TX_SHA256" not in dockerfile

--- a/tests/unit/test_shell_packaging_scripts.py
+++ b/tests/unit/test_shell_packaging_scripts.py
@@ -165,8 +165,8 @@ def test_dockerfile_rebuilds_transifex_cli_instead_of_using_vendor_binary():
     assert "go version -m /out/tx" in dockerfile
 
 
-def test_run_local_translation_resolves_config_before_chdir():
-    """The wrapper mirrors config-relative target and input path semantics."""
+def test_run_local_translation_delegates_config_validation_to_python():
+    """The wrapper uses the typed loader instead of reparsing YAML in shell."""
     script = (REPO_ROOT / "run-local-translation.sh").read_text(encoding="utf-8")
 
     assert 'CALLER_CWD=$(pwd)' in script
@@ -174,9 +174,8 @@ def test_run_local_translation_resolves_config_before_chdir():
     assert 'CONFIG_FILE_PATH=$(resolve_to_absolute "$1")' in script
     assert 'CONFIG_FILE_PATH=$(resolve_to_absolute "$TRANSLATOR_CONFIG_FILE")' in script
     assert 'if [ -n "${1:-}" ]; then' in script
-    assert 'CONFIG_BASE_DIR=$(cd "$(dirname "$CONFIG_FILE_PATH")"' in script
-    assert 'TARGET_ROOT="$CONFIG_BASE_DIR/$TARGET_ROOT"' in script
-    assert 'INPUT_FOLDER="$TARGET_ROOT/$INPUT_FOLDER"' in script
+    assert '"$VENV_PYTHON" -m localize.cli check --config "$CONFIG_FILE_PATH"' in script
+    assert "yaml_get()" not in script
     assert "TRANSLATOR_CONFIG_FILE" in script
     assert "./setup.sh" not in script
 


### PR DESCRIPTION
## Summary
- remove the local runner's ad-hoc YAML parser
- validate with the same typed Python loader used by the CLI and Action
- support quoted YAML, relative paths, filter settings, and future config shapes without duplicated shell semantics
- release as v0.1.12

## Verification
- regression contract failed before the fix and passes after it
- full suite: 769 passed
- Bash syntax, Ruff, and diff checks: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 0.1.12.
  * Generated workflows now use the `v0.1.12` localization pipeline action by default.
  * Local translation runs now use the CLI’s configuration validation for more consistent checks.

* **Documentation**
  * Updated GitHub Action, CLI, bootstrap, and release examples to reference version 0.1.12.

* **Bug Fixes**
  * Improved consistency between local translation validation and CLI configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->