### PR TITLE
Fix holistic placeholder restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.13] - 2026-08-28
+
+### Fixed
+
+- Restore holistic-review placeholders against both protected inputs before
+  checking for unresolved tokens. Reviewers may legitimately reuse a token
+  from the source text instead of the draft translation.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.13`.
+
 ## [0.1.12] - 2026-08-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.12
+      - uses: bisq-network/localize-pipeline@v0.1.13
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -229,7 +229,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.12
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.13
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -249,7 +249,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.12
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.13
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -331,7 +331,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.12
+- uses: bisq-network/localize-pipeline@v0.1.13
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.12
+      - uses: bisq-network/localize-pipeline@v0.1.13
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.12
+      - uses: bisq-network/localize-pipeline@v0.1.13
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -165,7 +165,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.12
+      - uses: bisq-network/localize-pipeline@v0.1.13
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -184,7 +184,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.12
+      - uses: bisq-network/localize-pipeline@v0.1.13
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.12
+      - uses: bisq-network/localize-pipeline@v0.1.13
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.12
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.13
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -119,7 +119,7 @@ Placeholder detection defaults to `standard`. Set
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.12
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.13
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -141,7 +141,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.12 \
+  --action-ref v0.1.13 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.12"
+    action_ref: str = "v0.1.13"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -580,7 +580,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.12", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.13", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -1684,14 +1684,19 @@ async def holistic_review_async(
                     has_tokens = "__PH_" in ai_value
                     logger.debug(f"AI returned for '{sample_key}': '{ai_value}' (has_tokens={has_tokens})")
 
-                # Restore placeholders in the reviewed translations
-                # AI might use tokens from EITHER source or translated content, so restore with both
+                # The reviewer may use tokens from either protected input. Restore
+                # against one combined map so the unresolved-token assertion runs
+                # only after both namespaces have been considered.
+                review_placeholder_map = {
+                    **source_placeholder_map,
+                    **translated_placeholder_map,
+                }
                 restored_json = {}
                 for key, value in parsed_json.items():
-                    # First restore with translated map, then with source map for any remaining tokens
-                    restored_value = restore_placeholders_in_properties(value, translated_placeholder_map)
-                    restored_value = restore_placeholders_in_properties(restored_value, source_placeholder_map)
-                    restored_json[key] = restored_value
+                    restored_json[key] = restore_placeholders_in_properties(
+                        value,
+                        review_placeholder_map,
+                    )
 
                 # Debug: Check restoration results
                 for sample_key in sample_ai_keys:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.12"
+version = "0.1.13"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -66,7 +66,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.12" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.13" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -445,7 +445,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.12"
+    assert create.call_args.args[0].action_ref == "v0.1.13"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -592,7 +592,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.12"
+    assert pyproject["project"]["version"] == "0.1.13"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_holistic_review_protection.py
+++ b/tests/unit/test_holistic_review_protection.py
@@ -245,6 +245,46 @@ async def test_holistic_review_uses_compatible_completion_token_limit():
 
 
 @pytest.mark.asyncio
+async def test_holistic_review_restores_source_side_protection_tokens():
+    """A review may reuse a token from the protected source text."""
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=json.dumps({"key1": "Hallo __PH_source__"})
+                )
+            )
+        ]
+    )
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=response)
+    provider.is_retryable_error.return_value = False
+
+    with (
+        patch("localize.translate_localization_files.DRY_RUN", False),
+        patch("localize.translate_localization_files.MODEL_PROVIDER", provider),
+        patch(
+            "localize.translate_localization_files.protect_placeholders_in_properties",
+            side_effect=[
+                ("key1=Hello __PH_source__", {"__PH_source__": "%0"}),
+                ("key1=Hallo __PH_draft__", {"__PH_draft__": "%0"}),
+            ],
+        ),
+    ):
+        result = await holistic_review_async(
+            source_content="key1=Hello %0",
+            translated_content="key1=Hallo %0",
+            target_language="German",
+            keys_to_review=["key1"],
+            semaphore=asyncio.Semaphore(1),
+            rate_limiter=_NullAsyncContext(),
+            style_rules_text="",
+        )
+
+    assert result == {"key1": "Hallo %0"}
+
+
+@pytest.mark.asyncio
 async def test_holistic_review_omits_json_mode_when_provider_does_not_support_it():
     response = SimpleNamespace(
         choices=[


### PR DESCRIPTION
Summary:
- Restore holistic-review tokens against the union of source and draft token maps.
- Add a regression test that reproduces the JabRef pilot failure.
- Release the fix as v0.1.13 and update generated Action refs.

Validation:
- Full pytest suite: 770 passed.
- Mutation check: the new regression fails against the previous sequential restoration code.
- Reproduced during the full 815-key JabRef Russian pilot with source-side indexed tokens.