### PR TITLE
Stabilize holistic review keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.15] - 2026-08-28
+
+### Fixed
+
+- Address holistic-review entries by opaque item IDs, preventing models from
+  translating, normalizing, or corrupting natural-language localization keys.
+- Retry non-empty holistic-review responses that omit requested item IDs or
+  return out-of-scope IDs instead of silently keeping draft values.
+- Mark every key in an exhausted holistic-review chunk as failed, so ledgers
+  retry it and the quality gate cannot silently accept a one-pass fallback.
+- Accept logical localization keys containing decoded Java character escapes;
+  reviewer responses no longer need to reproduce their serialized spelling.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.15`.
+
 ## [0.1.14] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.14
+      - uses: bisq-network/localize-pipeline@v0.1.15
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -230,7 +230,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.14
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.15
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -250,7 +250,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.14
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.15
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -332,7 +332,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.14
+- uses: bisq-network/localize-pipeline@v0.1.15
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.14
+      - uses: bisq-network/localize-pipeline@v0.1.15
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.14
+      - uses: bisq-network/localize-pipeline@v0.1.15
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -165,7 +165,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.14
+      - uses: bisq-network/localize-pipeline@v0.1.15
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -184,7 +184,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.14
+      - uses: bisq-network/localize-pipeline@v0.1.15
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.14
+      - uses: bisq-network/localize-pipeline@v0.1.15
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.14
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.15
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -119,7 +119,7 @@ Placeholder detection defaults to `standard`. Set
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.14
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.15
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -141,7 +141,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.14 \
+  --action-ref v0.1.15 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.14"
+    action_ref: str = "v0.1.15"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -580,7 +580,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.14", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.15", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -86,10 +86,7 @@ logger = logging.getLogger("translation_script")
 # This ensures that the AI returns a dictionary where every value is a string.
 LOCALIZATION_SCHEMA = {
     "type": "object",
-    "patternProperties": {
-        "^.*$": {"type": "string"}
-    },
-    "additionalProperties": False
+    "additionalProperties": {"type": "string"},
 }
 
 # Extract configuration values for convenience
@@ -1506,7 +1503,11 @@ def _build_holistic_review_system_prompt(
         translation_glossary_enforcement: str = "exact",
 ) -> str:
     """Builds the system prompt for the holistic review API call."""
-    keys_to_review_text = "\n".join([f"- {_display_translation_key(k)}" for k in keys_to_review])
+    review_items = _holistic_review_items(keys_to_review)
+    keys_to_review_text = "\n".join(
+        f'- "{item_id}" identifies source key "{_display_translation_key(key)}"'
+        for item_id, key in review_items.items()
+    )
     if translation_glossary_enforcement == "prompt-only":
         glossary_rules = "\n".join(
             f'- When the English source contains "{source_term}", use "{target_term}" '
@@ -1526,7 +1527,7 @@ def _build_holistic_review_system_prompt(
 You are a lead editor and quality assurance specialist for software localization. Your task is to review a list of newly translated keys within a {localization_format.display_name} file for {target_language}. You are given the full source and translated files for context, but you MUST only review and return the keys specified.
 
 **Critical Instructions**:
-1.  **Strictly Limited Scope**: You MUST only review and provide corrected translations for the following keys. Do NOT output any other keys in your final JSON.
+1.  **Strictly Limited Scope**: Review every item below. The left side is an opaque item ID; the right side is the source localization key used to find its values in the supplied files.
     ```
     {keys_to_review_text}
     ```
@@ -1538,7 +1539,7 @@ You are a lead editor and quality assurance specialist for software localization
 3.  **CRITICAL - Translate ALL Other Text**: You MUST ensure that ALL regular text (text that is NOT a placeholder token) is properly translated, even if it appears between, before, or after placeholder tokens. Do not leave any translatable text untranslated just because it is near placeholders.
 4.  **Apply All Quality Rules**: Meticulously apply the language-specific quality checklist to every key in your scope.
 5.  **Preserve Format Semantics**: Return plain translated string values. The system will serialize and escape values according to the target localization format. For Java `MessageFormat` strings, return single quotes (') as literal characters; the system handles required escaping.
-6.  **Output JSON Only**: Your final output **must** be a single, valid JSON object that adheres to the required schema. This object should contain ONLY the keys listed in the "Strictly Limited Scope" section above, with their final, corrected translations as the values.
+6.  **Output JSON Only**: Your final output **must** be a single, valid JSON object that adheres to the required schema. Return every opaque item ID listed in the "Strictly Limited Scope" section exactly once, with its final corrected translation as the value. JSON property names MUST be the opaque item IDs, never the source localization keys.
 7.  **Do Not Add Explanations**: Do not output any text, markdown, or explanations before or after the JSON object.
 
 {glossary_section}{style_rules_text}
@@ -1546,8 +1547,8 @@ You are a lead editor and quality assurance specialist for software localization
 **JSON Output Example**:
 ```json
 {{
-  "key.one": "Corrected translation for key one.",
-  "key.two": "Corrected translation for key two."
+  "review_item_0001": "Corrected translation for the first item.",
+  "review_item_0002": "Corrected translation for the second item."
 }}
 ```
 """
@@ -1612,6 +1613,39 @@ def _holistic_review_completion_token_limit(keys_to_review: List[str]) -> int:
     return max(8192, min(16384, len(keys_to_review) * 512))
 
 
+def _holistic_review_items(keys_to_review: List[str]) -> Dict[str, str]:
+    """Assign stable opaque response IDs so models never have to reproduce keys."""
+    return {
+        f"review_item_{index:04d}": key
+        for index, key in enumerate(keys_to_review, start=1)
+    }
+
+
+def _validate_holistic_review_response_keys(
+        parsed_json: Mapping[str, str],
+        keys_to_review: List[str],
+) -> None:
+    """Reject partial reviews and model-renamed or out-of-scope keys.
+
+    An empty object remains the established explicit "no corrections" response.
+    """
+    if not parsed_json:
+        return
+    expected_keys = set(keys_to_review)
+    actual_keys = set(parsed_json)
+    missing_keys = expected_keys - actual_keys
+    unexpected_keys = actual_keys - expected_keys
+    if missing_keys or unexpected_keys:
+        details = []
+        if missing_keys:
+            details.append(f"missing {len(missing_keys)} requested key(s)")
+        if unexpected_keys:
+            details.append(f"returned {len(unexpected_keys)} out-of-scope key(s)")
+        raise jsonschema.ValidationError(
+            "Holistic review key set mismatch: " + "; ".join(details),
+        )
+
+
 async def holistic_review_async(
         source_content: str,
         translated_content: str,
@@ -1651,6 +1685,7 @@ async def holistic_review_async(
     # Protect placeholders in both source and translated content before sending to AI
     protected_source, source_placeholder_map = protect_placeholders_in_properties(source_content)
     protected_translated, translated_placeholder_map = protect_placeholders_in_properties(translated_content)
+    review_items = _holistic_review_items(keys_to_review)
 
     logger.debug(f"Protected {len(source_placeholder_map)} placeholders in source content")
     logger.debug(f"Protected {len(translated_placeholder_map)} placeholders in translated content")
@@ -1707,6 +1742,7 @@ async def holistic_review_async(
                 # The response should be a JSON string. Parse and validate it.
                 parsed_json = loads_json_object(response_text)
                 jsonschema.validate(instance=parsed_json, schema=LOCALIZATION_SCHEMA)
+                _validate_holistic_review_response_keys(parsed_json, list(review_items))
 
                 # Debug: Check what AI returned before restoration
                 sample_ai_keys = list(parsed_json.keys())[:2]
@@ -1723,14 +1759,15 @@ async def holistic_review_async(
                     **translated_placeholder_map,
                 }
                 restored_json = {}
-                for key, value in parsed_json.items():
-                    restored_json[key] = restore_placeholders_in_properties(
+                for item_id, value in parsed_json.items():
+                    restored_json[review_items[item_id]] = restore_placeholders_in_properties(
                         value,
                         review_placeholder_map,
                     )
 
                 # Debug: Check restoration results
-                for sample_key in sample_ai_keys:
+                for sample_item_id in sample_ai_keys:
+                    sample_key = review_items[sample_item_id]
                     if sample_key in restored_json:
                         restored_value = restored_json[sample_key]
                         has_tokens = "__PH_" in restored_value
@@ -2665,6 +2702,7 @@ async def process_translation_queue(
                 return_exceptions=True,
             )
 
+            review_failed_keys = set()
             for i, (corrected_chunk, key_chunk) in enumerate(zip(review_results, key_chunks)):
                 if isinstance(corrected_chunk, Exception):
                     logger.error(
@@ -2673,6 +2711,7 @@ async def process_translation_queue(
                         translation_file,
                         exc_info=(type(corrected_chunk), corrected_chunk, corrected_chunk.__traceback__),
                     )
+                    review_failed_keys.update(key_chunk)
                     for key in key_chunk:
                         final_corrected_translations[key] = draft_translations.get(key, "")
                 elif corrected_chunk is not None:
@@ -2682,6 +2721,7 @@ async def process_translation_queue(
                             type(corrected_chunk).__name__,
                             i + 1,
                         )
+                        review_failed_keys.update(key_chunk)
                         for key in key_chunk:
                             final_corrected_translations[key] = draft_translations.get(key, "")
                         continue
@@ -2711,14 +2751,27 @@ async def process_translation_queue(
                                 len(dropped),
                             )
                         final_corrected_translations.update(scoped)
+                        missing = key_chunk_set - set(scoped)
+                        if missing:
+                            logger.warning(
+                                "Holistic review omitted %d key(s) from chunk %d; keeping draft values.",
+                                len(missing),
+                                i + 1,
+                            )
+                            review_failed_keys.update(missing)
+                            for key in missing:
+                                final_corrected_translations[key] = draft_translations.get(key, "")
                     else:
                         logger.info("Holistic review returned no corrections for this chunk; keeping draft values.")
                         for key in key_chunk:
                             final_corrected_translations[key] = draft_translations.get(key, "")
                 else:
                     logger.warning(f"Holistic review for chunk {i + 1} failed; keeping draft values for this chunk.")
+                    review_failed_keys.update(key_chunk)
                     for key in key_chunk:
                         final_corrected_translations[key] = draft_translations.get(key, "")
+
+            model_failed_keys.update(review_failed_keys)
 
             # Always apply the results from the review stage, which includes fallbacks to draft for failed chunks.
             logger.info("Applying corrected translations (including any draft fallbacks).")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.14"
+version = "0.1.15"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -311,6 +311,47 @@ async def test_failed_model_translation_marks_ledger_and_skips_memory(integratio
 
 
 @pytest.mark.asyncio
+async def test_failed_holistic_review_marks_keys_failed(integration_test_environment):
+    """A draft is not a successful two-pass translation when review failed."""
+    env = integration_test_environment
+    source_file_path = os.path.join(env['input_folder'], 'app.properties')
+    target_file_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
+    ledger_path = os.path.join(env['input_folder'], 'ledger.json')
+    validation_summary = {}
+
+    with open(source_file_path, 'w', encoding='utf-8') as f:
+        f.write("key.review=Needs review\n")
+    with open(target_file_path, 'w', encoding='utf-8') as f:
+        f.write("")
+
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Braucht Prüfung"))]
+    ))
+    provider.count_tokens.side_effect = lambda text, model: len(text.split())
+    provider.estimate_run_cost.return_value = MagicMock()
+    provider.format_estimate.return_value = "estimate"
+    provider.is_retryable_error.return_value = False
+
+    with patch('localize.translate_localization_files.MODEL_PROVIDER', provider), \
+         patch('localize.translate_localization_files.TRANSLATION_KEY_LEDGER_FILE_PATH', ledger_path), \
+         patch('localize.translate_localization_files.get_working_tree_changed_keys', return_value=set()), \
+         patch('localize.translate_localization_files.holistic_review_async', new_callable=AsyncMock) as review:
+        review.return_value = None
+        await localize.translate_localization_files.process_translation_queue(
+            translation_queue_folder=env['translation_queue_folder'],
+            translated_queue_folder=env['translated_queue_folder'],
+            glossary_file_path=env['mock_glossary_path_resolved'],
+            validation_summary=validation_summary,
+        )
+
+    ledger = localize.translate_localization_files.load_translation_key_ledger(ledger_path)
+    assert ledger["app_de.properties"]["key.review"]["status"] == "failed"
+    assert validation_summary["app_de.properties"]["model_translation_failed_count"] == 1
+    assert validation_summary["app_de.properties"]["model_translation_failed_keys"] == ["key.review"]
+
+
+@pytest.mark.asyncio
 async def test_key_ledger_preserves_full_file_baseline_after_partial_translation(integration_test_environment):
     env = integration_test_environment
     source_file_path = os.path.join(env['input_folder'], 'app.properties')

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -66,7 +66,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.14" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.15" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -445,7 +445,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.14"
+    assert create.call_args.args[0].action_ref == "v0.1.15"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -592,7 +592,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.14"
+    assert pyproject["project"]["version"] == "0.1.15"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_holistic_review_protection.py
+++ b/tests/unit/test_holistic_review_protection.py
@@ -196,7 +196,7 @@ async def test_holistic_review_uses_compatible_completion_token_limit():
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(
-                    content=json.dumps({"key1": "Hallo {0}"})
+                    content=json.dumps({"review_item_0001": "Hallo {0}"})
                 )
             )
         ]
@@ -240,6 +240,7 @@ async def test_holistic_review_uses_compatible_completion_token_limit():
     assert kwargs["response_format"] == {"type": "json_object"}
     assert [message["role"] for message in kwargs["messages"]] == ["system", "user"]
     assert "Return a JSON object" in kwargs["messages"][1]["content"]
+    assert "review_item_0001" in kwargs["messages"][0]["content"]
     assert "max_tokens" not in kwargs
     assert "max_completion_tokens" not in kwargs
 
@@ -251,7 +252,7 @@ async def test_holistic_review_restores_source_side_protection_tokens():
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(
-                    content=json.dumps({"key1": "Hallo __PH_source__"})
+                    content=json.dumps({"review_item_0001": "Hallo __PH_source__"})
                 )
             )
         ]
@@ -285,12 +286,127 @@ async def test_holistic_review_restores_source_side_protection_tokens():
 
 
 @pytest.mark.asyncio
+async def test_holistic_review_accepts_logical_newlines_in_keys():
+    """Java character escapes can decode to newlines in logical keys."""
+    logical_key = "Line one\nLine two"
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=json.dumps({"review_item_0001": "Zeile eins\nZeile zwei"})
+                )
+            )
+        ]
+    )
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=response)
+    provider.is_retryable_error.return_value = False
+
+    with (
+        patch("localize.translate_localization_files.DRY_RUN", False),
+        patch("localize.translate_localization_files.MODEL_PROVIDER", provider),
+        patch("localize.translate_localization_files._handle_retry", AsyncMock(return_value=False)),
+    ):
+        result = await holistic_review_async(
+            source_content="Line one\\nLine two=Line one\\nLine two",
+            translated_content="Line one\\nLine two=Zeile eins\\nZeile zwei",
+            target_language="German",
+            keys_to_review=[logical_key],
+            semaphore=asyncio.Semaphore(1),
+            rate_limiter=_NullAsyncContext(),
+            style_rules_text="",
+        )
+
+    assert result == {logical_key: "Zeile eins\nZeile zwei"}
+
+
+@pytest.mark.asyncio
+async def test_holistic_review_uses_opaque_ids_for_escaped_java_keys():
+    """Reviewer output never has to reproduce escaped or multiline source keys."""
+    logical_key = "Line one\nLine two"
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=json.dumps({"review_item_0001": "Zeile eins\nZeile zwei"})
+                )
+            )
+        ]
+    )
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(return_value=response)
+    provider.is_retryable_error.return_value = False
+
+    with (
+        patch("localize.translate_localization_files.DRY_RUN", False),
+        patch("localize.translate_localization_files.MODEL_PROVIDER", provider),
+        patch("localize.translate_localization_files._handle_retry", AsyncMock(return_value=False)),
+    ):
+        result = await holistic_review_async(
+            source_content="Line one\\nLine two=Line one\\nLine two",
+            translated_content="Line one\\nLine two=Zeile eins\\nZeile zwei",
+            target_language="German",
+            keys_to_review=[logical_key],
+            semaphore=asyncio.Semaphore(1),
+            rate_limiter=_NullAsyncContext(),
+            style_rules_text="",
+        )
+
+    assert result == {logical_key: "Zeile eins\nZeile zwei"}
+    system_prompt = provider.create_chat_completion.await_args.kwargs["messages"][0]["content"]
+    assert "review_item_0001" in system_prompt
+    assert "Line one\\nLine two" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_holistic_review_retries_until_response_has_exact_requested_keys():
+    """A review is complete only when it returns every requested key and no others."""
+    responses = [
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=json.dumps({"original.key": "Falsch"}))
+                )
+            ]
+        ),
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=json.dumps({"review_item_0001": "Richtig"}))
+                )
+            ]
+        ),
+    ]
+    provider = MagicMock()
+    provider.create_chat_completion = AsyncMock(side_effect=responses)
+    provider.is_retryable_error.return_value = False
+
+    with (
+        patch("localize.translate_localization_files.DRY_RUN", False),
+        patch("localize.translate_localization_files.MODEL_PROVIDER", provider),
+        patch("localize.translate_localization_files._handle_retry", AsyncMock(return_value=True)),
+    ):
+        result = await holistic_review_async(
+            source_content="original.key=Original",
+            translated_content="original.key=Entwurf",
+            target_language="German",
+            keys_to_review=["original.key"],
+            semaphore=asyncio.Semaphore(1),
+            rate_limiter=_NullAsyncContext(),
+            style_rules_text="",
+        )
+
+    assert result == {"original.key": "Richtig"}
+    assert provider.create_chat_completion.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_holistic_review_omits_json_mode_when_provider_does_not_support_it():
     response = SimpleNamespace(
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(
-                    content='```json\n{"key1": "Hallo {0}"}\n```'
+                    content='```json\n{"review_item_0001": "Hallo {0}"}\n```'
                 )
             )
         ]
@@ -324,11 +440,14 @@ async def test_holistic_review_omits_json_mode_when_provider_does_not_support_it
 
 @pytest.mark.asyncio
 async def test_holistic_review_completion_limit_scales_with_chunk_size():
+    keys = [f"key{i}" for i in range(40)]
+    reviewed = {f"review_item_{i + 1:04d}": f"Wert {i}" for i in range(len(keys))}
+    expected = {key: f"Wert {i}" for i, key in enumerate(keys)}
     response = SimpleNamespace(
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(
-                    content=json.dumps({"key0": "Wert 0"})
+                    content=json.dumps(reviewed)
                 )
             )
         ]
@@ -336,7 +455,6 @@ async def test_holistic_review_completion_limit_scales_with_chunk_size():
     provider = MagicMock()
     provider.create_chat_completion = AsyncMock(return_value=response)
     provider.is_retryable_error.return_value = False
-    keys = [f"key{i}" for i in range(40)]
 
     with (
         patch("localize.translate_localization_files.DRY_RUN", False),
@@ -352,7 +470,7 @@ async def test_holistic_review_completion_limit_scales_with_chunk_size():
             style_rules_text="",
         )
 
-    assert result == {"key0": "Wert 0"}
+    assert result == expected
     kwargs = provider.create_chat_completion.await_args.kwargs
     assert kwargs["completion_token_limit"] > 8192
 
@@ -366,7 +484,7 @@ async def test_holistic_review_retries_empty_content_without_name_error():
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(
-                    content=json.dumps({"key1": "Hallo"})
+                    content=json.dumps({"review_item_0001": "Hallo"})
                 )
             )
         ]


### PR DESCRIPTION
Summary:
- Address holistic-review entries with stable opaque item IDs rather than model-reproduced localization keys.
- Require every non-empty response to contain the exact requested IDs and retry incomplete or out-of-scope responses.
- Mark exhausted review chunks failed in the ledger and validation summary so the quality gate blocks one-pass fallbacks.
- Accept Java logical keys containing decoded character escapes without asking the model to serialize them.
- Release as v0.1.15.

Why:
JabRef has legal `\\n` escapes in natural-language property keys. Models may translate, normalize, or concatenate those keys when they are used as JSON field names. Opaque IDs separate localization identity from model output and preserve the exact key set across every format.

Validation:
- Full pytest suite: 781 passed, including integration and prompt-capture tests.
- Mutation check: opaque-ID tests fail against the prior natural-key protocol.
- Integration regression: an exhausted holistic review now marks its keys failed instead of silently accepting draft fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved holistic review reliability by preventing key mix-ups and rejecting incomplete or out-of-scope responses.
  - Failed review items are now tracked for retry instead of being silently skipped.
  - Localization keys containing decoded Java escape sequences are accepted correctly.

- **Documentation**
  - Updated usage examples and workflow guidance to reference version 0.1.15.

- **Release**
  - Updated the package and default bootstrap action reference to version 0.1.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->