### PR TITLE
Keep prior translation on model failure

### DIFF
--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -210,6 +210,42 @@ def normalize_value(value: Optional[str]) -> str:
     return value
 
 
+def prefer_existing_translation_on_failure(
+    results: List[Tuple[int, str, bool]],
+    keys_to_translate: List[str],
+    source_translations: Dict[str, str],
+    existing_translations: Dict[str, str],
+) -> List[Tuple[int, str, bool]]:
+    """Keep a prior localized value for keys the model failed to translate.
+
+    When a model translation fails, the pipeline otherwise falls back to the
+    source (English) value. For a key that already had a usable translation in
+    the target file, that fallback ships mixed-language UI (e.g. English text
+    on a Russian or Turkish screen). Prefer the existing translation instead;
+    the ``succeeded`` flag is left untouched so the key is still recorded as
+    ``failed`` in the ledger and retried on the next run.
+
+    Keys with no usable prior translation (new or empty targets, or values that
+    merely echoed the source) still fall back to the source value.
+    """
+    if not existing_translations:
+        return results
+    repaired: List[Tuple[int, str, bool]] = []
+    for position, value, succeeded in results:
+        if not succeeded and 0 <= position < len(keys_to_translate):
+            key = keys_to_translate[position]
+            existing_value = existing_translations.get(key)
+            source_value = source_translations.get(key, "")
+            if (
+                isinstance(existing_value, str)
+                and existing_value.strip()
+                and normalize_value(existing_value) != normalize_value(source_value)
+            ):
+                value = existing_value
+        repaired.append((position, value, succeeded))
+    return repaired
+
+
 def compute_ledger_hash(value: Optional[str]) -> str:
     """Compute a stable hash for ledger comparisons."""
     normalized = normalize_value(value)
@@ -2632,6 +2668,14 @@ async def process_translation_queue(
                     texts_to_translate[position] if position < len(texts_to_translate) else "",
                 )
                 results.append((position, fallback_text, False))
+            # Keep prior localized values for model failures instead of shipping
+            # the English source into a translated file (mixed-language UI).
+            results = prefer_existing_translation_on_failure(
+                results,
+                keys_to_translate,
+                source_translations,
+                original_target_translations,
+            )
             results.sort(key=lambda x: x[0])
             translations = [result for _, result, _ in results]
             model_failed_keys = {

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -18,6 +18,7 @@ from localize.translate_localization_files import (
     build_context,
     apply_ignored_source_values,
     normalize_value,
+    prefer_existing_translation_on_failure,
     compute_ledger_hash,
     extract_texts_to_translate,
     filter_git_changed_keys_by_source,
@@ -1602,6 +1603,53 @@ class TestFilterGitChangedKeys(unittest.TestCase):
         )
 
         self.assertIn("key.orphan", result)
+
+
+class TestPreferExistingTranslationOnFailure(unittest.TestCase):
+    """On model failure, keep a prior localized value instead of the source."""
+
+    def test_keeps_existing_translation_for_failed_key(self):
+        results = [(0, "This trade view is out of sync", False)]
+        keys = ["mobile.bisqEasy.openTrades.outOfSync.headline"]
+        source = {keys[0]: "This trade view is out of sync"}
+        existing = {keys[0]: "Этот экран сделки не синхронизирован"}
+
+        repaired = prefer_existing_translation_on_failure(results, keys, source, existing)
+
+        self.assertEqual(repaired[0][1], "Этот экран сделки не синхронизирован")
+        # The key stays marked as failed so it is retried next run.
+        self.assertFalse(repaired[0][2])
+
+    def test_falls_back_to_source_when_no_existing_translation(self):
+        results = [(0, "Needs translation", False)]
+        keys = ["key.fail"]
+        source = {"key.fail": "Needs translation"}
+
+        for existing in ({}, {"key.fail": ""}, {"key.fail": "   "}):
+            repaired = prefer_existing_translation_on_failure(results, keys, source, existing)
+            self.assertEqual(repaired[0][1], "Needs translation")
+            self.assertFalse(repaired[0][2])
+
+    def test_ignores_existing_value_identical_to_source(self):
+        results = [(0, "Open trade chat", False)]
+        keys = ["key.echo"]
+        source = {"key.echo": "Open trade chat"}
+        existing = {"key.echo": "Open trade chat"}
+
+        repaired = prefer_existing_translation_on_failure(results, keys, source, existing)
+
+        self.assertEqual(repaired[0][1], "Open trade chat")
+
+    def test_does_not_touch_successful_translations(self):
+        results = [(0, "Otevřít obchodní chat", True)]
+        keys = ["key.ok"]
+        source = {"key.ok": "Open trade chat"}
+        existing = {"key.ok": "stale value"}
+
+        repaired = prefer_existing_translation_on_failure(results, keys, source, existing)
+
+        self.assertEqual(repaired[0][1], "Otevřít obchodní chat")
+        self.assertTrue(repaired[0][2])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

When a model translation **fails** for a key, the pipeline falls back to the
**source (English)** value even when the target file already contains a valid
prior translation. That ships mixed-language UI — English strings on an
otherwise localized screen — and it recurs whenever the provider rate-limits or
errors on a subset of keys.

### Evidence (bisq-network/bisq-mobile#1805)

The `translation-quality-gate` reported `Model translation failures` and the diff
reverted previously-translated Russian and Turkish trade strings to English:

- `mobile_ru.properties` `mobile.bisqEasy.openTrades.outOfSync.{headline,body,openChat}` and `…waitingForTradeData`
- `mobile_tr.properties` `mobile.bisqEasy.openTrades.outOfSync.body` and `…waitingForTradeData`

Each of these keys had a good prior translation in the target file (e.g. ru
`Ожидание начала сделки...`, tr `İşlemin başlaması bekleniyor...`); the failed run
overwrote them with the English source. CodeRabbit flagged the result as a
mixed-language regression, and the fixes had to be applied by hand on the PR
branch.

## Root cause

`localize/translate_localization_files.py`, `process_translation_queue`: on model
failure the fallback value is `source_translations.get(key, …)` (the English
source), which then becomes the written value for the failed key.

## Change

Add `prefer_existing_translation_on_failure(...)` and apply it right before the
results are assembled. For a key the model failed to translate, keep the prior
localized value from the target file when one exists and is not merely an echo of
the source; otherwise keep the existing source fallback (new/empty keys are
unaffected). The `succeeded` flag is left untouched, so the key is still recorded
as `failed` in the ledger and retried on the next run — no data loss, just a
better interim fallback than English.

## Tests

`.venv/bin/pytest -q` — focused + suites (see run below). New unit tests in
`tests/unit/test_core_logic.py::TestPreferExistingTranslationOnFailure` cover:
keeps existing translation on failure; falls back to source when no usable prior
translation (missing/empty/whitespace); ignores an existing value identical to
source; leaves successful translations untouched. The existing
`test_failed_model_translation_marks_ledger_and_skips_memory` integration test
(new key, empty target) still passes — the change is a no-op there.

- [ ] Requires `docker compose run --rm translator` build + local run before merge.
