### PR TITLE
Add SSH signing to Localize Guardian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
 
 ## Unreleased
 
+## [0.1.19] - 2026-09-01
+
+### Added
+
+- Add opt-in, agent-backed SSH commit signing to Localize Guardian. SSH
+  identities are pinned by an exact SHA-256 public-key fingerprint and a
+  permission-checked single-key public file; OpenPGP remains the default.
+
+### Security
+
+- Snapshot SSH public signing material through a bounded non-following read,
+  derive a private one-key allowed-signers file, reject ambiguous or weak keys,
+  and reverify the exact signature both after commit creation and immediately
+  before publication.
+- Pin eligible macOS system-managed agent sockets to their exact inode inside
+  the private signing snapshot, then pass the validated `SSH_AUTH_SOCK` only to
+  the commit-signing subprocess. Model, credential-helper, fetch, push, test,
+  and verification subprocesses receive no SSH agent socket.
+- Make `guardian doctor` perform a real isolated SSH sign-and-verify probe and
+  reject an unavailable agent, substituted public identity, or untrusted
+  signing executable before a write-capable run.
+
+### Changed
+
+- The default bootstrap action ref is now `v0.1.19`.
+
 ## [0.1.18] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.18
+      - uses: bisq-network/localize-pipeline@v0.1.19
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -230,7 +230,7 @@ localize validate --config config.yaml
 localize run --dry-run --config config.yaml
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.18
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.19
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -271,6 +271,12 @@ default is `gpt-5.6-terra` with reasoning effort `high`. The dedicated Guardian
 login is kept outside monitored repositories; inherited API keys are not used
 in the default subscription mode.
 
+Write modes support the backward-compatible OpenPGP signer or an opt-in,
+agent-backed SSH signing key. The SSH path stores only an exact public-key
+fingerprint and public-key file; the agent socket reaches only the commit
+subprocess, and signatures are reverified before publication. See the full
+Guardian guide for setup and Keychain/launchd notes.
+
 Pipeline validation policy defaults to the exact repository base SHA. Projects
 that keep localization config outside the repository can opt into a private,
 operator-owned config snapshot with `pipeline_config_source: operator`.
@@ -296,7 +302,7 @@ the full guide for the macOS containment tradeoff.
 To onboard another repository without hand-copying files, run:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.18
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.19
 ```
 
 The command refuses dirty worktrees, creates a `localize/onboarding` branch, and
@@ -378,7 +384,7 @@ matches only.
 Pin a tagged release for production workflows once tags are available:
 
 ```yaml
-- uses: bisq-network/localize-pipeline@v0.1.18
+- uses: bisq-network/localize-pipeline@v0.1.19
 ```
 
 Use `@main` only when you intentionally want the latest unreleased changes.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.18
+      - uses: bisq-network/localize-pipeline@v0.1.19
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -99,7 +99,7 @@ a dedicated machine user:
 5. Pass the signing inputs to the action:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.18
+      - uses: bisq-network/localize-pipeline@v0.1.19
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -165,7 +165,7 @@ profile list.
 Use `api-base-url` for any OpenAI-compatible endpoint:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.18
+      - uses: bisq-network/localize-pipeline@v0.1.19
         with:
           config-file: config.yaml
           api-base-url: http://localhost:11434/v1
@@ -184,7 +184,7 @@ For custom adapters, install the package and list the adapter modules with the
 first-class plugin inputs:
 
 ```yaml
-      - uses: bisq-network/localize-pipeline@v0.1.18
+      - uses: bisq-network/localize-pipeline@v0.1.19
         with:
           config-file: config.yaml
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: bisq-network/localize-pipeline@v0.1.18
+      - uses: bisq-network/localize-pipeline@v0.1.19
         with:
           config-file: config.yaml
           diff-base: ${{ github.event.pull_request.base.sha }}

--- a/docs/guardian.md
+++ b/docs/guardian.md
@@ -201,7 +201,8 @@ Prerequisites:
 - Python 3.11 or later and the `localize` package;
 - Codex CLI plus either a ChatGPT-plan login (the default) or an explicitly
   selected API credential;
-- Git and an explicit GPG signing-key ID for every Guardian write mode;
+- Git and an explicit OpenPGP or agent-backed SSH signing identity for every
+  Guardian write mode;
 - a narrowly scoped GitHub credential available from an OS secret store;
 - a persistent local directory for state and logs.
 
@@ -279,6 +280,54 @@ outside monitored repositories, owned by the operator, and executable only by
 that user. Do not put a token literal in a helper, environment file, or
 scheduler argument.
 
+### Commit signing
+
+OpenPGP is the backward-compatible default. Keep `signing_format: openpgp`, set
+`signing_program` to the trusted GPG executable, and set `signing_key` to the
+full 40- or 64-hex fingerprint (optionally suffixed by `!` for an exact GPG key
+selector). Existing OpenPGP installations need no migration.
+
+Agent-backed Git SSH signing is an opt-in alternative:
+
+```yaml
+runtime:
+  signing_format: ssh
+  signing_program: /usr/bin/ssh-keygen
+  signing_key: SHA256:REPLACE_WITH_EXACT_PUBLIC_KEY_FINGERPRINT
+  signing_public_key: /absolute/path/to/guardian-signing-key.pub
+```
+
+`signing_key` is the exact unpadded SHA-256 fingerprint printed by
+`ssh-keygen -l -E sha256 -f <public-key>`. The public-key file must contain
+exactly one supported key. It must be an absolute, non-symlink regular file,
+owned by the operator or root, not writable by group or other users, and have
+one link. Its ancestors must also be trusted. DSA, malformed or multiple keys,
+RSA keys below 3072 bits, and a fingerprint mismatch fail closed.
+
+The Guardian never reads or stores an SSH private key. Before external poll
+work it copies the validated public key into a private bounded snapshot and
+derives a one-key `allowed-signers` file. Git selects that frozen public key and
+asks the existing `ssh-agent` for the matching private operation. The validated
+agent endpoint must have a private `0700` parent. If a higher macOS system
+directory is root-owned but group-writable, Guardian hard-links the exact socket
+inode into the private signing snapshot and verifies both names before use;
+ordinary mutable ancestors still fail closed. `SSH_AUTH_SOCK` is passed only to
+the `git commit` subprocess—not to Codex,
+credential helpers, repository fetch/push, signature verification, or focused
+tests. The resulting commit is verified against the one-key trust file both
+after creation and immediately before publication.
+
+An existing GitHub SSH signing key can therefore be reused when its private
+half is already available through the operator's agent; only its public half
+and exact fingerprint enter config. Register the public key as a GitHub signing
+key as usual. On macOS, Keychain can remember the private key, but it must also
+be available to the launchd-visible agent (for example via
+`ssh-add --apple-use-keychain`). Do not place a private-key path, private key,
+or a literal agent-socket path in Guardian YAML or a launchd property list.
+Run `guardian doctor` from the same user/session used by the scheduled job; its
+real sign-and-verify probe catches an unavailable agent or key before writes
+are enabled.
+
 Interactive runs may resolve tools from the operator's `PATH`. Before staging a
 LaunchAgent, set `runtime.codex_executable`, `runtime.git_executable`,
 `runtime.github_token_command[0]`, and—only in API-key mode—
@@ -323,10 +372,12 @@ GitHub identity, repository visibility, signing setup, and built-in adapters
 registered in the isolated Guardian process. Target-project adapter
 compatibility is checked later from the exact base checkout during a run.
 For `apply-owned-translations` and `propose-prevention`, set
-`runtime.signing_key` explicitly. The doctor creates an ephemeral local commit
-and proves that exact key can sign and verify with global and system Git config
-disabled—the same isolation boundary used for Guardian commits. A global
-`user.signingkey` is deliberately not accepted.
+`runtime.signing_key` explicitly (and `runtime.signing_public_key` for SSH).
+The doctor creates an ephemeral local commit and proves that exact key can sign
+and verify with global and system Git config disabled—the same isolation
+boundary used for Guardian commits. For SSH it also uses the private one-key
+allowed-signers snapshot and withholds the agent socket from verification. A
+global `user.signingkey` is deliberately not accepted.
 `run` performs one finite poll. `status` shows the last completed feedback run,
 component health, pending feedback revisions, actions, and current UTC daily
 model calls (completed plus active or unknown reservations) without printing raw

--- a/docs/localization-cli.md
+++ b/docs/localization-cli.md
@@ -31,7 +31,7 @@ localize validate --config config.yaml
 localize run --config config.yaml --dry-run
 localize run --config config.yaml
 localize quality-gate --repo-root . --input-folder i18n --config config.yaml --validation-summary logs/translation_validation_summary.json --output-json logs/quality.json --output-markdown logs/quality.md --changed-files i18n/messages_de.properties
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.18
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.19
 localize memory stats --memory-file logs/translation_memory.json
 ```
 
@@ -119,7 +119,7 @@ Placeholder detection defaults to `standard`. Set
 Use `bootstrap-pr` when onboarding another repository:
 
 ```bash
-localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.18
+localize bootstrap-pr --target-project-root path/to/repo --action-ref v0.1.19
 ```
 
 The command refuses dirty worktrees, creates `localize/onboarding`, writes
@@ -141,7 +141,7 @@ For custom adapters:
 ```bash
 localize bootstrap-pr \
   --target-project-root path/to/repo \
