### PR TITLE
Respect active placeholder profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.16] - 2026-08-30
+
+### Fixed
+
+- Make semantic-remediation numeric checks use the active placeholder profile,
+  so opt-in Java-indexed `%N` placeholders are never mistaken for numeric
+  literals.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.16`.
+
 ## [0.1.15] - 2026-08-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.15
+      - uses: bisq-network/localize-pipeline@v0.1.16
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -230,7 +230,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.15
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.16
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -250,7 +250,7 @@ Full guide: [docs/localization-cli.md](docs/localization-cli.md).
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.15
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.16
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -332,7 +332,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.15
+- uses: bisq-network/localize-pipeline@v0.1.16
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.15
+      - uses: bisq-network/localize-pipeline@v0.1.16
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.15
+      - uses: bisq-network/localize-pipeline@v0.1.16
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -165,7 +165,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.15
+      - uses: bisq-network/localize-pipeline@v0.1.16
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -184,7 +184,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.15
+      - uses: bisq-network/localize-pipeline@v0.1.16
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.15
+      - uses: bisq-network/localize-pipeline@v0.1.16
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.15
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.16
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -119,7 +119,7 @@ Placeholder detection defaults to `standard`. Set
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.15
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.16
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -141,7 +141,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.15 \
+  --action-ref v0.1.16 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.15"
+    action_ref: str = "v0.1.16"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -580,7 +580,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.15", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.16", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/localize/placeholder_rules.py
+++ b/localize/placeholder_rules.py
@@ -101,6 +101,13 @@ def extract_placeholder_tokens(text: str) -> Counter[str]:
     return Counter(match.group(0) for match in _active_pattern().finditer(text))
 
 
+def strip_placeholder_tokens(text: str) -> str:
+    """Remove tokens recognized by the active placeholder profile."""
+    if not isinstance(text, str):
+        raise ValueError("Input text must be a string.")
+    return _active_pattern().sub("", text)
+
+
 def protect_placeholders(text: str) -> Tuple[str, Dict[str, str]]:
     """Replace detected placeholders with opaque tokens and return the mapping."""
     if not isinstance(text, str):

--- a/localize/semantic_remediation.py
+++ b/localize/semantic_remediation.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Iterable, Mapping, Sequence
 
 from localize.localization_adapters import get_localization_adapter
 from localize.localization_profiles import LocalizationProfile
-from localize.placeholder_rules import PLACEHOLDER_PATTERN
+from localize.placeholder_rules import strip_placeholder_tokens
 from localize.translation_validator import (
     check_placeholder_parity,
     find_disallowed_control_characters,
@@ -106,6 +106,7 @@ def _matching_profile(
 
 
 def _skip(result: SemanticRemediationResult, finding: Mapping[str, Any], reason: str) -> None:
+    """Record one rejected remediation candidate with its concrete reason."""
     result.skipped.append({
         "file": str(finding.get("file", "")),
         "key": str(finding.get("key", "")),
@@ -114,7 +115,8 @@ def _skip(result: SemanticRemediationResult, finding: Mapping[str, Any], reason:
 
 
 def _numeric_literals(value: str) -> set[str]:
-    without_placeholders = PLACEHOLDER_PATTERN.sub("", value)
+    """Return normalized decimal literals outside active-profile placeholders."""
+    without_placeholders = strip_placeholder_tokens(value)
     return {
         "".join(str(unicodedata.decimal(character)) for character in match.group())
         for match in re.finditer(r"\d+", without_placeholders)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.15"
+version = "0.1.16"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -66,7 +66,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.15" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.16" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -445,7 +445,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.15"
+    assert create.call_args.args[0].action_ref == "v0.1.16"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -592,7 +592,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.15"
+    assert pyproject["project"]["version"] == "0.1.16"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_semantic_remediation.py
+++ b/tests/unit/test_semantic_remediation.py
@@ -1,6 +1,7 @@
 import json
 
 from localize.localization_profiles import load_localization_profiles
+from localize.placeholder_rules import placeholder_profile
 from localize.semantic_remediation import apply_semantic_review_suggestions
 
 
@@ -61,6 +62,7 @@ def test_semantic_remediation_skips_suggestions_that_break_placeholders(tmp_path
 
 
 def test_semantic_remediation_rejects_source_absent_numeric_constraints(tmp_path):
+    """Suggested requirements may not introduce numbers absent from source."""
     resources = tmp_path / "resources"
     resources.mkdir()
     (resources / "messages.properties").write_text(
@@ -94,6 +96,43 @@ def test_semantic_remediation_rejects_source_absent_numeric_constraints(tmp_path
     assert target_path.read_text(encoding="utf-8") == (
         "validation.invalidAmount=Ungültiger Betrag\n"
     )
+
+
+def test_semantic_remediation_excludes_java_indexed_placeholders_from_numbers(tmp_path):
+    """Java placeholder indices must not authorize new literal numbers."""
+    resources = tmp_path / "resources"
+    resources.mkdir()
+    (resources / "messages.properties").write_text(
+        "path=Write to %0\n",
+        encoding="utf-8",
+    )
+    target_path = resources / "messages_ru.properties"
+    target_path.write_text("path=Записать в %0\n", encoding="utf-8")
+
+    with placeholder_profile("java-indexed"):
+        result = apply_semantic_review_suggestions(
+            repo_root=str(tmp_path),
+            input_folder=str(resources),
+            findings=[
+                {
+                    "file": "messages_ru.properties",
+                    "key": "path",
+                    "severity": "error",
+                    "suggested_value": "Записать в %0, код 0",
+                }
+            ],
+            locale_codes=["ru"],
+            localization_profiles=load_localization_profiles(
+                {"localization_format": "java_properties"}
+            ),
+            changed_identities={("messages_ru.properties", "path")},
+        )
+
+    assert result.applied_count == 0
+    assert result.skipped[0]["reason"] == (
+        "suggestion introduces numeric literals absent from source"
+    )
+    assert target_path.read_text(encoding="utf-8") == "path=Записать в %0\n"
 
 
 def test_semantic_remediation_allows_localized_source_numeric_literals(tmp_path):


### PR DESCRIPTION
## Summary

- route semantic-remediation numeric checks through the active placeholder profile
- prevent digits inside opt-in Java-indexed `%N` placeholders from masking newly introduced numeric constraints
- add a mutation-checked regression and release v0.1.16 metadata

## Verification

- `venv/bin/pytest` — 782 passed, including integration and prompt-capture coverage
- mutation check: the new regression fails against the previous frozen-standard-pattern implementation
- `venv/bin/python -m build --sdist --wheel`
- `git diff --check`
- whole-repository search confirms no consumer imports `PLACEHOLDER_PATTERN`; it remains only as the documented compatibility alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric validation during semantic remediation so Java-indexed placeholders such as `%0` are not mistaken for numeric literals.
  * Prevented invalid remediation suggestions from modifying target files.

* **Documentation**
  * Updated GitHub Action, CLI, and bootstrap examples to reference `v0.1.16`.

* **Release**
  * Released version `0.1.16` with updated default action references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->