### PR TITLE
Support inflected glossary terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.14] - 2026-08-28
+
+### Added
+
+- Add `translation_glossary_enforcement: prompt-only` for inflected languages.
+  Both model passes still receive preferred glossary lemmas, while deterministic
+  validation no longer rejects grammatical surface forms that differ from the
+  configured dictionary form. Existing profiles remain `exact` by default.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.14`.
+
 ## [0.1.13] - 2026-08-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.13
+      - uses: bisq-network/localize-pipeline@v0.1.14
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -203,6 +203,7 @@ Key settings:
 | `supported_locales` | Target locales. |
 | `project_context` | Product/domain context injected into prompts. |
 | `brand_technical_glossary` | Terms that must not be translated. |
+| `translation_glossary_enforcement` | `exact` by default; use `prompt-only` for preferred lemmas that require grammatical inflection. |
 | `ignore_key_patterns` | Python regexes matched against adapter keys; matching keys are copied from source and never translated. |
 | `style_rules` | Locale-specific writing rules. |
 
@@ -229,7 +230,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.13
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.14
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -249,7 +250,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.13
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.14
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -331,7 +332,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.13
+- uses: bisq-network/localize-pipeline@v0.1.14
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -93,6 +93,10 @@ review_reasoning_effort: "none"    # deterministic, low-latency review behavior
 # --- Glossary (optional but recommended) ---
 # JSON file of per-language term mappings. See glossary.example.json for the format.
 glossary_file_path: "glossary.example.json"
+# "exact" (default) deterministically requires the configured target text.
+# Use "prompt-only" when mappings are grammatical lemmas whose surface form
+# must be inflected in the target language (for example Russian nouns).
+translation_glossary_enforcement: "exact"
 
 # Brand/technical terms that must never be translated.
 brand_technical_glossary:

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.13
+      - uses: bisq-network/localize-pipeline@v0.1.14
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.13
+      - uses: bisq-network/localize-pipeline@v0.1.14
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -165,7 +165,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.13
+      - uses: bisq-network/localize-pipeline@v0.1.14
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -184,7 +184,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.13
+      - uses: bisq-network/localize-pipeline@v0.1.14
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.13
+      - uses: bisq-network/localize-pipeline@v0.1.14
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.13
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.14
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -119,7 +119,7 @@ Placeholder detection defaults to `standard`. Set
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.13
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.14
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -141,7 +141,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.13 \
+  --action-ref v0.1.14 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/localize/app_config.py
+++ b/localize/app_config.py
@@ -36,6 +36,9 @@ from localize.model_provider import (
 from localize.semantic_quality import normalize_retained_source_word_allowlist
 
 
+TRANSLATION_GLOSSARY_ENFORCEMENT_VALUES = frozenset({"exact", "prompt-only"})
+
+
 @dataclass
 class QualityGateConfig:
     """Configuration for generated translation PR quality gates."""
@@ -113,6 +116,10 @@ class AppConfig:
     # Placeholder-detection profile ("standard" or "java-indexed"). Runtime
     # entry points activate it after loading so this loader remains state-free.
     placeholder_profile: str = DEFAULT_PLACEHOLDER_PROFILE
+
+    # "exact" deterministically requires the configured target text;
+    # "prompt-only" treats values as terminology lemmas that models may inflect.
+    translation_glossary_enforcement: str = "exact"
 
 
 @dataclass(frozen=True)
@@ -209,6 +216,17 @@ def validate_config(
         validate_placeholder_profile(placeholder_profile)
     except ValueError as exc:
         issues.append(ConfigIssue("error", str(exc)))
+
+    translation_glossary_enforcement = str(
+        config.get("translation_glossary_enforcement") or "exact"
+    ).strip().lower()
+    if translation_glossary_enforcement not in TRANSLATION_GLOSSARY_ENFORCEMENT_VALUES:
+        issues.append(ConfigIssue(
+            "error",
+            "translation_glossary_enforcement must be one of: "
+            + ", ".join(sorted(TRANSLATION_GLOSSARY_ENFORCEMENT_VALUES))
+            + ".",
+        ))
 
     translation_source = str(config.get("translation_source") or "transifex").strip().lower()
     if translation_source not in {"git", "transifex"}:
@@ -690,6 +708,15 @@ def load_app_config() -> AppConfig:
     except ValueError as exc:
         logger.critical("CRITICAL: %s", exc)
         sys.exit(1)
+    translation_glossary_enforcement = str(
+        config.get('translation_glossary_enforcement') or 'exact'
+    ).strip().lower()
+    if translation_glossary_enforcement not in TRANSLATION_GLOSSARY_ENFORCEMENT_VALUES:
+        logger.critical(
+            "CRITICAL: translation_glossary_enforcement must be one of: %s.",
+            ", ".join(sorted(TRANSLATION_GLOSSARY_ENFORCEMENT_VALUES)),
+        )
+        sys.exit(1)
     quality_gate_config = config.get('quality_gate', {}) or {}
     quality_gate = QualityGateConfig(
         source_identical_min_block_count=_as_positive_int(
@@ -849,4 +876,5 @@ def load_app_config() -> AppConfig:
         localization_profiles=localization_profiles,
         review_reasoning_effort=review_reasoning_effort,
         placeholder_profile=placeholder_profile,
+        translation_glossary_enforcement=translation_glossary_enforcement,
     )

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.13"
+    action_ref: str = "v0.1.14"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -580,7 +580,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.13", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.14", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -123,6 +123,7 @@ TRANSLATION_KEY_LEDGER_FILE_PATH = config.translation_key_ledger_file_path
 TRANSLATION_MEMORY_FILE_PATH = config.translation_memory_file_path
 TRANSLATION_MEMORY_ENABLED = config.translation_memory_enabled
 PRESERVE_QUEUES_FOR_DEBUG = config.preserve_queues_for_debug
+TRANSLATION_GLOSSARY_ENFORCEMENT = config.translation_glossary_enforcement
 MODEL_PROVIDER = config.model_provider
 client = config.openai_client
 _FALLBACK_PROVIDER = OpenAICompatibleProvider(client=None)
@@ -224,6 +225,7 @@ def translation_memory_context_fingerprint(
         glossary: Mapping[str, Dict[str, str]],
         brand_glossary: List[str],
         style_rules_text: str = "",
+        translation_glossary_enforcement: str = "exact",
 ) -> str:
     """Hash context that can materially change the correct target string."""
     payload = {
@@ -231,6 +233,7 @@ def translation_memory_context_fingerprint(
         "glossary": glossary.get(locale, {}),
         "brand_glossary": sorted(set(brand_glossary)),
         "style_rules_text": style_rules_text,
+        "translation_glossary_enforcement": translation_glossary_enforcement,
     }
     serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
@@ -753,6 +756,7 @@ def build_context(
         model_name: str,
         system_prompt_text: str = "",
         current_key: Optional[str] = None,
+        translation_glossary_enforcement: str = "exact",
 ) -> Tuple[str, str]:
     """
     Build the context and glossary text for the translation prompt.
@@ -774,7 +778,16 @@ def build_context(
     total_tokens = 0
 
     # Build glossary entries
-    glossary_entries = [f'"{k}" should be translated as "{v}"' for k, v in language_glossary.items()]
+    if translation_glossary_enforcement == "prompt-only":
+        glossary_entries = [
+            f'"{k}" preferred base term: "{v}" (inflect or adapt for grammar)'
+            for k, v in language_glossary.items()
+        ]
+    else:
+        glossary_entries = [
+            f'"{k}" should be translated as "{v}"'
+            for k, v in language_glossary.items()
+        ]
     glossary_text = '\n'.join(glossary_entries)
     glossary_tokens = count_tokens(glossary_text, model_name)
 
@@ -1391,6 +1404,7 @@ async def translate_text_async(
             style_rules_text=style_rules_text,
             project_context=PROJECT_CONTEXT,
             localization_format=localization_format or LOCALIZATION_FORMAT,
+            translation_glossary_enforcement=TRANSLATION_GLOSSARY_ENFORCEMENT,
         )
 
         # Build the context and glossary text
@@ -1402,6 +1416,7 @@ async def translate_text_async(
             MODEL_NAME,
             system_prompt_text=system_prompt,
             current_key=key,
+            translation_glossary_enforcement=TRANSLATION_GLOSSARY_ENFORCEMENT,
         )
 
         # Extract and protect placeholders
@@ -1488,18 +1503,24 @@ def _build_holistic_review_system_prompt(
         style_rules_text: str,  # Pass pre-computed rules
         localization_format: LocalizationFormat = LOCALIZATION_FORMAT,
         translation_glossary: Optional[Mapping[str, str]] = None,
+        translation_glossary_enforcement: str = "exact",
 ) -> str:
     """Builds the system prompt for the holistic review API call."""
     keys_to_review_text = "\n".join([f"- {_display_translation_key(k)}" for k in keys_to_review])
-    glossary_rules = "\n".join(
-        f'- When the English source contains "{source_term}", the translation must contain "{target_term}".'
-        for source_term, target_term in (translation_glossary or {}).items()
-    )
-    glossary_section = (
-        "**Mandatory Translation Glossary**:\n" + glossary_rules + "\n\n"
-        if glossary_rules
-        else ""
-    )
+    if translation_glossary_enforcement == "prompt-only":
+        glossary_rules = "\n".join(
+            f'- When the English source contains "{source_term}", use "{target_term}" '
+            "as the preferred base term; inflect or adapt it when grammar requires."
+            for source_term, target_term in (translation_glossary or {}).items()
+        )
+        glossary_heading = "**Preferred Translation Glossary**:\n"
+    else:
+        glossary_rules = "\n".join(
+            f'- When the English source contains "{source_term}", the translation must contain "{target_term}".'
+            for source_term, target_term in (translation_glossary or {}).items()
+        )
+        glossary_heading = "**Mandatory Translation Glossary**:\n"
+    glossary_section = glossary_heading + glossary_rules + "\n\n" if glossary_rules else ""
 
     return f"""
 You are a lead editor and quality assurance specialist for software localization. Your task is to review a list of newly translated keys within a {localization_format.display_name} file for {target_language}. You are given the full source and translated files for context, but you MUST only review and return the keys specified.
@@ -1554,6 +1575,14 @@ def _prefer_glossary_compliant_draft(
     return reviewed_value
 
 
+def _glossary_for_deterministic_enforcement(
+    translation_glossary: Mapping[str, str],
+    enforcement: str,
+) -> Mapping[str, str]:
+    """Return exact mappings only when the configured policy requires them."""
+    return translation_glossary if enforcement == "exact" else {}
+
+
 def _build_holistic_review_user_prompt(
         target_language: str,
         source_content: str,
@@ -1593,6 +1622,7 @@ async def holistic_review_async(
         style_rules_text: str,
         localization_format: Optional[LocalizationFormat] = None,
         translation_glossary: Optional[Mapping[str, str]] = None,
+        translation_glossary_enforcement: str = "exact",
 ) -> Optional[Dict[str, str]]:
     """
     Performs a holistic review of an entire translated file and returns corrections
@@ -1634,6 +1664,7 @@ async def holistic_review_async(
             style_rules_text=style_rules_text,
             localization_format=localization_format or LOCALIZATION_FORMAT,
             translation_glossary=translation_glossary,
+            translation_glossary_enforcement=translation_glossary_enforcement,
         )
         review_user_prompt = _build_holistic_review_user_prompt(
             target_language=target_language,
@@ -2336,11 +2367,16 @@ async def process_translation_queue(
                 if isinstance(raw_language_glossary, Mapping)
                 else {}
             )
+            enforced_language_glossary = _glossary_for_deterministic_enforcement(
+                language_glossary,
+                TRANSLATION_GLOSSARY_ENFORCEMENT,
+            )
             memory_context_fingerprint = translation_memory_context_fingerprint(
                 locale=language_code,
                 glossary=glossary,
                 brand_glossary=BRAND_GLOSSARY,
                 style_rules_text=style_rules_text_for_review,
+                translation_glossary_enforcement=TRANSLATION_GLOSSARY_ENFORCEMENT,
             )
 
             # Define full paths
@@ -2456,7 +2492,7 @@ async def process_translation_queue(
                             localization_format,
                             ignore_key_patterns=IGNORE_KEY_PATTERNS,
                             changed_keys_for_run=set(ignored_keys_requiring_output),
-                            translation_glossary=language_glossary,
+                            translation_glossary=enforced_language_glossary,
                     ):
                         logger.error(
                             "Skipping write for '%s' because post-translation validation failed.",
@@ -2624,6 +2660,7 @@ async def process_translation_queue(
                     style_rules_text=style_rules_text_for_review,
                     localization_format=localization_format,
                     translation_glossary=language_glossary,
+                    translation_glossary_enforcement=TRANSLATION_GLOSSARY_ENFORCEMENT,
                 ) for key_chunk in key_chunks],
                 return_exceptions=True,
             )
@@ -2658,7 +2695,7 @@ async def process_translation_queue(
                                 source_translations.get(key, ""),
                                 draft_translations.get(key, ""),
                                 value,
-                                language_glossary,
+                                enforced_language_glossary,
                             )
                             if selected_value != value:
                                 logger.warning(
@@ -2750,7 +2787,7 @@ async def process_translation_queue(
                 source_translations,
                 translation_file,
                 ignore_key_patterns=IGNORE_KEY_PATTERNS,
-                translation_glossary=language_glossary,
+                translation_glossary=enforced_language_glossary,
             )
             failed_keys = set(per_key_summary["failed_keys"]).union(model_failed_keys)
             increment_run_metric(run_metrics, "model_translation_failed_count", len(failed_keys))
@@ -2790,7 +2827,7 @@ async def process_translation_queue(
                     localization_format,
                     ignore_key_patterns=IGNORE_KEY_PATTERNS,
                     changed_keys_for_run=set(keys_to_translate),
-                    translation_glossary=language_glossary,
+                    translation_glossary=enforced_language_glossary,
             ):
                 logger.error("Skipping write for '%s' because post-translation validation failed.", translation_file)
                 skipped_files[translation_file] = ["Post-translation validation failed."]

--- a/localize/translation_prompts.py
+++ b/localize/translation_prompts.py
@@ -8,6 +8,7 @@ def build_translation_system_prompt(
         style_rules_text: str,
         project_context: str,
         localization_format: LocalizationFormat,
+        translation_glossary_enforcement: str = "exact",
 ) -> str:
     """Build the reusable system prompt for a single localization value."""
     project_context = project_context.strip()
@@ -18,6 +19,19 @@ def build_translation_system_prompt(
 {project_context}
 """
 
+    if translation_glossary_enforcement == "prompt-only":
+        translation_glossary_rule = (
+            "The Translation Glossary is preferred terminology guidance. Use each "
+            "target value as the preferred base term. Inflect or adapt it when "
+            "target-language grammar requires; do not force an ungrammatical exact "
+            "surface form."
+        )
+    else:
+        translation_glossary_rule = (
+            "These terms are non-negotiable. You MUST use the provided translation, "
+            "matching the source term case-insensitively."
+        )
+
     return f"""
 You are an expert translator specializing in software localization. Translate the following {localization_format.display_name} value from English to {target_language}, considering the context and glossary provided.
 
@@ -26,7 +40,7 @@ You are an expert translator specializing in software localization. Translate th
 - **CRITICAL - Translate ALL other text**: You MUST translate all regular text, even if it appears between, before, or after placeholder tokens. Do not skip text just because it is near placeholders.
 - **Strictly follow all glossaries**:
   - **Brand/Technical Glossary**: These terms MUST NOT be translated. Preserve their original casing and form.
-  - **Translation Glossary**: These terms are non-negotiable. You MUST use the provided translation, matching the source term case-insensitively.
+  - **Translation Glossary**: {translation_glossary_rule}
 - **Preserve formatting**: Keep special characters and formatting such as `\\n` and `\\t`.
 - **Do not add** any additional characters or punctuation (e.g., no square brackets, quotation marks, etc.).
 - **Provide only** the translated text corresponding to the Value.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.13"
+version = "0.1.14"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_app_config.py
+++ b/tests/unit/test_app_config.py
@@ -391,6 +391,21 @@ class TestLoadAppConfig:
 
         assert config.placeholder_profile == "standard"
 
+    def test_load_config_accepts_prompt_only_glossary_enforcement(self):
+        mock_config = {
+            "dry_run": True,
+            "translation_glossary_enforcement": "prompt-only",
+        }
+
+        with patch("localize.app_config._load_yaml_config", return_value=mock_config):
+            with patch("os.path.exists", return_value=False):
+                with patch("localize.app_config.setup_logger") as mock_logger:
+                    mock_logger.return_value = MagicMock()
+                    with patch.dict(os.environ, {}, clear=True):
+                        config = load_app_config()
+
+        assert config.translation_glossary_enforcement == "prompt-only"
+
     def test_load_config_rejects_unknown_placeholder_profile(self):
         mock_config = {
             "dry_run": True,
@@ -808,6 +823,13 @@ class TestValidateConfig:
         errors = self._errors(validate_config(config, path_exists=lambda p: True))
 
         assert any("Unknown placeholder profile" in error for error in errors)
+
+    def test_unknown_glossary_enforcement_is_validation_error(self):
+        config = {**self.GOOD, "translation_glossary_enforcement": "sometimes"}
+
+        errors = self._errors(validate_config(config, path_exists=lambda p: True))
+
+        assert any("translation_glossary_enforcement must be one of" in error for error in errors)
 
     def test_unknown_translation_source_is_validation_error(self):
         config = {**self.GOOD, "translation_source": "crowdin"}

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -66,7 +66,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.13" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.14" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -445,7 +445,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.13"
+    assert create.call_args.args[0].action_ref == "v0.1.14"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -592,7 +592,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.13"
+    assert pyproject["project"]["version"] == "0.1.14"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -277,6 +277,20 @@ class TestCoreLogic(unittest.TestCase):
             self.assertIn("key1", context_text)
             self.assertNotIn("key2", context_text)
 
+    def test_build_context_marks_prompt_only_terms_as_inflectable(self):
+        _, glossary_text = build_context(
+            {},
+            {},
+            {"entry": "запись"},
+            4000,
+            "gpt-4o-mini",
+            translation_glossary_enforcement="prompt-only",
+        )
+
+        self.assertIn("preferred base term", glossary_text)
+        self.assertIn("inflect or adapt", glossary_text)
+        self.assertNotIn("should be translated as", glossary_text)
+
     def test_build_context_prioritizes_sibling_keys(self):
         """
         Tests that build_context surfaces sibling keys (sharing a dotted prefix

--- a/tests/unit/test_glossary_enforcement.py
+++ b/tests/unit/test_glossary_enforcement.py
@@ -1,6 +1,7 @@
 from localize.translation_validator import find_glossary_mismatches
 from localize.translate_localization_files import (
     _build_holistic_review_system_prompt,
+    _glossary_for_deterministic_enforcement,
     _prefer_glossary_compliant_draft,
     load_glossary,
     run_post_translation_validation,
@@ -89,6 +90,30 @@ def test_holistic_review_prompt_receives_mandatory_glossary():
     assert "Mandatory Translation Glossary" in prompt
     assert '"entry"' in prompt
     assert '"Eintrag"' in prompt
+
+
+def test_holistic_review_prompt_allows_grammatical_inflection():
+    prompt = _build_holistic_review_system_prompt(
+        target_language="Russian",
+        keys_to_review=["Entry"],
+        source_content="Entry=Entry",
+        translated_content="Entry=Запись",
+        style_rules_text="",
+        translation_glossary={"entry": "запись"},
+        translation_glossary_enforcement="prompt-only",
+    )
+
+    assert "Preferred Translation Glossary" in prompt
+    assert "preferred base term" in prompt
+    assert "inflect or adapt" in prompt
+    assert "must contain" not in prompt
+
+
+def test_prompt_only_glossary_is_not_exactly_enforced():
+    glossary = {"entry": "запись"}
+
+    assert _glossary_for_deterministic_enforcement(glossary, "exact") == glossary
+    assert _glossary_for_deterministic_enforcement(glossary, "prompt-only") == {}
 
 
 def test_compliant_draft_wins_when_review_breaks_glossary():

--- a/tests/unit/test_translation_memory.py
+++ b/tests/unit/test_translation_memory.py
@@ -14,7 +14,10 @@ from localize.translation_memory import (
     save_translation_memory,
     translation_memory_suggestions,
 )
-from localize.translate_localization_files import apply_translation_memory
+from localize.translate_localization_files import (
+    apply_translation_memory,
+    translation_memory_context_fingerprint,
+)
 
 
 def test_translation_memory_roundtrip_and_lookup(tmp_path):
@@ -300,4 +303,20 @@ def test_translation_memory_context_fingerprint_invalidates_stale_entries():
             context_fingerprint="new",
         )
         is None
+    )
+
+
+def test_glossary_enforcement_policy_changes_memory_context_fingerprint():
+    kwargs = {
+        "locale": "ru",
+        "glossary": {"ru": {"entry": "запись"}},
+        "brand_glossary": ["JabRef"],
+    }
+
+    assert translation_memory_context_fingerprint(
+        **kwargs,
+        translation_glossary_enforcement="exact",
+    ) != translation_memory_context_fingerprint(
+        **kwargs,
+        translation_glossary_enforcement="prompt-only",
     )

--- a/tests/unit/test_translation_prompt.py
+++ b/tests/unit/test_translation_prompt.py
@@ -29,6 +29,20 @@ def test_translation_system_prompt_includes_configured_project_context():
     assert "Acme Cloud" in prompt
 
 
+def test_translation_system_prompt_describes_prompt_only_glossary_as_lemmas():
+    prompt = build_translation_system_prompt(
+        target_language="Russian",
+        style_rules_text="",
+        project_context="",
+        localization_format=JAVA_PROPERTIES_FORMAT,
+        translation_glossary_enforcement="prompt-only",
+    )
+
+    assert "preferred terminology guidance" in prompt
+    assert "Inflect or adapt" in prompt
+    assert "non-negotiable" not in prompt
+
+
 def test_translation_system_prompt_mentions_format_metadata():
     prompt = build_translation_system_prompt(
         target_language="German",


### PR DESCRIPTION
Summary:
- Add exact and prompt-only translation glossary enforcement policies.
- Keep exact deterministic enforcement as the backward-compatible default.
- In prompt-only mode, send preferred lemmas to both model passes and permit grammatical inflection.
- Include the policy in translation-memory fingerprints.
- Release as v0.1.14.

Why:
The JabRef Russian pilot produced grammatically correct inflected forms, but exact substring validation reverted 56 keys to English because its Crowdin glossary stores dictionary lemmas.

Validation:
- Full pytest suite: 777 passed.
- JabRef prompt-only config preflight passed.
- Exact-mode tests continue to cover deterministic rejection.