-  --action-ref v0.1.18 \
+  --action-ref v0.1.19 \
   --plugin-module my_project.localize_adapter \
   --plugin-install-command "python -m pip install ."
 ```

--- a/examples/guardian.config.yaml
+++ b/examples/guardian.config.yaml
@@ -13,8 +13,8 @@ schedule:
 
 # The scheduled assessment defaults are explicit here so model use and effort
 # remain an operator decision. Before enabling either write mode, configure an
-# exact GPG key ID; global Git user.signingkey is not visible inside Guardian's
-# isolated commit workspace.
+# exact signing identity; global Git user.signingkey is not visible inside
+# Guardian's isolated commit workspace. OpenPGP remains the default.
 runtime:
   codex_model: gpt-5.6-terra
   codex_reasoning_effort: high
@@ -32,7 +32,14 @@ runtime:
   # API billing is explicit opt-in. Change codex_auth_mode to api-key, set this
   # helper, and uncomment both USD limits below.
   # codex_api_key_command: [/absolute/path/to/model-key-helper]
+  # signing_format: openpgp
+  # signing_program: /absolute/path/to/gpg
   # signing_key: REPLACE_WITH_FULL_GPG_FINGERPRINT
+  # Agent-backed SSH alternative (all fields are required together):
+  # signing_format: ssh
+  # signing_program: /usr/bin/ssh-keygen
+  # signing_key: SHA256:REPLACE_WITH_EXACT_PUBLIC_KEY_FINGERPRINT
+  # signing_public_key: /absolute/path/to/guardian-signing-key.pub
 
 limits:
   run_timeout_seconds: 1800

--- a/localize/__init__.py
+++ b/localize/__init__.py
@@ -1,3 +1,3 @@
 """Public package for the reusable localization pipeline."""
 
-__version__ = "0.1.18"
+__version__ = "0.1.19"

--- a/localize/bootstrap_pr.py
+++ b/localize/bootstrap_pr.py
@@ -30,7 +30,7 @@ class BootstrapPrOptions:
     workflow_path: str = ".github/workflows/translate.yml"
     branch_name: str = "localize/onboarding"
     base_branch: Optional[str] = None
-    action_ref: str = "v0.1.18"
+    action_ref: str = "v0.1.19"
     commit_message: str = "Add Localize Pipeline onboarding"
     pr_title: str = "Add Localize Pipeline onboarding"
     overwrite: bool = False

--- a/localize/cli.py
+++ b/localize/cli.py
@@ -594,7 +594,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--branch", default="localize/onboarding", help="Onboarding branch name.")
     bootstrap_parser.add_argument("--base-branch", default=None, help="Optional base branch to check out first.")
-    bootstrap_parser.add_argument("--action-ref", default="v0.1.18", help="Action ref to use in the generated workflow.")
+    bootstrap_parser.add_argument("--action-ref", default="v0.1.19", help="Action ref to use in the generated workflow.")
     bootstrap_parser.add_argument(
         "--onboarding-guide-file",
         default="docs/localize-pipeline.md",

--- a/localize/guardian/__init__.py
+++ b/localize/guardian/__init__.py
@@ -18,6 +18,7 @@ from localize.guardian.models import (
     ProposedReplacement,
     RecurrenceCandidate,
     RepositoryPolicy,
+    SigningFormat,
     TrustedActor,
 )
 
@@ -40,5 +41,6 @@ __all__ = [
     "ProposedReplacement",
     "RecurrenceCandidate",
     "RepositoryPolicy",
+    "SigningFormat",
     "TrustedActor",
 ]

--- a/localize/guardian/cli.py
+++ b/localize/guardian/cli.py
@@ -50,6 +50,7 @@ from localize.guardian.models import (
     GuardianMode,
     PipelineConfigSource,
     RepositoryPolicy,
+    SigningFormat,
 )
 from localize.guardian.prevention_runtime import (
     SandboxedTestRunner,
@@ -79,7 +80,15 @@ from localize.guardian.scheduler import (
     render_launchd_plist,
     render_launchd_runner,
 )
-from localize.guardian.signing import canonical_signing_key, signature_matches
+from localize.guardian.signing import (
+    SigningError,
+    canonical_signing_key,
+    canonical_ssh_fingerprint,
+    snapshot_ssh_signing_material,
+    ssh_agent_environment,
+    ssh_signature_matches,
+    signature_matches,
+)
 
 
 _STARTER_CONFIG = """# Generic, report-only Localize Guardian policy.
@@ -103,6 +112,9 @@ runtime:
   # executable names with absolute paths so launchd cannot resolve another binary.
   codex_executable: codex
   git_executable: git
+  # OpenPGP remains the backward-compatible default. For agent-backed SSH,
+  # replace these signing fields as documented in docs/guardian.md.
+  signing_format: openpgp
   signing_program: gpg
   github_token_command: [gh, auth, token]
   # API billing is opt-in: switch codex_auth_mode to api-key, configure this
@@ -110,6 +122,11 @@ runtime:
   # codex_api_key_command: [/usr/bin/security, find-generic-password, -w, -s, localize-guardian]
   # Required for write modes; global Git configuration is intentionally ignored.
   # signing_key: REPLACE_WITH_FULL_GPG_FINGERPRINT
+  # SSH alternative (all four fields are required together):
+  # signing_format: ssh
+  # signing_program: /usr/bin/ssh-keygen
+  # signing_key: SHA256:REPLACE_WITH_EXACT_PUBLIC_KEY_FINGERPRINT
+  # signing_public_key: /absolute/path/to/guardian-signing-key.pub
 
 limits:
   run_timeout_seconds: 1800
@@ -482,8 +499,22 @@ def _signing_key_configured(
     *,
     git_executable: str,
     signing_program: str,
+    signing_format: SigningFormat = SigningFormat.OPENPGP,
+    signing_public_key: str | None = None,
+    temporary_root: Path | None = None,
 ) -> bool:
     """Prove the exact configured key can sign in Guardian's isolated context."""
+
+    if signing_format is SigningFormat.SSH:
+        return _ssh_signing_key_configured(
+            configured_key,
+            signing_public_key=signing_public_key,
+            git_executable=git_executable,
+            signing_program=signing_program,
+            temporary_root=temporary_root,
+        )
+    if signing_format is not SigningFormat.OPENPGP or signing_public_key is not None:
+        return False
 
     try:
         configured_key = canonical_signing_key(configured_key)  # type: ignore[arg-type]
@@ -583,6 +614,143 @@ def _signing_key_configured(
     except (OSError, subprocess.SubprocessError, ProcessResourceError):
         return False
     return True
+
+
+def _ssh_signing_key_configured(
+    configured_key: str | None,
+    *,
+    signing_public_key: str | None,
+    git_executable: str,
+    signing_program: str,
+    temporary_root: Path | None,
+) -> bool:
+    """Actually sign and verify with one exact agent-backed SSH public key."""
+
+    try:
+        fingerprint = canonical_ssh_fingerprint(configured_key)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return False
+    if signing_public_key is None:
+        return False
+    if not _command_available((git_executable,)) or not _command_available(
+        (signing_program,)
+    ):
+        return False
+    try:
+        require_absolute_trusted_executable(
+            (signing_program,),
+            field="runtime.signing_program",
+        )
+        parent = None if temporary_root is None else str(temporary_root)
+        with tempfile.TemporaryDirectory(
+            prefix="localize-guardian-ssh-probe-",
+            dir=parent,
+        ) as raw:
+            root = Path(raw).resolve(strict=True)
+            root.chmod(0o700)
+            isolated_home = root / "home"
+            repository = root / "repository"
+            isolated_home.mkdir(mode=0o700)
+            with snapshot_ssh_signing_material(
+                public_key_path=signing_public_key,
+                expected_fingerprint=fingerprint,
+                signing_program=signing_program,
+                temporary_root=root,
+            ) as material:
+                signing_socket = ssh_agent_environment(
+                    temporary_root=material.root,
+                )
+                environment = {
+                    "GIT_CONFIG_GLOBAL": os.devnull,
+                    "GIT_CONFIG_NOSYSTEM": "1",
+                    "GIT_TERMINAL_PROMPT": "0",
+                    "HOME": str(isolated_home),
+                    "LC_ALL": "C",
+                    "PATH": os.defpath,
+                }
+                git_prefix = [
+                    git_executable,
+                    "-c",
+                    "gpg.format=ssh",
+                    "-c",
+                    f"gpg.ssh.program={signing_program}",
+                    "-c",
+                    f"gpg.ssh.allowedSignersFile={material.allowed_signers}",
+                    "-c",
+                    "gpg.minTrustLevel=fully",
+                ]
+                commands = (
+                    (
+                        [*git_prefix, "init", "--quiet", str(repository)],
+                        environment,
+                    ),
+                    (
+                        [
+                            *git_prefix,
+                            "-C",
+                            str(repository),
+                            "-c",
+                            "user.name=Localize Guardian",
+                            "-c",
+                            "user.email=localize-guardian@users.noreply.github.com",
+                            "commit",
+                            "--allow-empty",
+                            "--no-verify",
+                            f"-S{material.public_key}",
+                            "--message=Localize Guardian signing probe",
+                        ],
+                        {**environment, **signing_socket},
+                    ),
+                    (
+                        [
+                            *git_prefix,
+                            "-C",
+                            str(repository),
+                            "verify-commit",
+                            "--raw",
+                            "HEAD",
+                        ],
+                        environment,
+                    ),
+                )
+                process_limits = ProcessLimits.for_timeout(
+                    20,
+                    max_file_size_bytes=8 * 1024 * 1024,
+                )
+                workspace_quota = WorkspaceQuota.capture(
+                    root,
+                    max_growth_bytes=16 * 1024 * 1024,
+                    max_added_entries=1_000,
+                )
+                verification_output = ""
+                for command, command_environment in commands:
+                    completed = run_bounded_process(
+                        command,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        shell=False,
+                        timeout=20,
+                        env=command_environment,
+                        start_new_session=True,
+                        limits=process_limits,
+                        workspace_quota=workspace_quota,
+                    )
+                    if completed.returncode != 0:
+                        return False
+                    verification_output = "\n".join(
+                        (completed.stdout or "", completed.stderr or "")
+                    )
+                return ssh_signature_matches(verification_output, fingerprint)
+    except (
+        ExecutableTrustError,
+        OSError,
+        SigningError,
+        ValueError,
+        subprocess.SubprocessError,
+        ProcessResourceError,
+    ):
+        return False
 
 
 def _command_available(command: Sequence[str]) -> bool:
@@ -978,6 +1146,37 @@ def _state_directory_doctor(config_path: Path) -> tuple[str, bool]:
     return "ok", True
 
 
+def _existing_safe_probe_parent(path: Path) -> Path | None:
+    """Return an existing trusted parent without creating or changing it."""
+
+    trusted_owners = {0}
+    if hasattr(os, "getuid"):
+        trusted_owners.add(os.getuid())
+    try:
+        metadata = path.lstat()
+        if (
+            not path.is_absolute()
+            or stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISDIR(metadata.st_mode)
+            or not _owned_by_current_user(metadata)
+            or not is_trusted_directory(
+                metadata,
+                trusted_owners=trusted_owners,
+            )
+        ):
+            return None
+        for ancestor in path.parents:
+            ancestor_metadata = ancestor.lstat()
+            if stat.S_ISLNK(ancestor_metadata.st_mode) or not is_trusted_directory(
+                ancestor_metadata,
+                trusted_owners=trusted_owners,
+            ):
+                return None
+    except OSError:
+        return None
+    return path
+
+
 def _operator_pipeline_config_doctor(
     config: GuardianConfig,
     *,
@@ -1152,12 +1351,21 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
         healthy = False
 
     configured_signing_key = config.runtime.signing_key
+    state_directory = guardian_state_dir(config_path)
+    signing_probe_root = (
+        state_directory
+        if state_ok and state_directory.is_dir() and not state_directory.is_symlink()
+        else _existing_safe_probe_parent(config_path.parent)
+    )
     if not write_mode:
         print(f"commit signing: not required ({config.mode.value} mode)")
     elif git_ready and signing_program_ready and _signing_key_configured(
         configured_signing_key,
         git_executable=config.runtime.git_executable,
         signing_program=config.runtime.signing_program,
+        signing_format=config.runtime.signing_format,
+        signing_public_key=config.runtime.signing_public_key,
+        temporary_root=signing_probe_root,
     ):
         print(
             "commit signing: exact key signed and verified in isolation "

--- a/localize/guardian/config.py
+++ b/localize/guardian/config.py
@@ -22,9 +22,13 @@ from localize.guardian.models import (
     PipelineConfigSource,
     PreventionPolicy,
     RepositoryPolicy,
+    SigningFormat,
     TrustedActor,
 )
-from localize.guardian.signing import canonical_signing_key
+from localize.guardian.signing import (
+    canonical_signing_key,
+    canonical_ssh_fingerprint,
+)
 
 
 class GuardianConfigError(ValueError):
@@ -146,6 +150,9 @@ _CONFIG_SCHEMA: dict[str, Any] = {
                 "codex_executable": _NON_EMPTY_STRING,
                 "git_executable": _NON_EMPTY_STRING,
                 "signing_program": _NON_EMPTY_STRING,
+                "signing_format": {
+                    "enum": [signing_format.value for signing_format in SigningFormat]
+                },
                 "github_token_command": {
                     "type": "array",
                     "minItems": 1,
@@ -159,6 +166,7 @@ _CONFIG_SCHEMA: dict[str, Any] = {
                     "items": _NON_EMPTY_STRING,
                 },
                 "signing_key": _NON_EMPTY_STRING,
+                "signing_public_key": _NON_EMPTY_STRING,
             },
         },
         "limits": {
@@ -809,12 +817,16 @@ def parse_guardian_config(raw_config: Mapping[str, Any]) -> GuardianConfig:
     auth_mode = CodexAuthMode(
         raw_runtime.get("codex_auth_mode", runtime_defaults.codex_auth_mode.value)
     )
+    signing_format = SigningFormat(
+        raw_runtime.get("signing_format", runtime_defaults.signing_format.value)
+    )
     for field in (
         "codex_model",
         "codex_executable",
         "git_executable",
         "signing_program",
         "signing_key",
+        "signing_public_key",
     ):
         value = raw_runtime.get(field)
         if value is not None:
@@ -824,9 +836,50 @@ def parse_guardian_config(raw_config: Mapping[str, Any]) -> GuardianConfig:
     raw_signing_key = raw_runtime.get("signing_key")
     if raw_signing_key is not None:
         try:
-            raw_signing_key = canonical_signing_key(raw_signing_key)
+            if signing_format is SigningFormat.SSH:
+                raw_signing_key = canonical_ssh_fingerprint(raw_signing_key)
+            else:
+                raw_signing_key = canonical_signing_key(raw_signing_key)
         except ValueError as exc:
             raise GuardianConfigError(f"runtime.signing_key {exc}") from None
+    raw_signing_public_key = raw_runtime.get("signing_public_key")
+    if signing_format is SigningFormat.SSH:
+        if raw_signing_key is None:
+            raise GuardianConfigError(
+                "runtime.signing_key is required with runtime.signing_format: ssh."
+            )
+        if raw_signing_public_key is None:
+            raise GuardianConfigError(
+                "runtime.signing_public_key is required with "
+                "runtime.signing_format: ssh."
+            )
+        public_key_path = PurePosixPath(raw_signing_public_key)
+        if (
+            not public_key_path.is_absolute()
+            or ".." in public_key_path.parts
+            or any(character in raw_signing_public_key for character in "*?[]\\")
+        ):
+            raise GuardianConfigError(
+                "runtime.signing_public_key must be an absolute POSIX file path."
+            )
+        if "signing_program" not in raw_runtime:
+            raise GuardianConfigError(
+                "runtime.signing_program is required with runtime.signing_format: ssh."
+            )
+        signing_program_path = PurePosixPath(raw_runtime["signing_program"])
+        if (
+            not signing_program_path.is_absolute()
+            or ".." in signing_program_path.parts
+        ):
+            raise GuardianConfigError(
+                "runtime.signing_program must be an absolute POSIX executable path "
+                "with runtime.signing_format: ssh."
+            )
+    elif raw_signing_public_key is not None:
+        raise GuardianConfigError(
+            "runtime.signing_public_key is only valid with "
+            "runtime.signing_format: ssh."
+        )
     codex_api_key_command = _runtime_command(
         raw_runtime,
         "codex_api_key_command",
@@ -875,6 +928,8 @@ def parse_guardian_config(raw_config: Mapping[str, Any]) -> GuardianConfig:
         ),
         codex_api_key_command=codex_api_key_command,
         signing_key=raw_signing_key,
+        signing_format=signing_format,
+        signing_public_key=raw_signing_public_key,
     )
 
     raw_limits = raw_config.get("limits", {})

--- a/localize/guardian/models.py
+++ b/localize/guardian/models.py
@@ -33,6 +33,13 @@ class PipelineConfigSource(str, Enum):
     OPERATOR = "operator"
 
 
+class SigningFormat(str, Enum):
+    """Commit-signature format used by the trusted publication broker."""
+
+    OPENPGP = "openpgp"
+    SSH = "ssh"
+
+
 _REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
@@ -92,6 +99,8 @@ class GuardianRuntime:
     github_token_command: tuple[str, ...] = ("gh", "auth", "token")
     codex_api_key_command: tuple[str, ...] = ()
     signing_key: str | None = None
+    signing_format: SigningFormat = SigningFormat.OPENPGP
+    signing_public_key: str | None = None
 
 
 @dataclass(frozen=True)

--- a/localize/guardian/runtime.py
+++ b/localize/guardian/runtime.py
@@ -63,6 +63,7 @@ from localize.guardian.models import (
     PipelineConfigSource,
     PreventionPolicy,
     RepositoryPolicy,
+    SigningFormat,
 )
 from localize.guardian.prevention_runtime import (
     PreventionCodexAuthor,
@@ -71,7 +72,13 @@ from localize.guardian.prevention_runtime import (
     SandboxedTestRunner,
 )
 from localize.guardian.scheduler import is_run_due
-from localize.guardian.signing import canonical_signing_key
+from localize.guardian.signing import (
+    SSHSigningMaterial,
+    SigningError,
+    canonical_signing_key,
+    canonical_ssh_fingerprint,
+    snapshot_ssh_signing_material,
+)
 from localize.guardian.state import GuardianState, _validate_sqlite_state_artifacts
 from localize.guardian.workspace import ExactRevision, materialize_exact_checkout
 
@@ -790,6 +797,19 @@ def _validate_scheduled_executables(config: GuardianConfig) -> None:
 def _validate_runtime_authority(config: GuardianConfig, *, scheduled: bool) -> None:
     if config.runtime.codex_auth_mode is CodexAuthMode.CHATGPT:
         _validate_subscription_codex_home(config)
+    if (
+        config.mode in _WRITE_MODES
+        and config.runtime.signing_format is SigningFormat.SSH
+    ):
+        try:
+            require_absolute_trusted_executable(
+                (config.runtime.signing_program,),
+                field="runtime.signing_program",
+            )
+        except ExecutableTrustError:
+            raise GuardianRuntimeError(
+                "Guardian SSH signing authority is unavailable or unsafe."
+            ) from None
     if scheduled:
         _validate_scheduled_executables(config)
 
@@ -866,10 +886,46 @@ def _require_explicit_write_signing_key(config: GuardianConfig) -> None:
     if config.mode not in _WRITE_MODES:
         return
     try:
-        canonical_signing_key(key)  # type: ignore[arg-type]
+        if config.runtime.signing_format is SigningFormat.SSH:
+            canonical_ssh_fingerprint(key)  # type: ignore[arg-type]
+            public_key = config.runtime.signing_public_key
+            if public_key is None or not Path(public_key).is_absolute():
+                raise ValueError
+        else:
+            canonical_signing_key(key)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         raise GuardianRuntimeError(
-            "Guardian write modes require an explicit full signing key fingerprint."
+            "Guardian write modes require an explicit exact signing key fingerprint."
+        ) from None
+
+
+@contextmanager
+def _snapshot_poll_signing_material(
+    *,
+    config: GuardianConfig,
+    state_directory: Path,
+) -> Iterator[SSHSigningMaterial | None]:
+    """Freeze an SSH public identity before any external write-mode work."""
+
+    if (
+        config.mode not in _WRITE_MODES
+        or config.runtime.signing_format is not SigningFormat.SSH
+    ):
+        yield None
+        return
+    try:
+        assert config.runtime.signing_public_key is not None
+        assert config.runtime.signing_key is not None
+        with snapshot_ssh_signing_material(
+            public_key_path=config.runtime.signing_public_key,
+            expected_fingerprint=config.runtime.signing_key,
+            signing_program=config.runtime.signing_program,
+            temporary_root=state_directory,
+        ) as material:
+            yield material
+    except SigningError:
+        raise GuardianRuntimeError(
+            "Guardian SSH signing identity is unavailable or unsafe."
         ) from None
 
 
@@ -881,6 +937,7 @@ def _build_controller(
     github_credential: SecretCommand,
     model_credential: SecretCommand | None,
     git_environment: Any,
+    ssh_signing_material: SSHSigningMaterial | None = None,
     operator_pipeline_configs: Mapping[str, PipelineConfigSnapshot] | None = None,
 ) -> GuardianController:
     """Assemble trusted production adapters without invoking a credential yet."""
@@ -903,13 +960,25 @@ def _build_controller(
     )
 
     def checkout_factory(revision: ExactRevision):
-        return materialize_exact_checkout(
-            revision,
-            credential_environment=git_environment,
-            git_binary=config.runtime.git_executable,
-            signing_program=config.runtime.signing_program,
-            timeout_seconds=attempt_timeout,
-        )
+        checkout_kwargs: dict[str, Any] = {
+            "credential_environment": git_environment,
+            "git_binary": config.runtime.git_executable,
+            "signing_program": config.runtime.signing_program,
+            "timeout_seconds": attempt_timeout,
+        }
+        if config.runtime.signing_format is SigningFormat.SSH:
+            if ssh_signing_material is None:
+                if config.mode in _WRITE_MODES:
+                    raise GuardianRuntimeError(
+                        "Guardian SSH signing identity is unavailable or unsafe."
+                    )
+                checkout_kwargs["signing_program"] = None
+            else:
+                checkout_kwargs.update(
+                    signing_format=SigningFormat.SSH,
+                    ssh_signing_material=ssh_signing_material,
+                )
+        return materialize_exact_checkout(revision, **checkout_kwargs)
 
     def model_credential_provider() -> str | None:
         if config.runtime.codex_auth_mode is CodexAuthMode.CHATGPT:
@@ -1121,7 +1190,10 @@ def _poll_with_locked_state(
                 if config.runtime.codex_auth_mode is CodexAuthMode.API_KEY
                 else None
             )
-            with _snapshot_operator_pipeline_configs(
+            with _snapshot_poll_signing_material(
+                config=config,
+                state_directory=state_directory,
+            ) as ssh_signing_material, _snapshot_operator_pipeline_configs(
                 config=config,
                 guardian_config_path=resolved_config,
                 state_directory=state_directory,
@@ -1148,6 +1220,7 @@ def _poll_with_locked_state(
                         github_credential=github_credential,
                         model_credential=model_credential,
                         git_environment=git_environment,
+                        ssh_signing_material=ssh_signing_material,
                         operator_pipeline_configs=operator_pipeline_configs,
                     )
                     try:

--- a/localize/guardian/signing.py
+++ b/localize/guardian/signing.py
@@ -1,12 +1,69 @@
-"""Exact OpenPGP fingerprint and Git verification helpers."""
+"""Exact OpenPGP and SSH signer identity helpers."""
 
 from __future__ import annotations
 
+import base64
+import binascii
+from collections.abc import Collection, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+import os
+from pathlib import Path
 import re
+import stat
+import tempfile
+
+from localize.guardian.filesystem_trust import is_trusted_directory
+from localize.guardian.executable_trust import (
+    ExecutableTrustError,
+    require_absolute_trusted_executable,
+)
+from localize.guardian.process import ProcessLimits, run_bounded_process
 
 
 _FINGERPRINT_RE = re.compile(r"^(?:[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64})!?$")
 _VALIDSIG_RE = re.compile(r"^\[GNUPG:\] VALIDSIG (.+)$", re.MULTILINE)
+_SSH_FINGERPRINT_RE = re.compile(r"^SHA256:[A-Za-z0-9+/]{43}$")
+_SSH_KEY_LINE_RE = re.compile(
+    r"^(?P<type>[A-Za-z0-9@._+-]+) (?P<blob>[A-Za-z0-9+/]+={0,2})"
+    r"(?: [^\r\n\x00]*)?$"
+)
+_SSH_KEYGEN_OUTPUT_RE = re.compile(
+    r"^(?P<bits>[1-9][0-9]*) (?P<fingerprint>SHA256:[A-Za-z0-9+/]{43}) "
+    r".* \([^()]+\)$"
+)
+_SSH_GOOD_SIGNATURE_RE = re.compile(
+    r'^Good "git" signature for localize-guardian with [A-Za-z0-9@._+-]+ key '
+    r"(?P<fingerprint>SHA256:[A-Za-z0-9+/]{43})$",
+    re.MULTILINE,
+)
+_ALLOWED_SSH_KEY_TYPES = frozenset(
+    {
+        "ecdsa-sha2-nistp256",
+        "ecdsa-sha2-nistp384",
+        "ecdsa-sha2-nistp521",
+        "sk-ecdsa-sha2-nistp256@openssh.com",
+        "sk-ssh-ed25519@openssh.com",
+        "ssh-ed25519",
+        "ssh-rsa",
+    }
+)
+_MAX_PUBLIC_KEY_BYTES = 16 * 1024
+_SSH_SIGNING_PRINCIPAL = "localize-guardian"
+
+
+class SigningError(RuntimeError):
+    """Configured signing material is unavailable, ambiguous, or unsafe."""
+
+
+@dataclass(frozen=True, slots=True)
+class SSHSigningMaterial:
+    """Private per-run snapshot used to select and verify one SSH signer."""
+
+    root: Path
+    public_key: Path
+    allowed_signers: Path
+    fingerprint: str
 
 
 def canonical_signing_key(value: str) -> str:
@@ -20,6 +77,30 @@ def canonical_signing_key(value: str) -> str:
     exact = value.endswith("!")
     fingerprint = value[:-1] if exact else value
     return fingerprint.upper() + ("!" if exact else "")
+
+
+def canonical_ssh_fingerprint(value: str) -> str:
+    """Return one exact OpenSSH SHA-256 public-key fingerprint."""
+
+    if not isinstance(value, str) or not _SSH_FINGERPRINT_RE.fullmatch(value):
+        raise ValueError(
+            "signing key must be an exact SHA256 OpenSSH public-key fingerprint"
+        )
+    encoded = value.removeprefix("SHA256:")
+    try:
+        decoded = base64.b64decode(encoded + "=", validate=True)
+    except (binascii.Error, ValueError):
+        raise ValueError(
+            "signing key must be an exact SHA256 OpenSSH public-key fingerprint"
+        ) from None
+    if (
+        len(decoded) != 32
+        or base64.b64encode(decoded).decode("ascii").rstrip("=") != encoded
+    ):
+        raise ValueError(
+            "signing key must be an exact SHA256 OpenSSH public-key fingerprint"
+        )
+    return value
 
 
 def verified_fingerprints(status_output: str) -> frozenset[str]:
@@ -36,3 +117,468 @@ def verified_fingerprints(status_output: str) -> frozenset[str]:
 def signature_matches(status_output: str, signing_key: str) -> bool:
     expected = canonical_signing_key(signing_key).removesuffix("!")
     return expected in verified_fingerprints(status_output)
+
+
+def ssh_signature_matches(status_output: str, signing_key: str) -> bool:
+    """Require one successful Git SSH signature from the exact configured key."""
+
+    expected = canonical_ssh_fingerprint(signing_key)
+    fingerprints = [
+        match.group("fingerprint")
+        for match in _SSH_GOOD_SIGNATURE_RE.finditer(status_output)
+    ]
+    return fingerprints == [expected]
+
+
+def _current_group_ids() -> frozenset[int]:
+    groups: set[int] = set()
+    for getter_name in ("getgid", "getegid"):
+        getter = getattr(os, getter_name, None)
+        if callable(getter):
+            groups.add(getter())
+    getgroups = getattr(os, "getgroups", None)
+    if callable(getgroups):
+        groups.update(getgroups())
+    return frozenset(groups)
+
+
+def _has_effective_write_access(path: Path) -> bool:
+    try:
+        if os.access in os.supports_effective_ids:
+            return os.access(path, os.W_OK, effective_ids=True)
+        return os.access(path, os.W_OK)
+    except (NotImplementedError, OSError, TypeError):
+        return True
+
+
+def _is_trusted_socket_ancestor(
+    metadata: os.stat_result,
+    *,
+    current_groups: Collection[int] | None = None,
+    effectively_writable: bool = False,
+) -> bool:
+    """Accept ordinary safe ancestors plus privileged root-group boundaries."""
+
+    if is_trusted_directory(metadata, trusted_owners=_trusted_owners()):
+        return True
+    mode = stat.S_IMODE(metadata.st_mode)
+    groups = _current_group_ids() if current_groups is None else frozenset(current_groups)
+    return (
+        stat.S_ISDIR(metadata.st_mode)
+        and metadata.st_uid == 0
+        and not mode & 0o002
+        and metadata.st_gid not in groups
+        and not effectively_writable
+    )
+
+
+def _private_agent_socket_proxy(
+    source: Path,
+    source_metadata: os.stat_result,
+    temporary_root: str | Path | None,
+) -> Path:
+    if temporary_root is None:
+        raise ValueError("SSH_AUTH_SOCK requires a private signing snapshot")
+    root = Path(temporary_root)
+    try:
+        root_metadata = root.lstat()
+        _require_trusted_ancestors(root)
+    except (OSError, SigningError):
+        raise ValueError("SSH_AUTH_SOCK requires a private signing snapshot") from None
+    if (
+        not root.is_absolute()
+        or stat.S_ISLNK(root_metadata.st_mode)
+        or not stat.S_ISDIR(root_metadata.st_mode)
+        or root_metadata.st_uid not in _trusted_owners()
+        or stat.S_IMODE(root_metadata.st_mode) != 0o700
+    ):
+        raise ValueError("SSH_AUTH_SOCK requires a private signing snapshot")
+
+    proxy = root / "agent.sock"
+    created = False
+    try:
+        try:
+            proxy_metadata = proxy.lstat()
+        except FileNotFoundError:
+            if source_metadata.st_nlink != 1:
+                raise OSError
+            os.link(source, proxy, follow_symlinks=False)
+            created = True
+            proxy_metadata = proxy.lstat()
+        source_after = source.lstat()
+        root_after = root.lstat()
+        if (
+            stat.S_ISLNK(proxy_metadata.st_mode)
+            or not stat.S_ISSOCK(proxy_metadata.st_mode)
+            or proxy_metadata.st_uid not in _trusted_owners()
+            or proxy_metadata.st_nlink != 2
+            or source_after.st_nlink != 2
+            or (proxy_metadata.st_dev, proxy_metadata.st_ino)
+            != (source_metadata.st_dev, source_metadata.st_ino)
+            or (source_after.st_dev, source_after.st_ino)
+            != (source_metadata.st_dev, source_metadata.st_ino)
+            or (root_after.st_dev, root_after.st_ino, root_after.st_mode, root_after.st_uid)
+            != (
+                root_metadata.st_dev,
+                root_metadata.st_ino,
+                root_metadata.st_mode,
+                root_metadata.st_uid,
+            )
+        ):
+            raise OSError
+    except OSError:
+        if created:
+            try:
+                proxy.unlink()
+            except OSError:
+                pass
+        raise ValueError("SSH_AUTH_SOCK could not be snapshotted safely") from None
+    return proxy
+
+
+def ssh_agent_environment(
+    values: Mapping[str, str] | None = None,
+    *,
+    temporary_root: str | Path | None = None,
+) -> dict[str, str]:
+    """Return one validated agent socket suitable only for signing a commit."""
+
+    if values is None:
+        raw_socket = os.environ.get("SSH_AUTH_SOCK")
+        normalized = {} if raw_socket is None else {"SSH_AUTH_SOCK": raw_socket}
+    elif not isinstance(values, Mapping) or any(
+        key != "SSH_AUTH_SOCK" or not isinstance(value, str)
+        for key, value in values.items()
+    ):
+        raise ValueError("signing environment may only set SSH_AUTH_SOCK")
+    else:
+        normalized = dict(values)
+    raw_socket = normalized.get("SSH_AUTH_SOCK")
+    if raw_socket is None:
+        raise ValueError("SSH_AUTH_SOCK is required for SSH commit signing")
+    socket_path = Path(raw_socket)
+    if (
+        not raw_socket
+        or any(character in raw_socket for character in "\r\n\x00")
+        or not socket_path.is_absolute()
+        or ".." in socket_path.parts
+    ):
+        raise ValueError("SSH_AUTH_SOCK must be an absolute Unix socket path")
+    try:
+        source_metadata = socket_path.lstat()
+        resolved_socket = socket_path.resolve(strict=True)
+        metadata = resolved_socket.lstat()
+        parent_metadata = resolved_socket.parent.lstat()
+    except (OSError, RuntimeError):
+        raise ValueError("SSH_AUTH_SOCK must identify an available Unix socket") from None
+    if (
+        stat.S_ISLNK(source_metadata.st_mode)
+        or not stat.S_ISSOCK(metadata.st_mode)
+        or source_metadata.st_dev != metadata.st_dev
+        or source_metadata.st_ino != metadata.st_ino
+        or metadata.st_uid not in _trusted_owners()
+        or metadata.st_nlink not in {1, 2}
+        or not is_trusted_directory(
+            parent_metadata,
+            trusted_owners=_trusted_owners(),
+        )
+        # macOS launchd sockets may be mode 0666. A non-searchable parent is
+        # the portable security boundary because BSDs need not enforce socket
+        # file modes consistently.
+        or bool(stat.S_IMODE(parent_metadata.st_mode) & 0o077)
+    ):
+        raise ValueError("SSH_AUTH_SOCK must identify a private Unix socket")
+    requires_proxy = False
+    for ancestor in resolved_socket.parent.parents:
+        try:
+            ancestor_metadata = ancestor.lstat()
+        except OSError:
+            raise ValueError("SSH_AUTH_SOCK must identify a private Unix socket") from None
+        ordinary_trust = is_trusted_directory(
+            ancestor_metadata,
+            trusted_owners=_trusted_owners(),
+        )
+        if stat.S_ISLNK(ancestor_metadata.st_mode) or not _is_trusted_socket_ancestor(
+            ancestor_metadata,
+            effectively_writable=_has_effective_write_access(ancestor),
+        ):
+            raise ValueError("SSH_AUTH_SOCK must identify a private Unix socket")
+        requires_proxy = requires_proxy or not ordinary_trust
+    if requires_proxy:
+        resolved_socket = _private_agent_socket_proxy(
+            resolved_socket,
+            metadata,
+            temporary_root,
+        )
+    elif metadata.st_nlink != 1:
+        raise ValueError("SSH_AUTH_SOCK must identify a private Unix socket")
+    return {"SSH_AUTH_SOCK": str(resolved_socket)}
+
+
+def _trusted_owners() -> frozenset[int]:
+    owners = {0}
+    if hasattr(os, "getuid"):
+        owners.add(os.getuid())
+    return frozenset(owners)
+
+
+def _require_trusted_ancestors(path: Path) -> None:
+    owners = _trusted_owners()
+    for ancestor in reversed(path.parents):
+        try:
+            metadata = ancestor.stat(follow_symlinks=False)
+        except OSError:
+            raise SigningError("SSH public key path is unavailable or unsafe.") from None
+        if ancestor.is_symlink() or not is_trusted_directory(
+            metadata,
+            trusted_owners=owners,
+        ):
+            raise SigningError("SSH public key path is unavailable or unsafe.")
+
+
+def _read_trusted_public_key(path: Path) -> bytes:
+    if not path.is_absolute():
+        raise SigningError("SSH public key path is unavailable or unsafe.")
+    _require_trusted_ancestors(path)
+    try:
+        leaf = path.lstat()
+    except OSError:
+        raise SigningError("SSH public key path is unavailable or unsafe.") from None
+    if (
+        stat.S_ISLNK(leaf.st_mode)
+        or not stat.S_ISREG(leaf.st_mode)
+        or leaf.st_uid not in _trusted_owners()
+        or stat.S_IMODE(leaf.st_mode) & 0o022
+        or leaf.st_nlink != 1
+        or leaf.st_size <= 0
+        or leaf.st_size > _MAX_PUBLIC_KEY_BYTES
+    ):
+        raise SigningError("SSH public key path is unavailable or unsafe.")
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        raise SigningError("SSH public key path is unavailable or unsafe.") from None
+    try:
+        before = os.fstat(descriptor)
+        if (
+            before.st_dev != leaf.st_dev
+            or before.st_ino != leaf.st_ino
+            or before.st_mode != leaf.st_mode
+            or before.st_uid != leaf.st_uid
+            or before.st_nlink != 1
+            or before.st_size != leaf.st_size
+            or before.st_mtime_ns != leaf.st_mtime_ns
+            or before.st_ctime_ns != leaf.st_ctime_ns
+        ):
+            raise SigningError("SSH public key path is unavailable or unsafe.")
+        chunks: list[bytes] = []
+        remaining = _MAX_PUBLIC_KEY_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, min(4096, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        content = b"".join(chunks)
+        after = os.fstat(descriptor)
+        if (
+            len(content) > _MAX_PUBLIC_KEY_BYTES
+            or after.st_dev != before.st_dev
+            or after.st_ino != before.st_ino
+            or after.st_mode != before.st_mode
+            or after.st_uid != before.st_uid
+            or after.st_nlink != before.st_nlink
+            or after.st_size != before.st_size
+            or after.st_mtime_ns != before.st_mtime_ns
+            or after.st_ctime_ns != before.st_ctime_ns
+        ):
+            raise SigningError("SSH public key path is unavailable or unsafe.")
+        return content
+    except SigningError:
+        raise
+    except OSError:
+        raise SigningError("SSH public key path is unavailable or unsafe.") from None
+    finally:
+        os.close(descriptor)
+
+
+def _parse_public_key(content: bytes) -> tuple[str, str]:
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        raise SigningError("SSH public key is malformed or unsupported.") from None
+    if any(ord(character) < 32 and character != "\n" for character in text):
+        raise SigningError("SSH public key is malformed or unsupported.")
+    lines = text.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    if len(lines) != 1:
+        raise SigningError("SSH public key must contain exactly one key.")
+    match = _SSH_KEY_LINE_RE.fullmatch(lines[0])
+    if match is None:
+        raise SigningError("SSH public key is malformed or unsupported.")
+    key_type = match.group("type")
+    blob = match.group("blob")
+    if key_type not in _ALLOWED_SSH_KEY_TYPES:
+        raise SigningError("SSH public key is unsupported or weak.")
+    try:
+        decoded = base64.b64decode(blob, validate=True)
+    except (binascii.Error, ValueError):
+        raise SigningError("SSH public key is malformed or unsupported.") from None
+    if (
+        len(decoded) < 4
+        or base64.b64encode(decoded).decode("ascii") != blob
+    ):
+        raise SigningError("SSH public key is malformed or unsupported.")
+    type_length = int.from_bytes(decoded[:4], "big")
+    embedded_type = decoded[4 : 4 + type_length]
+    if embedded_type != key_type.encode("ascii"):
+        raise SigningError("SSH public key is malformed or unsupported.")
+    return key_type, blob
+
+
+def _write_private_file(path: Path, content: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        view = memoryview(content)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short write")
+            view = view[written:]
+        os.fchmod(descriptor, 0o600)
+    finally:
+        os.close(descriptor)
+
+
+def _inspect_snapshot(
+    *,
+    signing_program: str,
+    public_key: Path,
+    expected_fingerprint: str,
+    key_type: str,
+) -> None:
+    try:
+        completed = run_bounded_process(
+            (
+                signing_program,
+                "-l",
+                "-E",
+                "sha256",
+                "-f",
+                str(public_key),
+            ),
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="strict",
+            env={"LANG": "C", "LC_ALL": "C", "PATH": os.defpath},
+            shell=False,
+            timeout=10,
+            start_new_session=True,
+            limits=ProcessLimits.for_timeout(10, max_file_size_bytes=1024 * 1024),
+        )
+    except Exception:
+        raise SigningError("SSH public key could not be inspected safely.") from None
+    output = completed.stdout.strip()
+    match = _SSH_KEYGEN_OUTPUT_RE.fullmatch(output)
+    if completed.returncode != 0 or match is None or "\n" in output:
+        raise SigningError("SSH public key could not be inspected safely.")
+    if match.group("fingerprint") != expected_fingerprint:
+        raise SigningError("SSH public key fingerprint does not match configuration.")
+    bits = int(match.group("bits"))
+    if key_type == "ssh-rsa" and bits < 3072:
+        raise SigningError("SSH public key uses a weak RSA key.")
+    if key_type != "ssh-rsa" and bits < 256:
+        raise SigningError("SSH public key uses a weak key.")
+
+
+@contextmanager
+def snapshot_ssh_signing_material(
+    *,
+    public_key_path: str | Path,
+    expected_fingerprint: str,
+    signing_program: str,
+    temporary_root: str | Path,
+) -> Iterator[SSHSigningMaterial]:
+    """Yield a private, exact-key SSH signing snapshot and trust file."""
+
+    fingerprint = canonical_ssh_fingerprint(expected_fingerprint)
+    try:
+        require_absolute_trusted_executable(
+            (signing_program,),
+            field="runtime.signing_program",
+        )
+    except ExecutableTrustError:
+        raise SigningError("SSH signing program is unavailable or unsafe.") from None
+    source = Path(public_key_path)
+    content = _read_trusted_public_key(source)
+    key_type, blob = _parse_public_key(content)
+    root = Path(temporary_root)
+    try:
+        root_metadata = root.stat(follow_symlinks=False)
+    except OSError:
+        raise SigningError("SSH signing snapshot root is unavailable or unsafe.") from None
+    if (
+        root.is_symlink()
+        or not stat.S_ISDIR(root_metadata.st_mode)
+        or root_metadata.st_uid not in _trusted_owners()
+        or stat.S_IMODE(root_metadata.st_mode) != 0o700
+    ):
+        raise SigningError("SSH signing snapshot root is unavailable or unsafe.")
+    _require_trusted_ancestors(root)
+
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix="ssh-signing-",
+            dir=root,
+        ) as raw_directory:
+            snapshot_root = Path(raw_directory)
+            snapshot_root.chmod(0o700)
+            public_key = snapshot_root / "signing-key.pub"
+            allowed_signers = snapshot_root / "allowed-signers"
+            canonical_key = f"{key_type} {blob}\n".encode("ascii")
+            _write_private_file(public_key, canonical_key)
+            _inspect_snapshot(
+                signing_program=signing_program,
+                public_key=public_key,
+                expected_fingerprint=fingerprint,
+                key_type=key_type,
+            )
+            _write_private_file(
+                allowed_signers,
+                f"{_SSH_SIGNING_PRINCIPAL} {key_type} {blob}\n".encode("ascii"),
+            )
+            yield SSHSigningMaterial(
+                root=snapshot_root,
+                public_key=public_key,
+                allowed_signers=allowed_signers,
+                fingerprint=fingerprint,
+            )
+    except SigningError:
+        raise
+    except OSError:
+        raise SigningError("SSH signing snapshot could not be created safely.") from None
+
+
+__all__ = [
+    "SSHSigningMaterial",
+    "SigningError",
+    "canonical_signing_key",
+    "canonical_ssh_fingerprint",
+    "ssh_agent_environment",
+    "ssh_signature_matches",
+    "signature_matches",
+    "snapshot_ssh_signing_material",
+    "verified_fingerprints",
+]

--- a/localize/guardian/workspace.py
+++ b/localize/guardian/workspace.py
@@ -18,7 +18,16 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from urllib.parse import urlsplit
 
-from localize.guardian.signing import canonical_signing_key, signature_matches
+from localize.guardian.models import SigningFormat
+from localize.guardian.executable_trust import require_absolute_trusted_executable
+from localize.guardian.signing import (
+    SSHSigningMaterial,
+    canonical_signing_key,
+    canonical_ssh_fingerprint,
+    ssh_agent_environment,
+    ssh_signature_matches,
+    signature_matches,
+)
 from localize.guardian.process import ProcessLimits, run_bounded_process
 
 
@@ -43,7 +52,7 @@ _PROTECTED_ENVIRONMENT_KEYS = frozenset(
         "PATH",
     }
 )
-_SIGNING_ENVIRONMENT_KEYS = frozenset({"GNUPGHOME"})
+_OPENPGP_SIGNING_ENVIRONMENT_KEYS = frozenset({"GNUPGHOME"})
 _DEFAULT_AUTHOR_NAME = "Localize Guardian"
 _DEFAULT_AUTHOR_EMAIL = "localize-guardian@users.noreply.github.com"
 _COMMIT_SUBJECT = "[localize-guardian] Apply review feedback"
@@ -266,7 +275,43 @@ class _GitRunner:
     process_runner: ProcessRunner = field(repr=False)
     git_binary: str = "git"
     signing_program: str | None = None
+    signing_format: SigningFormat = SigningFormat.OPENPGP
+    ssh_signing_material: SSHSigningMaterial | None = None
     timeout_seconds: float = 120.0
+
+    def _ssh_material(self) -> SSHSigningMaterial:
+        material = self.ssh_signing_material
+        if self.signing_format is not SigningFormat.SSH or material is None:
+            raise WorkspaceError("exact SSH signing material is unavailable")
+        if self.signing_program is None:
+            raise WorkspaceError("SSH signing program is unavailable")
+        try:
+            canonical_ssh_fingerprint(material.fingerprint)
+            root = material.root
+            root_metadata = root.lstat()
+            if (
+                not root.is_absolute()
+                or stat.S_ISLNK(root_metadata.st_mode)
+                or not stat.S_ISDIR(root_metadata.st_mode)
+                or stat.S_IMODE(root_metadata.st_mode) != 0o700
+                or root_metadata.st_uid not in {0, os.getuid()}
+            ):
+                raise OSError
+            for path in (material.public_key, material.allowed_signers):
+                metadata = path.lstat()
+                path.relative_to(root)
+                if (
+                    not path.is_absolute()
+                    or stat.S_ISLNK(metadata.st_mode)
+                    or not stat.S_ISREG(metadata.st_mode)
+                    or stat.S_IMODE(metadata.st_mode) != 0o600
+                    or metadata.st_uid not in {0, os.getuid()}
+                    or metadata.st_nlink != 1
+                ):
+                    raise OSError
+        except (OSError, ValueError):
+            raise WorkspaceError("exact SSH signing material is unavailable") from None
+        return material
 
     def run(
         self,
@@ -276,6 +321,14 @@ class _GitRunner:
         extra_environment: Mapping[str, str] | None = None,
         input_text: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        if "SSH_AUTH_SOCK" in self.environment:
+            raise WorkspaceError("base Git environment must not contain SSH_AUTH_SOCK")
+        if extra_environment and "SSH_AUTH_SOCK" in extra_environment and (
+            self.signing_format is not SigningFormat.SSH
+            or not arguments
+            or arguments[0] != "commit"
+        ):
+            raise WorkspaceError("SSH_AUTH_SOCK is only permitted for SSH git commit")
         environment = dict(self.environment)
         if extra_environment:
             overlap = _PROTECTED_ENVIRONMENT_KEYS.intersection(extra_environment)
@@ -290,7 +343,22 @@ class _GitRunner:
             "credential.helper=",
         ]
         if self.signing_program is not None:
-            command.extend(("-c", f"gpg.program={self.signing_program}"))
+            if self.signing_format is SigningFormat.SSH:
+                material = self._ssh_material()
+                command.extend(
+                    (
+                        "-c",
+                        "gpg.format=ssh",
+                        "-c",
+                        f"gpg.ssh.program={self.signing_program}",
+                        "-c",
+                        f"gpg.ssh.allowedSignersFile={material.allowed_signers}",
+                        "-c",
+                        "gpg.minTrustLevel=fully",
+                    )
+                )
+            else:
+                command.extend(("-c", f"gpg.program={self.signing_program}"))
         command.extend(("-C", str(self.path), *arguments))
         try:
             completed = self.process_runner(
@@ -516,7 +584,7 @@ def _validate_identity_value(value: str, *, label: str) -> str:
     return value
 
 
-def _signing_environment(values: Mapping[str, str] | None) -> dict[str, str]:
+def _openpgp_signing_environment(values: Mapping[str, str] | None) -> dict[str, str]:
     if values is None:
         configured_home = os.environ.get("GNUPGHOME")
         candidate = Path(configured_home) if configured_home else Path.home() / ".gnupg"
@@ -524,7 +592,7 @@ def _signing_environment(values: Mapping[str, str] | None) -> dict[str, str]:
             return {}
         return {"GNUPGHOME": str(candidate.resolve(strict=True))}
     if not isinstance(values, Mapping) or any(
-        key not in _SIGNING_ENVIRONMENT_KEYS or not isinstance(value, str)
+        key not in _OPENPGP_SIGNING_ENVIRONMENT_KEYS or not isinstance(value, str)
         for key, value in values.items()
     ):
         raise ValueError("signing_environment may only set GNUPGHOME")
@@ -535,6 +603,66 @@ def _signing_environment(values: Mapping[str, str] | None) -> dict[str, str]:
             raise ValueError("GNUPGHOME must be an absolute, non-symlinked directory")
         normalized["GNUPGHOME"] = str(home.resolve(strict=True))
     return normalized
+
+
+def _ssh_signing_environment(
+    values: Mapping[str, str] | None,
+    *,
+    require_socket: bool,
+) -> dict[str, str]:
+    if require_socket:
+        return ssh_agent_environment(values)
+    if values is not None and (
+        not isinstance(values, Mapping) or any(
+            key != "SSH_AUTH_SOCK" or not isinstance(value, str)
+            for key, value in values.items()
+        )
+    ):
+        raise ValueError("signing_environment may only set SSH_AUTH_SOCK")
+    if values is not None and "SSH_AUTH_SOCK" in values:
+        raw_socket = values["SSH_AUTH_SOCK"]
+        socket_path = Path(raw_socket)
+        if (
+            not raw_socket
+            or any(character in raw_socket for character in "\r\n\x00")
+            or not socket_path.is_absolute()
+            or ".." in socket_path.parts
+        ):
+            raise ValueError("SSH_AUTH_SOCK must be an absolute Unix socket path")
+    return {}
+
+
+def _canonical_signing_identity(
+    runner: _GitRunner,
+    signing_key: str | None,
+) -> str | None:
+    if runner.signing_format is SigningFormat.SSH:
+        expected = runner._ssh_material().fingerprint
+        if signing_key is not None and canonical_ssh_fingerprint(signing_key) != expected:
+            raise ValueError("signing key fingerprint does not match SSH signing material")
+        return expected
+    return canonical_signing_key(signing_key) if signing_key is not None else None
+
+
+def _commit_signing_environment(
+    runner: _GitRunner,
+    values: Mapping[str, str] | None,
+) -> dict[str, str]:
+    if runner.signing_format is SigningFormat.SSH:
+        return ssh_agent_environment(
+            values,
+            temporary_root=runner._ssh_material().root,
+        )
+    return _openpgp_signing_environment(values)
+
+
+def _verification_signing_environment(
+    runner: _GitRunner,
+    values: Mapping[str, str] | None,
+) -> dict[str, str]:
+    if runner.signing_format is SigningFormat.SSH:
+        return _ssh_signing_environment(values, require_socket=False)
+    return _openpgp_signing_environment(values)
 
 
 def _verify_commit_signature(
@@ -548,10 +676,15 @@ def _verify_commit_signature(
         ("verify-commit", "--raw", commit_sha),
         extra_environment=signing_environment,
     )
-    if signing_key is not None and not signature_matches(
-        "\n".join((completed.stdout or "", completed.stderr or "")),
-        signing_key,
-    ):
+    output = "\n".join((completed.stdout or "", completed.stderr or ""))
+    if runner.signing_format is SigningFormat.SSH:
+        expected = _canonical_signing_identity(runner, signing_key)
+        assert expected is not None
+        if not ssh_signature_matches(output, expected):
+            raise WorkspaceError(
+                "verified SSH commit signer does not match the configured fingerprint"
+            )
+    elif signing_key is not None and not signature_matches(output, signing_key):
         raise WorkspaceError(
             "verified commit signer does not match the configured fingerprint"
         )
@@ -585,11 +718,15 @@ class GuardianWorkspace:
         """Commit exactly the already-validated files, then re-verify the commit."""
         if not isinstance(sign, bool):
             raise ValueError("sign must be a boolean")
-        if signing_key is not None:
-            signing_key = canonical_signing_key(signing_key)
+        if sign or signing_key is not None:
+            signing_key = _canonical_signing_identity(self._runner, signing_key)
         if not sign and signing_environment is not None:
             raise ValueError("signing_environment requires signed commits")
-        verified_signing_environment = _signing_environment(signing_environment) if sign else {}
+        verified_signing_environment = (
+            _commit_signing_environment(self._runner, signing_environment)
+            if sign
+            else {}
+        )
         author_name = _validate_identity_value(author_name, label="author_name")
         author_email = _validate_identity_value(author_email, label="author_email")
         normalized_paths = tuple(sorted(_normalize_relative_path(path) for path in expected_paths))
@@ -654,7 +791,10 @@ class GuardianWorkspace:
         ]
         command = ["commit", "--cleanup=verbatim", "--file=-"]
         if sign:
-            command.append("-S" if signing_key is None else f"-S{signing_key}")
+            if self._runner.signing_format is SigningFormat.SSH:
+                command.append(f"-S{self._runner._ssh_material().public_key}")
+            else:
+                command.append("-S" if signing_key is None else f"-S{signing_key}")
         else:
             command.append("--no-gpg-sign")
         identity_environment = {
@@ -700,7 +840,11 @@ class GuardianWorkspace:
                 self._runner,
                 commit_sha,
                 signing_key=signing_key,
-                signing_environment=verified_signing_environment,
+                signing_environment=(
+                    {}
+                    if self._runner.signing_format is SigningFormat.SSH
+                    else verified_signing_environment
+                ),
             )
         if _porcelain_status(self._runner):
             raise WorkspaceError("working tree is not clean after the Guardian commit")
@@ -725,9 +869,11 @@ class GuardianWorkspace:
 
         if not re.fullmatch(r"[0-9a-f]{64}", evidence_hash):
             raise ValueError("evidence_hash must be a lowercase SHA-256 digest")
-        if signing_key is not None:
-            signing_key = canonical_signing_key(signing_key)
-        verified_signing_environment = _signing_environment(signing_environment)
+        signing_key = _canonical_signing_identity(self._runner, signing_key)
+        verified_signing_environment = _commit_signing_environment(
+            self._runner,
+            signing_environment,
+        )
         author_name = _validate_identity_value(author_name, label="author_name")
         author_email = _validate_identity_value(author_email, label="author_email")
         normalized_paths = tuple(
@@ -777,7 +923,10 @@ class GuardianWorkspace:
             raise WorkspaceError("staged prevention paths do not match the allowlist")
 
         command = ["commit", "--cleanup=verbatim", "--file=-"]
-        command.append("-S" if signing_key is None else f"-S{signing_key}")
+        if self._runner.signing_format is SigningFormat.SSH:
+            command.append(f"-S{self._runner._ssh_material().public_key}")
+        else:
+            command.append("-S" if signing_key is None else f"-S{signing_key}")
         identity_environment = {
             "GIT_AUTHOR_EMAIL": author_email,
             "GIT_AUTHOR_NAME": author_name,
@@ -823,7 +972,11 @@ class GuardianWorkspace:
             self._runner,
             commit_sha,
             signing_key=signing_key,
-            signing_environment=verified_signing_environment,
+            signing_environment=(
+                {}
+                if self._runner.signing_format is SigningFormat.SSH
+                else verified_signing_environment
+            ),
         )
         if _porcelain_status(self._runner):
             raise WorkspaceError("working tree is not clean after prevention commit")
@@ -883,12 +1036,11 @@ class GuardianWorkspace:
         _verify_commit_signature(
             self._runner,
             commit.commit_sha,
-            signing_key=(
-                canonical_signing_key(signing_key)
-                if signing_key is not None
-                else None
+            signing_key=_canonical_signing_identity(self._runner, signing_key),
+            signing_environment=_verification_signing_environment(
+                self._runner,
+                signing_environment,
             ),
-            signing_environment=_signing_environment(signing_environment),
         )
 
         try:
@@ -916,6 +1068,15 @@ class GuardianWorkspace:
             raise WorkspaceError("prevention branch already exists at another commit")
 
         before_push()
+        _verify_commit_signature(
+            self._runner,
+            commit.commit_sha,
+            signing_key=_canonical_signing_identity(self._runner, signing_key),
+            signing_environment=_verification_signing_environment(
+                self._runner,
+                signing_environment,
+            ),
+        )
         self._runner.run(
             (
                 "push",
@@ -990,16 +1151,14 @@ class GuardianWorkspace:
         if _porcelain_status(self._runner):
             raise WorkspaceError("working tree is not clean before publication")
         if require_signature:
-            verified_signing_environment = _signing_environment(signing_environment)
             _verify_commit_signature(
                 self._runner,
                 commit.commit_sha,
-                signing_key=(
-                    canonical_signing_key(signing_key)
-                    if signing_key is not None
-                    else None
+                signing_key=_canonical_signing_identity(self._runner, signing_key),
+                signing_environment=_verification_signing_environment(
+                    self._runner,
+                    signing_environment,
                 ),
-                signing_environment=verified_signing_environment,
             )
 
         def credentials() -> dict[str, str]:
@@ -1026,8 +1185,19 @@ class GuardianWorkspace:
         if self._runner.revision("FETCH_HEAD^{commit}") != self.original_sha:
             raise WorkspaceError("remote branch changed since intake")
 
+        push_environment = credentials()
         if before_push is not None:
             before_push()
+        if require_signature:
+            _verify_commit_signature(
+                self._runner,
+                commit.commit_sha,
+                signing_key=_canonical_signing_identity(self._runner, signing_key),
+                signing_environment=_verification_signing_environment(
+                    self._runner,
+                    signing_environment,
+                ),
+            )
         self._runner.run(
             (
                 "push",
@@ -1036,7 +1206,7 @@ class GuardianWorkspace:
                 "origin",
                 f"{commit.commit_sha}:{self.revision.ref}",
             ),
-            extra_environment=credentials(),
+            extra_environment=push_environment,
         )
         remote_output = self._runner.run(
             ("ls-remote", "--refs", "origin", self.revision.ref),
@@ -1062,6 +1232,8 @@ def materialize_exact_checkout(
     credential_environment: CredentialEnvironment | None = None,
     git_binary: str = "git",
     signing_program: str | None = None,
+    signing_format: SigningFormat = SigningFormat.OPENPGP,
+    ssh_signing_material: SSHSigningMaterial | None = None,
     timeout_seconds: float = 120.0,
     _process_runner: ProcessRunner = _bounded_git_process,
 ) -> Iterator[GuardianWorkspace]:
@@ -1082,6 +1254,19 @@ def materialize_exact_checkout(
         or any(character in signing_program for character in "\r\n\x00")
     ):
         raise ValueError("signing_program must be a safe executable name or path")
+    if not isinstance(signing_format, SigningFormat):
+        raise TypeError("signing_format must be a SigningFormat")
+    if signing_format is SigningFormat.SSH:
+        if signing_program is None or ssh_signing_material is None:
+            raise ValueError(
+                "SSH signing requires a signing program and exact signing material"
+            )
+        require_absolute_trusted_executable(
+            (signing_program,),
+            field="signing_program",
+        )
+    elif ssh_signing_material is not None:
+        raise ValueError("SSH signing material is only valid with SSH signing")
     if (
         isinstance(timeout_seconds, bool)
         or not isinstance(timeout_seconds, (int, float))
@@ -1107,6 +1292,8 @@ def materialize_exact_checkout(
             process_runner=_process_runner,
             git_binary=git_binary,
             signing_program=signing_program,
+            signing_format=signing_format,
+            ssh_signing_material=ssh_signing_material,
             timeout_seconds=float(timeout_seconds),
         )
         runner.run(("init", "--quiet"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "localize-pipeline"
-version = "0.1.18"
+version = "0.1.19"
 description = "Agent-friendly AI localization pipeline that translates Java properties and JSON into pull requests"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_bootstrap_pr.py
+++ b/tests/unit/test_bootstrap_pr.py
@@ -66,7 +66,7 @@ def test_bootstrap_pr_creates_onboarding_branch_commit_and_files(tmp_path):
     workflow = (repo / ".github/workflows/translate.yml").read_text(encoding="utf-8")
     assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
     assert "actions/checkout@v4" not in workflow
-    assert "bisq-network/localize-pipeline@v0.1.18" in workflow
+    assert "bisq-network/localize-pipeline@v0.1.19" in workflow
     assert "dry-run: true" in workflow
 
     glossary = yaml.safe_load((repo / "glossary.json").read_text(encoding="utf-8"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -445,7 +445,7 @@ def test_cli_bootstrap_pr_defaults_to_latest_release_ref(capsys):
 
     capsys.readouterr()
     assert exit_code == 0
-    assert create.call_args.args[0].action_ref == "v0.1.18"
+    assert create.call_args.args[0].action_ref == "v0.1.19"
 
 
 def test_cli_quality_gate_delegates_to_rerunnable_reporter(tmp_path):
@@ -592,7 +592,7 @@ def test_pyproject_exposes_localize_console_script():
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["name"] == "localize-pipeline"
-    assert pyproject["project"]["version"] == "0.1.18"
+    assert pyproject["project"]["version"] == "0.1.19"
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/bisq-network/localize-pipeline"
     assert pyproject["project"]["urls"]["Changelog"]
     assert pyproject["project"]["urls"]["Issues"] == "https://github.com/bisq-network/localize-pipeline/issues"

--- a/tests/unit/test_guardian_cli.py
+++ b/tests/unit/test_guardian_cli.py
@@ -20,11 +20,12 @@ import pytest
 import yaml
 
 from localize import cli as root_cli
-from localize.guardian import FeedbackEvent, GuardianMode
+from localize.guardian import FeedbackEvent, GuardianMode, SigningFormat
 from localize.guardian import cli
 from localize.guardian import runtime as guardian_runtime
 from localize.guardian.config import load_guardian_config
 from localize.guardian.github import GitHubRepositoryIdentity
+from localize.guardian.signing import SSHSigningMaterial
 from localize.guardian.state import GuardianState
 
 
@@ -640,6 +641,101 @@ def test_doctor_requires_signing_only_for_write_modes(
     assert "commit signing: error" in apply_output
 
 
+def test_doctor_wires_the_complete_ssh_signing_identity_into_real_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = _init_config(tmp_path)
+    capsys.readouterr()
+    fingerprint = "SHA256:" + "A" * 43
+    configured = config_path.read_text(encoding="utf-8")
+    configured = _replace_once(
+        configured,
+        "mode: observe",
+        "mode: apply-owned-translations",
+    )
+    configured = _replace_once(
+        configured,
+        "  signing_format: openpgp\n  signing_program: gpg",
+        (
+            "  signing_format: ssh\n"
+            "  signing_program: /usr/bin/ssh-keygen\n"
+            f"  signing_key: {fingerprint}\n"
+            "  signing_public_key: /keys/guardian.pub"
+        ),
+    )
+    config_path.write_text(configured, encoding="utf-8")
+    config_path.chmod(0o600)
+    monkeypatch.setattr(cli, "_command_available", lambda _command: True)
+    monkeypatch.setattr(
+        cli,
+        "_probe_github",
+        lambda _config: (
+            GitHubRepositoryIdentity("acme/widgets", 100000001, False),
+        ),
+    )
+    probe = Mock(return_value=True)
+    monkeypatch.setattr(cli, "_signing_key_configured", probe)
+
+    assert cli.main(["doctor", "--config", str(config_path)]) == 0
+
+    probe.assert_called_once_with(
+        fingerprint,
+        git_executable="git",
+        signing_program="/usr/bin/ssh-keygen",
+        signing_format=SigningFormat.SSH,
+        signing_public_key="/keys/guardian.pub",
+        temporary_root=cli.guardian_state_dir(config_path),
+    )
+    assert "exact key signed and verified" in capsys.readouterr().out
+
+
+def test_ssh_doctor_uses_trusted_config_parent_without_creating_missing_state_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = _init_config(tmp_path)
+    capsys.readouterr()
+    state_directory = cli.guardian_state_dir(config_path)
+    state_directory.rmdir()
+    fingerprint = "SHA256:" + "A" * 43
+    configured = config_path.read_text(encoding="utf-8")
+    configured = _replace_once(
+        configured,
+        "mode: observe",
+        "mode: apply-owned-translations",
+    )
+    configured = _replace_once(
+        configured,
+        "  signing_format: openpgp\n  signing_program: gpg",
+        (
+            "  signing_format: ssh\n"
+            "  signing_program: /usr/bin/ssh-keygen\n"
+            f"  signing_key: {fingerprint}\n"
+            "  signing_public_key: /keys/guardian.pub"
+        ),
+    )
+    config_path.write_text(configured, encoding="utf-8")
+    config_path.chmod(0o600)
+    monkeypatch.setattr(cli, "_command_available", lambda _command: True)
+    monkeypatch.setattr(
+        cli,
+        "_probe_github",
+        lambda _config: (
+            GitHubRepositoryIdentity("acme/widgets", 100000001, False),
+        ),
+    )
+    probe = Mock(return_value=True)
+    monkeypatch.setattr(cli, "_signing_key_configured", probe)
+
+    assert cli.main(["doctor", "--config", str(config_path)]) == 0
+
+    assert not state_directory.exists()
+    assert probe.call_args.kwargs["temporary_root"] == config_path.parent
+
+
 def test_signing_probe_never_falls_back_to_global_git_configuration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -724,6 +820,118 @@ def test_signing_probe_fails_closed_when_exact_key_cannot_sign(
         signing_program="/usr/bin/gpg",
     ) is False
     assert calls == 2
+
+
+def test_ssh_signing_probe_uses_frozen_key_and_agent_only_for_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fingerprint = "SHA256:" + "A" * 43
+    calls: list[tuple[list[str], dict[str, str]]] = []
+    captured_snapshot: dict[str, object] = {}
+
+    @contextmanager
+    def fake_snapshot(**kwargs: object):
+        captured_snapshot.update(kwargs)
+        root = Path(kwargs["temporary_root"])
+        yield SSHSigningMaterial(
+            root=root,
+            public_key=root / "signing-key.pub",
+            allowed_signers=root / "allowed-signers",
+            fingerprint=fingerprint,
+        )
+
+    def run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((argv, dict(kwargs["env"])))  # type: ignore[arg-type]
+        output = (
+            'Good "git" signature for localize-guardian with ED25519 key '
+            f"{fingerprint}\n"
+            if "verify-commit" in argv
+            else ""
+        )
+        return subprocess.CompletedProcess(argv, 0, output, "")
+
+    monkeypatch.setattr(cli, "_command_available", lambda _command: True)
+    monkeypatch.setattr(cli, "snapshot_ssh_signing_material", fake_snapshot)
+    monkeypatch.setattr(
+        cli,
+        "ssh_agent_environment",
+        lambda **_kwargs: {"SSH_AUTH_SOCK": "/private/test-agent.sock"},
+    )
+    monkeypatch.setattr(cli, "run_bounded_process", run)
+
+    assert cli._signing_key_configured(
+        fingerprint,
+        signing_format=SigningFormat.SSH,
+        signing_public_key="/keys/guardian.pub",
+        git_executable="/usr/bin/git",
+        signing_program="/usr/bin/ssh-keygen",
+        temporary_root=tmp_path,
+    )
+    assert len(calls) == 3
+    commit_call = next(call for call in calls if "commit" in call[0])
+    assert commit_call[1]["SSH_AUTH_SOCK"] == "/private/test-agent.sock"
+    assert all(
+        "SSH_AUTH_SOCK" not in environment
+        for arguments, environment in calls
+        if "commit" not in arguments
+    )
+    assert "gpg.format=ssh" in commit_call[0]
+    assert "gpg.ssh.program=/usr/bin/ssh-keygen" in commit_call[0]
+    assert any(argument.startswith("gpg.ssh.allowedSignersFile=") for argument in commit_call[0])
+    assert "gpg.minTrustLevel=fully" in commit_call[0]
+    assert any(argument.startswith("-S") for argument in commit_call[0])
+    assert captured_snapshot["public_key_path"] == "/keys/guardian.pub"
+    assert captured_snapshot["expected_fingerprint"] == fingerprint
+
+
+def test_ssh_signing_probe_rejects_wrong_verified_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fingerprint = "SHA256:" + "A" * 43
+
+    @contextmanager
+    def fake_snapshot(**kwargs: object):
+        root = Path(kwargs["temporary_root"])
+        yield SSHSigningMaterial(
+            root=root,
+            public_key=root / "signing-key.pub",
+            allowed_signers=root / "allowed-signers",
+            fingerprint=fingerprint,
+        )
+
+    monkeypatch.setattr(cli, "_command_available", lambda _command: True)
+    monkeypatch.setattr(cli, "snapshot_ssh_signing_material", fake_snapshot)
+    monkeypatch.setattr(
+        cli,
+        "ssh_agent_environment",
+        lambda **_kwargs: {"SSH_AUTH_SOCK": "/private/test-agent.sock"},
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_bounded_process",
+        lambda argv, **_kwargs: subprocess.CompletedProcess(
+            argv,
+            0,
+            (
+                'Good "git" signature for localize-guardian with ED25519 key '
+                f"SHA256:{'B' * 43}\n"
+                if "verify-commit" in argv
+                else ""
+            ),
+            "",
+        ),
+    )
+
+    assert not cli._signing_key_configured(
+        fingerprint,
+        signing_format=SigningFormat.SSH,
+        signing_public_key="/keys/guardian.pub",
+        git_executable="/usr/bin/git",
+        signing_program="/usr/bin/ssh-keygen",
+        temporary_root=tmp_path,
+    )
 
 
 def test_doctor_consumes_secret_free_runtime_commands_from_config(

--- a/tests/unit/test_guardian_config.py
+++ b/tests/unit/test_guardian_config.py
@@ -15,6 +15,7 @@ from localize.guardian import (
     PreventionPolicy,
     ProposedReplacement,
     RepositoryPolicy,
+    SigningFormat,
     TrustedActor,
 )
 from localize.guardian.config import GuardianConfigError, load_guardian_config
@@ -107,10 +108,12 @@ def test_minimal_config_is_report_only_with_safe_limits(tmp_path: Path) -> None:
     assert config.runtime.codex_home == "~/.local/share/localize-guardian/codex"
     assert config.runtime.codex_executable == "codex"
     assert config.runtime.git_executable == "git"
+    assert config.runtime.signing_format is SigningFormat.OPENPGP
     assert config.runtime.signing_program == "gpg"
     assert config.runtime.github_token_command == ("gh", "auth", "token")
     assert config.runtime.codex_api_key_command == ()
     assert config.runtime.signing_key is None
+    assert config.runtime.signing_public_key is None
     assert config.schedule.hour == 0
     assert config.schedule.minute == 0
 
@@ -590,6 +593,75 @@ limits:
         "guardian",
     )
     assert config.runtime.signing_key == fingerprint
+    assert config.runtime.signing_format is SigningFormat.OPENPGP
+    assert config.runtime.signing_public_key is None
+
+
+def test_loads_exact_ssh_signing_identity(tmp_path: Path) -> None:
+    fingerprint = "SHA256:" + "A" * 43
+    config_text = f"""runtime:
+  signing_format: ssh
+  signing_program: /usr/bin/ssh-keygen
+  signing_key: {fingerprint}
+  signing_public_key: /keys/guardian.pub
+""" + _minimal_config()
+
+    config = load_guardian_config(_write_config(tmp_path, config_text))
+
+    assert config.runtime.signing_format is SigningFormat.SSH
+    assert config.runtime.signing_program == "/usr/bin/ssh-keygen"
+    assert config.runtime.signing_key == fingerprint
+    assert config.runtime.signing_public_key == "/keys/guardian.pub"
+
+
+@pytest.mark.parametrize(
+    "runtime_yaml, offending",
+    [
+        (
+            "signing_format: ssh\n  signing_key: SHA256:" + "A" * 43,
+            "signing_public_key",
+        ),
+        (
+            "signing_format: ssh\n  signing_key: SHA256:" + "A" * 43
+            + "\n  signing_public_key: /keys/guardian.pub",
+            "signing_program",
+        ),
+        (
+            "signing_format: ssh\n  signing_public_key: /keys/guardian.pub",
+            "signing_key",
+        ),
+        (
+            "signing_format: ssh\n  signing_key: " + "A" * 40
+            + "\n  signing_public_key: /keys/guardian.pub",
+            "SHA256",
+        ),
+        (
+            "signing_format: ssh\n  signing_key: SHA256:" + "A" * 42
+            + "\n  signing_public_key: /keys/guardian.pub",
+            "SHA256",
+        ),
+        (
+            "signing_format: ssh\n  signing_key: SHA256:" + "A" * 43
+            + "\n  signing_public_key: keys/guardian.pub",
+            "absolute",
+        ),
+        (
+            "signing_format: openpgp\n  signing_key: " + "A" * 40
+            + "\n  signing_public_key: /keys/guardian.pub",
+            "only valid",
+        ),
+        ("signing_format: x509", "signing_format"),
+    ],
+)
+def test_rejects_ambiguous_or_incomplete_signing_formats(
+    tmp_path: Path,
+    runtime_yaml: str,
+    offending: str,
+) -> None:
+    yaml_text = f"runtime:\n  {runtime_yaml}\n" + _minimal_config()
+
+    with pytest.raises(GuardianConfigError, match=offending):
+        load_guardian_config(_write_config(tmp_path, yaml_text))
 
 
 def test_chatgpt_auth_rejects_api_key_and_dollar_budget_configuration(

--- a/tests/unit/test_guardian_credentials.py
+++ b/tests/unit/test_guardian_credentials.py
@@ -26,6 +26,7 @@ def test_secret_command_uses_exact_argv_minimal_environment_and_redacted_errors(
     monkeypatch.setenv("PATH", "/usr/bin:/opt/bin")
     monkeypatch.setenv("GITHUB_TOKEN", "must-not-leak")
     monkeypatch.setenv("OPENAI_API_KEY", "must-not-leak-either")
+    monkeypatch.setenv("SSH_AUTH_SOCK", "/private/must-not-leak-agent.sock")
 
     command = credentials.SecretCommand(("gh", "auth", "token"), timeout_seconds=7)
 
@@ -41,6 +42,7 @@ def test_secret_command_uses_exact_argv_minimal_environment_and_redacted_errors(
     assert kwargs["env"]["PATH"] == "/usr/bin:/opt/bin"
     assert "GITHUB_TOKEN" not in kwargs["env"]
     assert "OPENAI_API_KEY" not in kwargs["env"]
+    assert "SSH_AUTH_SOCK" not in kwargs["env"]
     assert "secret-value" not in repr(command)
 
 

--- a/tests/unit/test_guardian_prevention_runtime.py
+++ b/tests/unit/test_guardian_prevention_runtime.py
@@ -233,7 +233,13 @@ def test_prevention_author_uses_workspace_write_stdin_and_scrubs_write_credentia
     assert kwargs["limits"].require_linux_cgroup is True
     assert kwargs["env"]["CODEX_API_KEY"] == "explicit-model-key"
     assert "OPENAI_API_KEY" not in kwargs["env"]
-    for forbidden in ("GITHUB_TOKEN", "GH_TOKEN", "GIT_ASKPASS", "GNUPGHOME"):
+    for forbidden in (
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "GIT_ASKPASS",
+        "GNUPGHOME",
+        "SSH_AUTH_SOCK",
+    ):
         assert forbidden not in kwargs["env"]
     assert result.usage == CodexUsage(input_tokens=12, output_tokens=3, cost_usd=0.02)
 
@@ -332,6 +338,7 @@ def test_sandboxed_runner_uses_identical_configured_argv_and_minimal_environment
     )
     monkeypatch.setenv("GITHUB_TOKEN", "forbidden")
     monkeypatch.setenv("OPENAI_API_KEY", "forbidden")
+    monkeypatch.setenv("SSH_AUTH_SOCK", "/private/forbidden-agent.sock")
     results = SandboxedTestRunner(timeout_seconds=23).run_pair(
         base_workspace=base,
         candidate_workspace=candidate,
@@ -368,6 +375,7 @@ def test_sandboxed_runner_uses_identical_configured_argv_and_minimal_environment
         assert kwargs["limits"].require_linux_cgroup is True
         assert "GITHUB_TOKEN" not in kwargs["env"]
         assert "OPENAI_API_KEY" not in kwargs["env"]
+        assert "SSH_AUTH_SOCK" not in kwargs["env"]
     assert [result.outcome for result in results] == [
         TestOutcome.FAILED,
         TestOutcome.PASSED,

--- a/tests/unit/test_guardian_runtime.py
+++ b/tests/unit/test_guardian_runtime.py
@@ -33,8 +33,10 @@ from localize.guardian.models import (
     PreventionPolicy,
     PipelineConfigSnapshot,
     RepositoryPolicy,
+    SigningFormat,
     TrustedActor,
 )
+from localize.guardian.signing import SSHSigningMaterial, SigningError
 from localize.guardian.state import GuardianState
 from localize.guardian.workspace import ExactRevision
 from localize.guardian import runtime
@@ -42,6 +44,7 @@ from localize.guardian import runtime
 
 UTC = timezone.utc
 NOW = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
+_REAL_VALIDATE_RUNTIME_AUTHORITY = runtime._validate_runtime_authority
 
 
 @pytest.fixture(autouse=True)
@@ -240,6 +243,92 @@ def test_scheduled_signing_program_is_required_only_for_write_modes(
         runtime._validate_scheduled_executables(write_config)
 
 
+def test_manual_ssh_write_requires_a_trusted_absolute_signing_program(
+    tmp_path: Path,
+) -> None:
+    ssh_runtime = replace(
+        _config().runtime,
+        signing_format=SigningFormat.SSH,
+        signing_program="/usr/bin/ssh-keygen",
+        signing_key="SHA256:" + "A" * 43,
+        signing_public_key="/keys/guardian.pub",
+    )
+    config = replace(
+        _config(GuardianMode.APPLY_OWNED_TRANSLATIONS),
+        runtime=ssh_runtime,
+    )
+
+    _REAL_VALIDATE_RUNTIME_AUTHORITY(config, scheduled=False)
+
+    unsafe_program = tmp_path / "ssh-keygen"
+    unsafe_program.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    unsafe_program.chmod(0o722)
+    config = replace(
+        config,
+        runtime=replace(ssh_runtime, signing_program=str(unsafe_program)),
+    )
+    with pytest.raises(runtime.GuardianRuntimeError, match="SSH signing authority"):
+        _REAL_VALIDATE_RUNTIME_AUTHORITY(config, scheduled=False)
+
+
+def test_ssh_signing_snapshot_is_exact_private_and_redacts_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fingerprint = "SHA256:" + "A" * 43
+    public_key_path = "/keys/guardian.pub"
+    material = SSHSigningMaterial(
+        root=tmp_path,
+        public_key=tmp_path / "signing-key.pub",
+        allowed_signers=tmp_path / "allowed-signers",
+        fingerprint=fingerprint,
+    )
+    config = replace(
+        _config(GuardianMode.APPLY_OWNED_TRANSLATIONS),
+        runtime=replace(
+            _config().runtime,
+            signing_format=SigningFormat.SSH,
+            signing_program="/usr/bin/ssh-keygen",
+            signing_key=fingerprint,
+            signing_public_key=public_key_path,
+        ),
+    )
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_snapshot(**kwargs: object) -> Iterator[SSHSigningMaterial]:
+        captured.update(kwargs)
+        yield material
+
+    monkeypatch.setattr(runtime, "snapshot_ssh_signing_material", fake_snapshot)
+    with runtime._snapshot_poll_signing_material(
+        config=config,
+        state_directory=tmp_path,
+    ) as selected:
+        assert selected is material
+    assert captured == {
+        "public_key_path": public_key_path,
+        "expected_fingerprint": fingerprint,
+        "signing_program": "/usr/bin/ssh-keygen",
+        "temporary_root": tmp_path,
+    }
+
+    @contextmanager
+    def failing_snapshot(**_kwargs: object) -> Iterator[SSHSigningMaterial]:
+        raise SigningError("secret path and agent diagnostic")
+        yield material
+
+    monkeypatch.setattr(runtime, "snapshot_ssh_signing_material", failing_snapshot)
+    with pytest.raises(runtime.GuardianRuntimeError, match="unavailable") as failure:
+        with runtime._snapshot_poll_signing_material(
+            config=config,
+            state_directory=tmp_path,
+        ):
+            pytest.fail("unsafe signing material must not be yielded")
+    assert "secret" not in str(failure.value)
+    assert failure.value.__cause__ is None
+
+
 class _Credential:
     def __init__(self, secret: str) -> None:
         self.secret = secret
@@ -398,6 +487,78 @@ def test_build_controller_wires_exact_runtime_policy_and_credentials(
         "credential_environment": git_environment,
         "git_binary": "/opt/bin/git",
         "signing_program": "/opt/bin/gpg",
+        "timeout_seconds": 120.0,
+    }
+
+
+def test_build_controller_wires_exact_ssh_snapshot_into_every_write_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fingerprint = "SHA256:" + "A" * 43
+    config = replace(
+        _config(GuardianMode.APPLY_OWNED_TRANSLATIONS),
+        runtime=replace(
+            _config().runtime,
+            signing_format=SigningFormat.SSH,
+            signing_program="/usr/bin/ssh-keygen",
+            signing_key=fingerprint,
+            signing_public_key="/keys/guardian.pub",
+        ),
+    )
+    material = SSHSigningMaterial(
+        root=tmp_path,
+        public_key=tmp_path / "signing-key.pub",
+        allowed_signers=tmp_path / "allowed-signers",
+        fingerprint=fingerprint,
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        runtime,
+        "CodexDriver",
+        lambda **_kwargs: SimpleNamespace(model="test"),
+    )
+    monkeypatch.setattr(runtime, "GuardianController", lambda **kwargs: kwargs)
+    monkeypatch.setattr(
+        runtime,
+        "AuthenticatedGitHubSnapshotProvider",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "materialize_exact_checkout",
+        lambda revision, **kwargs: (
+            captured.update(revision=revision, checkout=kwargs) or object()
+        ),
+    )
+    controller = runtime._build_controller(
+        config=config,
+        state=SimpleNamespace(),  # type: ignore[arg-type]
+        state_directory=tmp_path,
+        github_credential=SimpleNamespace(
+            argv=config.runtime.github_token_command
+        ),  # type: ignore[arg-type]
+        model_credential=None,
+        git_environment=lambda: {},
+        ssh_signing_material=material,
+    )
+    revision = ExactRevision(
+        host="github.com",
+        owner="acme",
+        repository="widgets",
+        ref="refs/heads/main",
+        sha="a" * 40,
+    )
+
+    controller["checkout_factory"](revision)
+
+    assert captured["revision"] is revision
+    assert captured["checkout"] == {
+        "credential_environment": controller["publish_credential_environment"],
+        "git_binary": "/opt/bin/git",
+        "signing_program": "/usr/bin/ssh-keygen",
+        "signing_format": SigningFormat.SSH,
+        "ssh_signing_material": material,
         "timeout_seconds": 120.0,
     }
 

--- a/tests/unit/test_guardian_runtime.py
+++ b/tests/unit/test_guardian_runtime.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import os
 from pathlib import Path
+import shutil
 import stat
 import subprocess
 import sys
@@ -246,10 +247,13 @@ def test_scheduled_signing_program_is_required_only_for_write_modes(
 def test_manual_ssh_write_requires_a_trusted_absolute_signing_program(
     tmp_path: Path,
 ) -> None:
+    signing_program = shutil.which("ssh-keygen")
+    if signing_program is None:
+        pytest.skip("OpenSSH ssh-keygen is unavailable")
     ssh_runtime = replace(
         _config().runtime,
         signing_format=SigningFormat.SSH,
-        signing_program="/usr/bin/ssh-keygen",
+        signing_program=str(Path(signing_program).resolve()),
         signing_key="SHA256:" + "A" * 43,
         signing_public_key="/keys/guardian.pub",
     )

--- a/tests/unit/test_guardian_signing.py
+++ b/tests/unit/test_guardian_signing.py
@@ -1,0 +1,423 @@
+"""Exact signer identity and private SSH signing-material tests."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import socket
+import stat
+import subprocess
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+
+from localize.guardian.signing import (
+    _is_trusted_socket_ancestor,
+    _private_agent_socket_proxy,
+    SigningError,
+    canonical_ssh_fingerprint,
+    snapshot_ssh_signing_material,
+    ssh_agent_environment,
+    ssh_signature_matches,
+)
+
+
+def _ssh_keygen() -> str:
+    executable = shutil.which("ssh-keygen")
+    if executable is None:
+        pytest.skip("OpenSSH ssh-keygen is unavailable")
+    return str(Path(executable).resolve())
+
+
+def _generate_key(root: Path, *, bits: int | None = None) -> tuple[Path, str]:
+    private_key = root / "guardian"
+    command = [_ssh_keygen(), "-q", "-N", "", "-C", "guardian-test"]
+    if bits is None:
+        command.extend(("-t", "ed25519"))
+    else:
+        command.extend(("-t", "rsa", "-b", str(bits)))
+    command.extend(("-f", str(private_key)))
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    assert completed.returncode == 0, completed.stderr
+    public_key = private_key.with_suffix(".pub")
+    fingerprint = subprocess.run(
+        [_ssh_keygen(), "-l", "-E", "sha256", "-f", str(public_key)],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.split()[1]
+    return public_key, fingerprint
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "SHA256:" + "A" * 42,
+        "SHA256:" + "A" * 44,
+        "SHA256:" + "A" * 42 + "B",
+        "sha256:" + "A" * 43,
+        "SHA256:" + "=" * 43,
+        "A" * 40,
+        "",
+    ],
+)
+def test_ssh_fingerprint_requires_exact_openssh_sha256_form(value: str) -> None:
+    with pytest.raises(ValueError, match="SHA256"):
+        canonical_ssh_fingerprint(value)
+
+    expected = "SHA256:" + "A" * 43
+    assert canonical_ssh_fingerprint(expected) == expected
+
+
+def test_ssh_signature_status_requires_one_exact_good_signature() -> None:
+    fingerprint = "SHA256:" + "A" * 43
+    good = (
+        'Good "git" signature for localize-guardian with ED25519 key '
+        f"{fingerprint}\n"
+    )
+
+    assert ssh_signature_matches(good, fingerprint)
+    assert not ssh_signature_matches(good + good, fingerprint)
+    assert not ssh_signature_matches(
+        good.replace("A" * 43, "B" * 43),
+        fingerprint,
+    )
+    assert not ssh_signature_matches("", fingerprint)
+
+
+def test_ssh_agent_environment_accepts_only_a_socket_in_a_private_directory() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="lg-agent-test-",
+        dir=str(Path("/tmp").resolve()),
+    ) as raw_root:
+        root = Path(raw_root)
+        root.chmod(0o700)
+        socket_path = root / "agent.sock"
+        agent_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            agent_socket.bind(str(socket_path))
+            assert ssh_agent_environment(
+                {"SSH_AUTH_SOCK": str(socket_path)}
+            ) == {"SSH_AUTH_SOCK": str(socket_path.resolve())}
+
+            linked_socket = root / "linked.sock"
+            linked_socket.symlink_to(socket_path)
+            with pytest.raises(ValueError, match="private Unix socket"):
+                ssh_agent_environment({"SSH_AUTH_SOCK": str(linked_socket)})
+
+            root.chmod(0o770)
+            with pytest.raises(ValueError, match="private Unix socket"):
+                ssh_agent_environment({"SSH_AUTH_SOCK": str(socket_path)})
+        finally:
+            root.chmod(0o700)
+            agent_socket.close()
+
+    with pytest.raises(ValueError, match="only set SSH_AUTH_SOCK"):
+        ssh_agent_environment({"GNUPGHOME": "/private/secret"})
+
+
+def test_ssh_agent_environment_rejects_accessible_or_mutable_ancestors(
+) -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="lg-agent-test-",
+        dir=str(Path("/tmp").resolve()),
+    ) as raw_root:
+        accessible_parent = Path(raw_root)
+        accessible_parent.chmod(0o755)
+        accessible_socket = accessible_parent / "agent.sock"
+        first_agent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        first_agent.bind(str(accessible_socket))
+        accessible_socket.chmod(0o600)
+
+        mutable_ancestor = accessible_parent / "mutable"
+        mutable_ancestor.mkdir(mode=0o777)
+        mutable_ancestor.chmod(0o777)
+        private_parent = mutable_ancestor / "private"
+        private_parent.mkdir(mode=0o700)
+        nested_socket = private_parent / "agent.sock"
+        second_agent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        second_agent.bind(str(nested_socket))
+        try:
+            with pytest.raises(ValueError, match="private Unix socket"):
+                ssh_agent_environment({"SSH_AUTH_SOCK": str(accessible_socket)})
+            with pytest.raises(ValueError, match="private Unix socket"):
+                ssh_agent_environment({"SSH_AUTH_SOCK": str(nested_socket)})
+        finally:
+            first_agent.close()
+            second_agent.close()
+
+
+def test_ssh_agent_environment_accepts_permissive_socket_inside_private_parent(
+) -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="lg-agent-test-",
+        dir=str(Path("/tmp").resolve()),
+    ) as raw_root:
+        private_parent = Path(raw_root)
+        private_parent.chmod(0o700)
+        socket_path = private_parent / "agent.sock"
+        agent_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            agent_socket.bind(str(socket_path))
+            socket_path.chmod(0o666)
+
+            assert ssh_agent_environment({"SSH_AUTH_SOCK": str(socket_path)}) == {
+                "SSH_AUTH_SOCK": str(socket_path.resolve())
+            }
+        finally:
+            agent_socket.close()
+
+
+def test_socket_ancestor_trusts_only_privileged_system_group_boundaries() -> None:
+    privileged_system = SimpleNamespace(
+        st_mode=stat.S_IFDIR | 0o775,
+        st_uid=0,
+        st_gid=0,
+    )
+    operator_mutable = SimpleNamespace(
+        st_mode=stat.S_IFDIR | 0o775,
+        st_uid=os.getuid(),
+        st_gid=0,
+    )
+    root_world_writable = SimpleNamespace(
+        st_mode=stat.S_IFDIR | 0o777,
+        st_uid=0,
+        st_gid=0,
+    )
+    unprivileged_group = SimpleNamespace(
+        st_mode=stat.S_IFDIR | 0o775,
+        st_uid=0,
+        st_gid=20,
+    )
+    other_system_group = SimpleNamespace(
+        st_mode=stat.S_IFDIR | 0o775,
+        st_uid=0,
+        st_gid=42,
+    )
+    root_symlink = SimpleNamespace(
+        st_mode=stat.S_IFLNK | 0o775,
+        st_uid=0,
+        st_gid=0,
+    )
+
+    assert _is_trusted_socket_ancestor(
+        privileged_system,
+        current_groups={20},
+        effectively_writable=False,
+    )
+    assert not _is_trusted_socket_ancestor(
+        privileged_system,
+        current_groups={0, 20},
+        effectively_writable=False,
+    )
+    assert _is_trusted_socket_ancestor(
+        other_system_group,
+        current_groups={20},
+        effectively_writable=False,
+    )
+    assert not _is_trusted_socket_ancestor(
+        privileged_system,
+        current_groups={20},
+        effectively_writable=True,
+    )
+    for unsafe in (
+        operator_mutable,
+        root_world_writable,
+        unprivileged_group,
+        root_symlink,
+    ):
+        assert not _is_trusted_socket_ancestor(
+            unsafe,
+            current_groups={20},
+            effectively_writable=False,
+        )
+
+
+def test_private_agent_proxy_pins_the_exact_socket_inode() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="lg-agent-test-",
+        dir=str(Path("/tmp").resolve()),
+    ) as raw_root:
+        root = Path(raw_root)
+        root.chmod(0o700)
+        source_root = root / "source"
+        proxy_root = root / "proxy"
+        source_root.mkdir(mode=0o700)
+        proxy_root.mkdir(mode=0o700)
+        source = source_root / "agent.sock"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            server.bind(str(source))
+            server.listen(1)
+            source_metadata = source.lstat()
+
+            proxy = _private_agent_socket_proxy(
+                source,
+                source_metadata,
+                proxy_root,
+            )
+
+            assert proxy.parent == proxy_root
+            assert (proxy.stat().st_dev, proxy.stat().st_ino) == (
+                source_metadata.st_dev,
+                source_metadata.st_ino,
+            )
+            assert proxy.stat().st_nlink == 2
+            client.connect(str(proxy))
+            connection, _address = server.accept()
+            connection.close()
+        finally:
+            client.close()
+            server.close()
+
+
+def test_snapshots_one_exact_public_key_and_derives_private_allowed_signers(
+    tmp_path: Path,
+) -> None:
+    public_key, fingerprint = _generate_key(tmp_path)
+    signing_root = tmp_path / "private-signing"
+    signing_root.mkdir(mode=0o700)
+
+    with snapshot_ssh_signing_material(
+        public_key_path=public_key,
+        expected_fingerprint=fingerprint,
+        signing_program=_ssh_keygen(),
+        temporary_root=signing_root,
+    ) as material:
+        key_fields = public_key.read_text(encoding="utf-8").split()
+        assert material.fingerprint == fingerprint
+        assert material.public_key.read_text(encoding="utf-8") == (
+            f"{key_fields[0]} {key_fields[1]}\n"
+        )
+        assert material.allowed_signers.read_text(encoding="utf-8") == (
+            f"localize-guardian {key_fields[0]} {key_fields[1]}\n"
+        )
+        assert stat.S_IMODE(material.root.stat().st_mode) == 0o700
+        assert stat.S_IMODE(material.public_key.stat().st_mode) == 0o600
+        assert stat.S_IMODE(material.allowed_signers.stat().st_mode) == 0o600
+        snapshot_root = material.root
+
+    assert not snapshot_root.exists()
+
+
+@pytest.mark.parametrize("unsafe", ["symlink", "group-writable", "hardlink"])
+def test_rejects_mutable_or_aliased_public_key_files(
+    tmp_path: Path,
+    unsafe: str,
+) -> None:
+    public_key, fingerprint = _generate_key(tmp_path)
+    candidate = public_key
+    if unsafe == "symlink":
+        candidate = tmp_path / "linked.pub"
+        candidate.symlink_to(public_key)
+    elif unsafe == "group-writable":
+        public_key.chmod(0o664)
+    else:
+        candidate = tmp_path / "hardlinked.pub"
+        os.link(public_key, candidate)
+
+    signing_root = tmp_path / "private-signing"
+    signing_root.mkdir(mode=0o700)
+    with pytest.raises(SigningError, match="unsafe"):
+        with snapshot_ssh_signing_material(
+            public_key_path=candidate,
+            expected_fingerprint=fingerprint,
+            signing_program=_ssh_keygen(),
+            temporary_root=signing_root,
+        ):
+            pytest.fail("unsafe public key must not be snapshotted")
+
+
+def test_rejects_untrusted_public_key_ancestor(tmp_path: Path) -> None:
+    unsafe_parent = tmp_path / "unsafe-parent"
+    unsafe_parent.mkdir(mode=0o777)
+    unsafe_parent.chmod(0o777)
+    public_key, fingerprint = _generate_key(unsafe_parent)
+    signing_root = tmp_path / "private-signing"
+    signing_root.mkdir(mode=0o700)
+
+    with pytest.raises(SigningError, match="unsafe"):
+        with snapshot_ssh_signing_material(
+            public_key_path=public_key,
+            expected_fingerprint=fingerprint,
+            signing_program=_ssh_keygen(),
+            temporary_root=signing_root,
+        ):
+            pytest.fail("an untrusted ancestor must fail closed")
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "ssh-dss AAAAB3NzaC1kc3MAAACBAInvalid\n",
+        "not-an-ssh-key\n",
+        "ssh-ed25519 AAAA\nssh-ed25519 AAAA\n",
+        "ssh-ed25519 AAAA\x00comment\n",
+    ],
+)
+def test_rejects_malformed_multiple_or_dsa_public_keys(
+    tmp_path: Path,
+    contents: str,
+) -> None:
+    public_key = tmp_path / "guardian.pub"
+    public_key.write_text(contents, encoding="utf-8")
+    public_key.chmod(0o600)
+    signing_root = tmp_path / "private-signing"
+    signing_root.mkdir(mode=0o700)
+
+    with pytest.raises(SigningError, match="public key"):
+        with snapshot_ssh_signing_material(
+            public_key_path=public_key,
+            expected_fingerprint="SHA256:" + "A" * 43,
+            signing_program=_ssh_keygen(),
+            temporary_root=signing_root,
+        ):
+            pytest.fail("invalid public key data must fail closed")
+
+
+def test_rejects_noncanonical_public_key_base64(tmp_path: Path) -> None:
+    public_key, fingerprint = _generate_key(tmp_path)
+    key_type, blob, *_comment = public_key.read_text(encoding="utf-8").split()
+    assert not blob.endswith("=")
+    public_key.write_text(f"{key_type} {blob}==\n", encoding="utf-8")
+    public_key.chmod(0o600)
+    signing_root = tmp_path / "private-signing"
+    signing_root.mkdir(mode=0o700)
+
+    with pytest.raises(SigningError, match="malformed or unsupported"):
+        with snapshot_ssh_signing_material(
+            public_key_path=public_key,
+            expected_fingerprint=fingerprint,
+            signing_program=_ssh_keygen(),
+            temporary_root=signing_root,
+        ):
+            pytest.fail("noncanonical public-key data must fail closed")
+
+
+def test_rejects_wrong_fingerprint_and_weak_rsa(tmp_path: Path) -> None:
+    public_key, fingerprint = _generate_key(tmp_path)
+    signing_root = tmp_path / "private-signing"
+    signing_root.mkdir(mode=0o700)
+    with pytest.raises(SigningError, match="fingerprint"):
+        with snapshot_ssh_signing_material(
+            public_key_path=public_key,
+            expected_fingerprint="SHA256:" + "A" * 43,
+            signing_program=_ssh_keygen(),
+            temporary_root=signing_root,
+        ):
+            pytest.fail("a substituted identity must fail closed")
+
+    weak_root = tmp_path / "weak"
+    weak_root.mkdir()
+    weak_key, weak_fingerprint = _generate_key(weak_root, bits=2048)
+    with pytest.raises(SigningError, match="weak"):
+        with snapshot_ssh_signing_material(
+            public_key_path=weak_key,
+            expected_fingerprint=weak_fingerprint,
+            signing_program=_ssh_keygen(),
+            temporary_root=signing_root,
+        ):
+            pytest.fail("weak RSA must fail closed")

--- a/tests/unit/test_guardian_workspace.py
+++ b/tests/unit/test_guardian_workspace.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import os
+import socket
 import subprocess
+import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import pytest
 
+from localize.guardian.models import SigningFormat
+from localize.guardian.signing import SSHSigningMaterial
 from localize.guardian.workspace import (
     CommitResult,
     ExactRevision,
@@ -508,6 +512,327 @@ def test_default_commit_path_requests_and_verifies_signature(tmp_path):
     assert all("push" not in call for call in calls)
 
 
+def test_openpgp_profile_keeps_the_existing_git_flags_and_environment(tmp_path):
+    remote, _base_sha, head_sha = _create_remote(tmp_path)
+    fingerprint = "A" * 40
+    gnupg_home = tmp_path / "gnupg"
+    gnupg_home.mkdir(mode=0o700)
+    calls: list[tuple[tuple[str, ...], dict[str, str]]] = []
+    original_run = subprocess.run
+
+    def signing_spy(args: Sequence[str], **kwargs):
+        arguments = tuple(args)
+        calls.append((arguments, dict(kwargs["env"])))
+        if "commit" in arguments and f"-S{fingerprint}" in arguments:
+            unsigned = tuple(
+                "--no-gpg-sign" if value == f"-S{fingerprint}" else value
+                for value in arguments
+            )
+            return original_run(unsigned, **kwargs)
+        if "verify-commit" in arguments:
+            return subprocess.CompletedProcess(
+                arguments,
+                0,
+                "",
+                f"[GNUPG:] VALIDSIG {fingerprint}\n",
+            )
+        return original_run(arguments, **kwargs)
+
+    with materialize_exact_checkout(
+        _revision(ref="refs/heads/translation-review", sha=head_sha),
+        remote_url=remote.as_uri(),
+        allow_file_remote=True,
+        signing_program="/usr/bin/gpg",
+        _process_runner=signing_spy,
+    ) as workspace:
+        (workspace.path / "i18n/messages_ru.properties").write_text(
+            "hello=Здравствуйте\n",
+            encoding="utf-8",
+        )
+        workspace.commit_validated_changes(
+            expected_paths=("i18n/messages_ru.properties",),
+            pull_number=7,
+            feedback_urls=(
+                "https://github.example.com/acme/project/pull/7#discussion_r123",
+            ),
+            signing_key=fingerprint,
+            signing_environment={"GNUPGHOME": str(gnupg_home)},
+        )
+
+    signing_calls = [
+        call for call in calls if "commit" in call[0] or "verify-commit" in call[0]
+    ]
+    assert len(signing_calls) == 2
+    for arguments, environment in signing_calls:
+        assert "gpg.program=/usr/bin/gpg" in arguments
+        assert "gpg.format=ssh" not in arguments
+        assert not any(
+            argument.startswith("gpg.ssh.") for argument in arguments
+        )
+        assert environment["GNUPGHOME"] == str(gnupg_home.resolve())
+        assert "SSH_AUTH_SOCK" not in environment
+
+
+def test_ssh_signing_uses_exact_snapshot_and_limits_agent_socket_to_commit(
+    tmp_path,
+):
+    remote, _base_sha, head_sha = _create_remote(tmp_path)
+    fingerprint = "SHA256:" + "A" * 43
+    signing_root = tmp_path / "ssh-signing"
+    signing_root.mkdir(mode=0o700)
+    public_key = signing_root / "signing-key.pub"
+    allowed_signers = signing_root / "allowed-signers"
+    public_key.write_text("ssh-ed25519 AAAATest\n", encoding="ascii")
+    allowed_signers.write_text(
+        "localize-guardian ssh-ed25519 AAAATest\n",
+        encoding="ascii",
+    )
+    public_key.chmod(0o600)
+    allowed_signers.chmod(0o600)
+    material = SSHSigningMaterial(
+        root=signing_root,
+        public_key=public_key,
+        allowed_signers=allowed_signers,
+        fingerprint=fingerprint,
+    )
+    socket_root = Path(
+        tempfile.mkdtemp(prefix="lg-agent-", dir=str(Path("/tmp").resolve()))
+    )
+    socket_path = socket_root / "agent.sock"
+    agent_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    agent_socket.bind(str(socket_path))
+    calls: list[tuple[tuple[str, ...], dict[str, str]]] = []
+    original_run = subprocess.run
+
+    def signing_spy(args: Sequence[str], **kwargs):
+        arguments = tuple(args)
+        calls.append((arguments, dict(kwargs["env"])))
+        if "commit" in arguments and any(
+            argument.startswith("-S") for argument in arguments
+        ):
+            unsigned = tuple(
+                "--no-gpg-sign" if value.startswith("-S") else value
+                for value in arguments
+            )
+            return original_run(unsigned, **kwargs)
+        if "verify-commit" in arguments:
+            return subprocess.CompletedProcess(
+                arguments,
+                0,
+                (
+                    'Good "git" signature for localize-guardian with ED25519 key '
+                    f"{fingerprint}\n"
+                ),
+                "",
+            )
+        return original_run(arguments, **kwargs)
+
+    try:
+        with materialize_exact_checkout(
+            _revision(ref="refs/heads/translation-review", sha=head_sha),
+            remote_url=remote.as_uri(),
+            allow_file_remote=True,
+            signing_format=SigningFormat.SSH,
+            signing_program="/usr/bin/ssh-keygen",
+            ssh_signing_material=material,
+            _process_runner=signing_spy,
+        ) as workspace:
+            (workspace.path / "i18n/messages_ru.properties").write_text(
+                "hello=Здравствуйте\n",
+                encoding="utf-8",
+            )
+            commit = workspace.commit_validated_changes(
+                expected_paths=("i18n/messages_ru.properties",),
+                pull_number=7,
+                feedback_urls=(
+                    "https://github.example.com/acme/project/pull/7#discussion_r123",
+                ),
+                signing_key=fingerprint,
+                signing_environment={"SSH_AUTH_SOCK": str(socket_path)},
+            )
+            workspace.publish_commit(
+                commit,
+                signing_key=fingerprint,
+                signing_environment={"SSH_AUTH_SOCK": str(socket_path)},
+            )
+    finally:
+        agent_socket.close()
+        socket_path.unlink(missing_ok=True)
+        socket_root.rmdir()
+
+    commit_call = next(call for call in calls if "commit" in call[0])
+    assert commit_call[1]["SSH_AUTH_SOCK"] == str(socket_path)
+    assert f"-S{public_key}" in commit_call[0]
+    assert all(
+        "SSH_AUTH_SOCK" not in environment
+        for arguments, environment in calls
+        if "commit" not in arguments
+    )
+    verify_calls = [arguments for arguments, _environment in calls if "verify-commit" in arguments]
+    assert len(verify_calls) == 3
+    for arguments in verify_calls:
+        assert "gpg.format=ssh" in arguments
+        assert "gpg.ssh.program=/usr/bin/ssh-keygen" in arguments
+        assert f"gpg.ssh.allowedSignersFile={allowed_signers}" in arguments
+        assert "gpg.minTrustLevel=fully" in arguments
+    push_index = next(index for index, call in enumerate(calls) if "push" in call[0])
+    assert "verify-commit" in calls[push_index - 1][0]
+
+
+def test_ssh_signing_rejects_wrong_fingerprint_or_non_socket_agent(tmp_path):
+    remote, _base_sha, head_sha = _create_remote(tmp_path)
+    fingerprint = "SHA256:" + "A" * 43
+    signing_root = tmp_path / "ssh-signing"
+    signing_root.mkdir(mode=0o700)
+    public_key = signing_root / "signing-key.pub"
+    allowed_signers = signing_root / "allowed-signers"
+    public_key.write_text("ssh-ed25519 AAAATest\n", encoding="ascii")
+    allowed_signers.write_text(
+        "localize-guardian ssh-ed25519 AAAATest\n",
+        encoding="ascii",
+    )
+    public_key.chmod(0o600)
+    allowed_signers.chmod(0o600)
+    material = SSHSigningMaterial(
+        root=signing_root,
+        public_key=public_key,
+        allowed_signers=allowed_signers,
+        fingerprint=fingerprint,
+    )
+    fake_socket = tmp_path / "not-a-socket"
+    fake_socket.write_text("not a socket", encoding="ascii")
+
+    with materialize_exact_checkout(
+        _revision(ref="refs/heads/translation-review", sha=head_sha),
+        remote_url=remote.as_uri(),
+        allow_file_remote=True,
+        signing_format=SigningFormat.SSH,
+        signing_program="/usr/bin/ssh-keygen",
+        ssh_signing_material=material,
+    ) as workspace:
+        target = workspace.path / "i18n/messages_ru.properties"
+        target.write_text("hello=Здравствуйте\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="fingerprint"):
+            workspace.commit_validated_changes(
+                expected_paths=("i18n/messages_ru.properties",),
+                pull_number=7,
+                feedback_urls=(
+                    "https://github.example.com/acme/project/pull/7#discussion_r123",
+                ),
+                signing_key="SHA256:" + "B" * 43,
+                signing_environment={"SSH_AUTH_SOCK": str(fake_socket)},
+            )
+        with pytest.raises(ValueError, match="SSH_AUTH_SOCK"):
+            workspace.commit_validated_changes(
+                expected_paths=("i18n/messages_ru.properties",),
+                pull_number=7,
+                feedback_urls=(
+                    "https://github.example.com/acme/project/pull/7#discussion_r123",
+                ),
+                signing_key=fingerprint,
+                signing_environment={"SSH_AUTH_SOCK": str(fake_socket)},
+            )
+
+
+def test_git_runner_restricts_agent_socket_to_ssh_commit_subprocess(tmp_path):
+    remote, _base_sha, head_sha = _create_remote(tmp_path)
+    fingerprint = "SHA256:" + "A" * 43
+    signing_root = tmp_path / "ssh-signing"
+    signing_root.mkdir(mode=0o700)
+    public_key = signing_root / "signing-key.pub"
+    allowed_signers = signing_root / "allowed-signers"
+    public_key.write_text("ssh-ed25519 AAAATest\n", encoding="ascii")
+    allowed_signers.write_text(
+        "localize-guardian ssh-ed25519 AAAATest\n",
+        encoding="ascii",
+    )
+    public_key.chmod(0o600)
+    allowed_signers.chmod(0o600)
+    material = SSHSigningMaterial(
+        root=signing_root,
+        public_key=public_key,
+        allowed_signers=allowed_signers,
+        fingerprint=fingerprint,
+    )
+
+    with materialize_exact_checkout(
+        _revision(ref="refs/heads/translation-review", sha=head_sha),
+        remote_url=remote.as_uri(),
+        allow_file_remote=True,
+        signing_format=SigningFormat.SSH,
+        signing_program="/usr/bin/ssh-keygen",
+        ssh_signing_material=material,
+    ) as workspace:
+        workspace._runner.process_runner = lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0],
+            0,
+            "",
+            "",
+        )
+        for operation in ("fetch", "push", "verify-commit", "status"):
+            with pytest.raises(WorkspaceError, match="SSH_AUTH_SOCK.*commit"):
+                workspace._runner.run(
+                    (operation,),
+                    extra_environment={"SSH_AUTH_SOCK": "/private/agent.sock"},
+                )
+
+
+def test_ssh_checkout_rejects_untrusted_signing_program_at_public_boundary(tmp_path):
+    remote, _base_sha, head_sha = _create_remote(tmp_path)
+    fingerprint = "SHA256:" + "A" * 43
+    signing_root = tmp_path / "ssh-signing"
+    signing_root.mkdir(mode=0o700)
+    public_key = signing_root / "signing-key.pub"
+    allowed_signers = signing_root / "allowed-signers"
+    public_key.write_text("ssh-ed25519 AAAATest\n", encoding="ascii")
+    allowed_signers.write_text(
+        "localize-guardian ssh-ed25519 AAAATest\n",
+        encoding="ascii",
+    )
+    public_key.chmod(0o600)
+    allowed_signers.chmod(0o600)
+    material = SSHSigningMaterial(
+        root=signing_root,
+        public_key=public_key,
+        allowed_signers=allowed_signers,
+        fingerprint=fingerprint,
+    )
+    untrusted_program = tmp_path / "untrusted-ssh-keygen"
+    untrusted_program.write_text("#!/bin/sh\nexit 0\n", encoding="ascii")
+    untrusted_program.chmod(0o777)
+
+    with pytest.raises(ValueError, match="trusted, non-symlinked executable"):
+        with materialize_exact_checkout(
+            _revision(ref="refs/heads/translation-review", sha=head_sha),
+            remote_url=remote.as_uri(),
+            allow_file_remote=True,
+            signing_format=SigningFormat.SSH,
+            signing_program=str(untrusted_program),
+            ssh_signing_material=material,
+        ):
+            pytest.fail("an untrusted SSH verification program must fail closed")
+
+
+def test_unsigned_openpgp_commit_still_rejects_malformed_supplied_key(tmp_path):
+    remote, _base_sha, head_sha = _create_remote(tmp_path)
+
+    with materialize_exact_checkout(
+        _revision(ref="refs/heads/translation-review", sha=head_sha),
+        remote_url=remote.as_uri(),
+        allow_file_remote=True,
+    ) as workspace:
+        with pytest.raises(ValueError, match="OpenPGP fingerprint"):
+            workspace.commit_validated_changes(
+                expected_paths=("i18n/messages_ru.properties",),
+                pull_number=7,
+                feedback_urls=(
+                    "https://github.example.com/acme/project/pull/7#discussion_r123",
+                ),
+                sign=False,
+                signing_key="not-a-fingerprint",
+            )
+
+
 def test_signs_validated_prevention_modifications_and_new_tests_then_creates_branch(
     tmp_path,
 ):
@@ -597,6 +922,8 @@ def test_signs_validated_prevention_modifications_and_new_tests_then_creates_bra
     assert lease_checks == ["checked"]
     push_call = next(arguments for arguments, _env in calls if "push" in arguments)
     assert "--force-with-lease=refs/heads/guardian/prevention-abc:" in push_call
+    push_index = next(index for index, call in enumerate(calls) if "push" in call[0])
+    assert "verify-commit" in calls[push_index - 1][0]
     assert all(
         "prevention-secret" not in "\0".join(arguments)
         for arguments, _environment in calls


### PR DESCRIPTION
## Summary

- add opt-in, agent-backed SSH commit signing to Localize Guardian while
  preserving OpenPGP as the backward-compatible default
- pin one exact SHA-256 public-key fingerprint and snapshot one trusted public
  key into a private per-poll signing bundle
- pass the validated SSH agent endpoint only to `git commit`, then verify the
  exact signature after creation and immediately before publication
- make `guardian doctor` perform a real isolated SSH sign-and-verify probe
- prepare the documented `v0.1.19` release and bootstrap Action reference

## Security properties

The Guardian never reads or stores an SSH private key. SSH mode requires an
exact canonical SHA-256 fingerprint, one absolute single-link public-key file,
a trusted absolute signing executable, and one supported non-DSA key (including
a 3072-bit minimum for RSA). Public material is read through a bounded
non-following, inode-stable snapshot and converted to a private one-key
`allowed-signers` file.

`SSH_AUTH_SOCK` is excluded from Codex, credential helpers, fetch, push,
verification, and focused-test subprocesses. It reaches only the commit
subprocess. For eligible macOS system-managed socket paths whose higher
ancestors are privileged but not ordinarily private, Guardian creates a
private hard-link proxy to the already validated socket inode and revalidates
both names and link counts before use. Mutable or substituted paths fail
closed.

The exact committed identity is checked against the private one-key trust file
immediately after commit creation and again immediately before publication.
The real doctor probe uses the same signer, agent, and verifier boundary that a
write-capable run will use.

## Verification

- `1429 passed, 1 skipped` (full unit and integration suite)
- 433 focused Guardian/signing/transplant regressions passed
- real no-network SSH-agent signed-commit canary plus two exact verifications:
  passed
- real macOS launchd-agent inode-proxy canary: passed; cleanup restored the
  original single-link socket state
- independent security review: no findings
- Ruff: clean
- `git diff --check`: clean

No Bisq, JabRef, reviewer, bot, key, fingerprint, socket, or host deployment
policy is committed in this PR. Each self-hosted operator supplies and owns
those choices outside monitored repositories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in agent-backed SSH commit signing for Guardian workflows.
  * SSH identities are validated by fingerprint, with signatures reverified before publication.
  * Added Guardian doctor checks for SSH signing configuration.

* **Security**
  * Improved protection of signing keys and agent access, including weak-key rejection and isolated signing operations.

* **Documentation**
  * Updated configuration examples and signing guidance for OpenPGP and SSH workflows.

* **Chores**
  * Released version 0.1.19 and updated default GitHub Action references. OpenPGP remains the default signing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->