### PR TITLE
Correct Docker deployment documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,6 +43,7 @@ build/
 config.yaml
 config-mobile.yaml
 docker/config.docker.mobile.yaml
+profiles/
 docker/docker-compose.override*.yml
 docker/docker-compose.override*.yaml
 secrets/

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -82,18 +82,6 @@ jobs:
         if: ${{ matrix.python-version == '3.11' }}
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
-      - name: Create dummy secret files (for CI build only)
-        if: ${{ matrix.python-version == '3.11' }}
-        run: |
-          # These files are required for the Docker build's COPY step to succeed.
-          # They are empty and do not contain real secrets.
-          mkdir -p secrets/gpg_bot_key
-          touch secrets/gpg_bot_key/bot_public_key.asc
-          touch secrets/gpg_bot_key/bot_secret_key.asc
-          # The build process requires a .env file to be present, but the values are not
-          # used in the CI environment. We create a dummy file to satisfy this requirement.
-          echo "DUMMY_KEY=123" > docker/.env
-
       # QEMU not required unless building multi-arch
       # - name: Set up QEMU
       #   uses: docker/setup-qemu-action@v3
@@ -106,10 +94,6 @@ jobs:
           file: ./docker/Dockerfile
           load: true
           tags: translator-app:ci-${{ github.sha }}
-          build-args: |
-            SKIP_GPG_IMPORT=true
-            SKIP_DEPLOY_KEY=true
-            GPG_KEY_FINGERPRINT_FOR_TRUST=DUMMY_FINGERPRINT_FOR_CI
 
       - name: Display Docker Image Info
         if: ${{ matrix.python-version == '3.11' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,17 @@ stable `1.0.0`, minor releases may still refine public APIs with migration notes
   CVE-2026-84304 dependency finding for fragmented HTTP/2 DATA-frame heap
   exhaustion and avoiding the affected range for the xDS server panic in
   GHSA-2v4p-qf9q-27wj.
+- Exclude project profiles from the Docker build context; Compose bind-mounts
+  the selected config and glossary read-only at runtime, preventing ignored or
+  private profiles from entering image layers.
 
 ### Changed
 
 - The default bootstrap action ref is now `v0.1.20`.
+- Correct the deployment guides to document the 90-file PR batch default,
+  Compose runtime key mounts, host-level cron, and root-safe Compose commands.
+- Remove obsolete dummy credential files and unused secret-related build
+  arguments from the CI image build.
 
 ## [0.1.19] - 2026-09-01
 

--- a/SECURITY_STRATEGY.md
+++ b/SECURITY_STRATEGY.md
@@ -6,7 +6,7 @@ This document outlines the security strategy for the automated translation servi
 
 1.  **Least Privilege**: Components (API tokens, SSH keys) are granted only the permissions necessary for their function.
 2.  **Dedicated Credentials**: The service uses dedicated credentials (SSH deploy keys, GPG keys) to limit the blast radius of a compromise.
-3.  **Secure by Default**: The default configuration for server deployment is secure, and local development overrides use secure methods like SSH agent forwarding.
+3.  **Secure by Default**: Server and local Docker runs use the same explicit runtime-secret mounts and pinned SSH host keys.
 4.  **No Secrets in Git**: All sensitive information is stored outside of the Git repository. The project's `.gitignore` file is configured to ignore the `docker/.env` and root `/.env` files, preventing accidental commits of secrets.
 
 ## 1. Server Deployment Security
@@ -15,19 +15,18 @@ This model is for the automated, scheduled execution of the service on a product
 
 ### Credential Management
 
-*   **Secrets File (`docker/.env`)**: All secrets—`OPENAI_API_KEY`, `TX_TOKEN`, `GITHUB_TOKEN`, and Git configuration—are stored in a single `docker/.env` file on the host. This file **must**:
+*   **Environment File (`docker/.env`)**: Token credentials (`OPENAI_API_KEY`, `TX_TOKEN`, and `GITHUB_TOKEN`) plus non-secret runtime and Git identity settings are stored in `docker/.env` on the host. Private deploy and signing keys remain separate host files. The environment file **must**:
     *   Be protected with strict file permissions (`chmod 600 docker/.env`).
     *   **NEVER** be committed to Git (it is listed in `.gitignore`).
 *   **SSH Deploy Key**: A dedicated, **passphrase-less** SSH key pair is used for the service.
-    *   The private key resides on the host server (e.g., in `~/.ssh/translator_deploy_key`).
+    *   The private key resides in a permission-restricted host file selected by `DEPLOY_KEY_FILE` (default: `secrets/deploy_key/id_ed25519`).
     *   The public key is configured as a **Deploy Key** with **write access** on the bot's **forked** GitHub repository. This key is used exclusively for pushing translated commits.
-*   **GPG Private Key**: The bot's GPG private key is stored on the host at `secrets/gpg_bot_key/bot_secret_key.asc` and protected with strict file permissions. It is imported into the container's GPG keyring at runtime by the entrypoint script.
+*   **GPG Private Key**: The bot's GPG private key is stored in the permission-restricted host file selected by `GPG_BOT_KEY_FILE` (default: `secrets/gpg_bot_key/bot_secret_key.asc`). It is imported into the container's GPG keyring at runtime by the entrypoint script.
 
 ### Docker Image and Container Security
 
-*   **Runtime Secrets**: API tokens and other secrets from `docker/.env` are injected into the container as environment variables at runtime.
-    *   For interactive sessions, these are available directly.
-    *   For automated `cron` jobs, the entrypoint script writes these variables to `/etc/environment` and sets permissions to `600` (`-rw-------`). This is necessary because the `cron` daemon does not inherit the runtime environment, and this file is the standard, secure mechanism for providing it.
+*   **Runtime Secrets**: API tokens from `docker/.env` are injected when Compose creates the container. Compose separately mounts the deploy and GPG key files read-only under `/run/secrets/`; the entrypoint consumes those files only after the container starts. None of these credentials is a Docker build input.
+    *   The scheduled job is a host-level cron entry that starts a new `docker compose run` process. There is no cron daemon or persistent environment file inside the container.
 *   **Privilege Dropping**: The container starts as `root` to perform initial setup (like cloning the repo and setting permissions) and then drops privileges to a non-root `appuser` to execute the main translation script.
 *   **No Persistent Container**: The service runs as a transient container via `docker compose run`, which is triggered by a host-level cron job. The container is created for the job and destroyed upon completion, minimizing its attack surface.
 
@@ -35,8 +34,7 @@ This model is for the automated, scheduled execution of the service on a product
 
 This model is for developers running the service on their local machines.
 
-*   **SSH Agent Forwarding**: The `docker-compose.override.yml` file (used only for local runs and gitignored) configures the container to use SSH Agent Forwarding.
-    *   **Benefit**: This is highly secure. Your local, passphrase-protected SSH private key **never leaves your host machine**. The container is only given access to the agent's socket, allowing it to perform Git operations without ever handling the key directly.
+*   **Runtime Key Mounts**: Local Docker runs use the same Compose runtime secrets as server runs. The deploy and signing keys remain host files, are mounted read-only under `/run/secrets/`, and are consumed by the entrypoint for the transient container. No ignored Compose override or SSH agent forwarding is part of the supported path.
 *   **Local `.env` File**: Local runs can use a local `docker/.env` file for API keys, which is also gitignored.
 
 ## Key Revocation Plan
@@ -46,7 +44,7 @@ Rapid revocation is critical if a credential is compromised.
 1.  **SSH Deploy Key Compromise**:
     1.  Immediately revoke the Deploy Key from the fork's settings on GitHub.
     2.  Delete the compromised SSH key pair from the server.
-    3.  Generate a new SSH key pair, add the new public key as a Deploy Key, and update the server's SSH config.
+    3.  Generate a new SSH key pair, add the new public key as a Deploy Key, and replace the host file selected by `DEPLOY_KEY_FILE`.
 
 2.  **GPG Signing Key Compromise**:
     1.  Remove the compromised GPG public key from the committer's GitHub account.

--- a/docker/translator-cron
+++ b/docker/translator-cron
@@ -6,6 +6,6 @@
 # IMPORTANT: Replace '/path/to/your/project' with the absolute path to this project's root directory on your server.
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-0 3 * * * cd /path/to/your/project/docker && mkdir -p ../logs && /usr/bin/docker compose run --rm translator >> /path/to/your/project/logs/cron_job.log 2>&1
+0 3 * * * cd /path/to/your/project && mkdir -p logs && /usr/bin/docker compose --env-file docker/.env -f docker/docker-compose.yml run -T --rm translator >> /path/to/your/project/logs/cron_job.log 2>&1
 
-# An empty line at the end of the crontab is recommended for portability. 
+# An empty line at the end of the crontab is recommended for portability.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -33,7 +33,7 @@ override or secret.
 | `LOCALIZE_DRY_RUN` | Python pipeline, shell scripts, Action | Forces dry-run mode when true, even if the config says otherwise. |
 | `LOCALIZE_SMOKE_ONLY` | `update-translations.sh` | Runs the smoke path and exits before Transifex, translation, commit, or PR work. |
 | `TX_PULL_TIMEOUT` | `update-translations.sh` | Timeout in seconds for `tx pull`; defaults to `3600`. |
-| `MAX_FILES_PER_PR` | `update-translations.sh` | Maximum files per generated PR batch; defaults to `150`. |
+| `MAX_FILES_PER_PR` | `update-translations.sh` | Maximum files per generated PR batch; defaults to `90`. |
 | `TRANSLATION_FILTER_GLOB` | Python pipeline, local runner, shell scripts | Filters translation files by basename glob. The `translation_file_filter_glob` config key sets this when the environment does not. |
 | `TRANSLATION_QUALITY_AUDIT_SCOPE` | `update-translations.sh` | Optional CLI override for quality-gate audit scope. When unset, the gate uses config. |
 | `LOCALIZE_ALLOW_RESET_LEDGER` | Python pipeline | Allows a corrupt translation-key ledger to be backed up and reset. Default behavior fails closed. |

--- a/docs/how-to-run-locally.md
+++ b/docs/how-to-run-locally.md
@@ -2,7 +2,8 @@
 
 This guide explains how to run the full translation pipeline on your local machine for testing or development.
 
-The only recommended method is to use Docker, as it perfectly replicates the production server environment and handles all dependencies automatically.
+The recommended method is Docker because it uses the same image, Compose file,
+and runtime-secret boundary as the server deployment.
 
 ## Local Development with Docker
 
@@ -10,18 +11,29 @@ This method runs the entire `update-translations.sh` orchestration script inside
 
 ### Setup and Execution
 
-It is a prerequisite that you have a `secrets/deploy_key/id_ed25519` file with a GitHub deploy key that has write access to the target repository. Please refer to the main `README.md` for detailed instructions on setting this up.
+Create `docker/.env` and the key files described in
+[new-project-deployment.md](new-project-deployment.md). By default, Compose
+reads the deploy key from `secrets/deploy_key/id_ed25519` and the signing key
+from `secrets/gpg_bot_key/bot_secret_key.asc`; `DEPLOY_KEY_FILE` and
+`GPG_BOT_KEY_FILE` can select other host paths.
 
-The process for running the service locally is **identical** to the server deployment. It uses a baked-in SSH deploy key for all Git operations, which works consistently across all platforms (including macOS).
+The keys are read-only runtime secrets. Compose mounts them under
+`/run/secrets/` only when the container starts, and the entrypoint installs or
+imports them for that transient run. They are not stored in the image.
 
-Note: Enable Docker BuildKit for builds using secrets:
+Enable Docker BuildKit for the image build:
+
 ```bash
 export DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1
 ```
 
-Once the prerequisites are met, you can build and run the service with a single command from the project root:
+From the project root, build and run with the repository's Compose file and env
+file explicitly selected:
+
 ```bash
-docker compose run --rm translator
+docker compose --env-file docker/.env -f docker/docker-compose.yml build
+docker compose --env-file docker/.env -f docker/docker-compose.yml run -T --rm translator
 ```
 
-There is no longer a need for a separate `docker-compose.override.yml` file or for using `ssh-agent`.
+`-T` prevents Compose from consuming terminal input in scripts. No local
+Compose override or SSH agent forwarding is required.

--- a/docs/how-to-run-locally.md
+++ b/docs/how-to-run-locally.md
@@ -35,5 +35,7 @@ docker compose --env-file docker/.env -f docker/docker-compose.yml build
 docker compose --env-file docker/.env -f docker/docker-compose.yml run -T --rm translator
 ```
 
-`-T` prevents Compose from consuming terminal input in scripts. No local
-Compose override or SSH agent forwarding is required.
+`-T` disables pseudo-TTY allocation. `docker compose run` still keeps standard
+input open by default; add `--interactive=false` when a script must not pass
+input to the container. No local Compose override or SSH agent forwarding is
+required.

--- a/docs/new-project-deployment.md
+++ b/docs/new-project-deployment.md
@@ -121,7 +121,8 @@ Never commit `docker/.env` or files under `secrets/`.
 
 ## 4. Add Deploy And Signing Keys
 
-For the Docker production image, place secrets in the expected paths:
+For the Compose deployment, place the runtime secret sources in the expected
+host paths:
 
 ```bash
 mkdir -p secrets/deploy_key secrets/gpg_bot_key
@@ -132,22 +133,30 @@ install -m 600 /path/to/bot_secret_key.asc secrets/gpg_bot_key/bot_secret_key.as
 Add the deploy key public half to the target fork with write access. Make sure
 the GPG key identity matches `GIT_AUTHOR_EMAIL`.
 
+Compose mounts these files read-only at `/run/secrets/deploy_key` and
+`/run/secrets/gpg_bot_key` when the container starts. The entrypoint then
+installs/imports them for the unprivileged runtime user. The private keys are
+not build inputs and are not stored in image layers.
+
 ## 5. Build
 
 ```bash
 docker compose --env-file docker/.env -f docker/docker-compose.yml build
 ```
 
-BuildKit mounts the deploy and GPG keys as build secrets. They are used during
-the build and are not copied into image layers.
+The image build does not read the deploy key, signing key, or project profiles.
+Compose supplies the keys as runtime secrets and bind-mounts the selected
+profile's config and glossary read-only when `translator` runs.
 
 ## 6. Validate The Container
 
-Run a low-risk format/config check:
+Run a low-risk CLI and format-registry smoke check without invoking the
+repository-managing entrypoint:
 
 ```bash
-docker compose --env-file docker/.env -f docker/docker-compose.yml run -T --rm translator \
-  python -m localize.cli formats
+docker compose --env-file docker/.env -f docker/docker-compose.yml run -T --rm \
+  --no-deps --entrypoint python3.11 translator \
+  -m localize.cli formats
 ```
 
 Then run the full pipeline manually:
@@ -201,8 +210,9 @@ More detail: [docs/maintenance/disk-space-management.md](maintenance/disk-space-
 ## Operational Checks
 
 - `git status` in the pipeline repo should be clean before deploys.
-- Rebuild after changes to `localize/`, `requirements.txt`, Docker files, or
-  profile files.
+- Rebuild after changes to `localize/`, `requirements.txt`, or Docker files.
+- Profile config and glossary changes are bind-mounted and take effect on the
+  next container run without rebuilding the image.
 - Run a manual `docker compose ... run -T --rm translator` after rebuilds.
 - Keep deploy keys and tokens scoped to the target repository.
 - Rotate keys periodically.

--- a/tests/unit/test_docker_runtime_secrets.py
+++ b/tests/unit/test_docker_runtime_secrets.py
@@ -11,6 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = PROJECT_ROOT / "docker" / "Dockerfile"
 COMPOSE_FILE = PROJECT_ROOT / "docker" / "docker-compose.yml"
 ENTRYPOINT = PROJECT_ROOT / "docker" / "docker-entrypoint.sh"
+DOCKERIGNORE = PROJECT_ROOT / ".dockerignore"
+BUILD_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "build-verify.yml"
 
 
 def _dockerfile() -> str:
@@ -69,6 +71,44 @@ def test_compose_mounts_private_keys_only_as_runtime_secrets():
         compose["secrets"]["deploy_key"]["file"]
         == "${DEPLOY_KEY_FILE:-../secrets/deploy_key/id_ed25519}"
     )
+
+
+def test_project_profiles_stay_out_of_the_image_and_mount_read_only_at_runtime():
+    ignore_patterns = {
+        line.strip()
+        for line in DOCKERIGNORE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    compose = _compose()
+    mounts = [
+        mount
+        for mount in compose["services"]["translator"]["volumes"]
+        if isinstance(mount, dict)
+    ]
+    profile_mounts = {
+        mount["target"]: mount
+        for mount in mounts
+        if str(mount.get("source", "")).startswith("../profiles/")
+    }
+
+    assert "profiles/" in ignore_patterns
+    assert set(profile_mounts) == {"/app/config.yaml", "/app/glossary.json"}
+    assert all(mount.get("read_only") is True for mount in profile_mounts.values())
+    assert all(
+        mount.get("bind", {}).get("create_host_path") is False
+        for mount in profile_mounts.values()
+    )
+
+
+def test_ci_image_build_does_not_stage_runtime_credentials():
+    workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Create dummy secret files" not in workflow
+    assert "secrets/gpg_bot_key" not in workflow
+    assert "DUMMY_KEY" not in workflow
+    assert "SKIP_GPG_IMPORT=true" not in workflow
+    assert "SKIP_DEPLOY_KEY=true" not in workflow
+    assert "GPG_KEY_FINGERPRINT_FOR_TRUST" not in workflow
 
 
 def test_entrypoint_installs_runtime_ssh_and_gpg_secrets():

--- a/tests/unit/test_docker_runtime_secrets.py
+++ b/tests/unit/test_docker_runtime_secrets.py
@@ -16,18 +16,22 @@ BUILD_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "build-verify.yml"
 
 
 def _dockerfile() -> str:
+    """Read the production Dockerfile."""
     return DOCKERFILE.read_text(encoding="utf-8")
 
 
 def _compose() -> dict:
+    """Load the production Compose model."""
     return yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
 
 
 def _entrypoint() -> str:
+    """Read the production container entrypoint."""
     return ENTRYPOINT.read_text(encoding="utf-8")
 
 
 def test_dockerfile_does_not_handle_private_keys_at_build_time():
+    """Prevent private-key operations from returning to image builds."""
     dockerfile = _dockerfile()
 
     assert "id=gpg_bot_key" not in dockerfile
@@ -39,6 +43,7 @@ def test_dockerfile_does_not_handle_private_keys_at_build_time():
 
 
 def test_compose_mounts_private_keys_only_as_runtime_secrets():
+    """Require exact read-only runtime key mounts and host sources."""
     compose = _compose()
     translator = compose["services"]["translator"]
     build = translator.get("build", {})
@@ -74,6 +79,7 @@ def test_compose_mounts_private_keys_only_as_runtime_secrets():
 
 
 def test_project_profiles_stay_out_of_the_image_and_mount_read_only_at_runtime():
+    """Keep project profiles out of layers and bind-mount them read-only."""
     ignore_patterns = {
         line.strip()
         for line in DOCKERIGNORE.read_text(encoding="utf-8").splitlines()
@@ -101,6 +107,7 @@ def test_project_profiles_stay_out_of_the_image_and_mount_read_only_at_runtime()
 
 
 def test_ci_image_build_does_not_stage_runtime_credentials():
+    """Prevent CI from staging dummy credentials into the build context."""
     workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
 
     assert "Create dummy secret files" not in workflow
@@ -112,6 +119,7 @@ def test_ci_image_build_does_not_stage_runtime_credentials():
 
 
 def test_entrypoint_installs_runtime_ssh_and_gpg_secrets():
+    """Require entrypoint installation of runtime SSH and GPG secrets."""
     entrypoint = _entrypoint()
 
     assert 'DEPLOY_KEY_PATH:-/run/secrets/deploy_key' in entrypoint
@@ -132,6 +140,7 @@ def test_entrypoint_installs_runtime_ssh_and_gpg_secrets():
 
 
 def test_entrypoint_reuses_runtime_secrets_after_privilege_drop():
+    """Require the unprivileged re-entry path to reuse installed secrets."""
     entrypoint = _entrypoint()
 
     assert 'if [ -s "$user_home/.ssh/deploy_key" ]; then' in entrypoint

--- a/tests/unit/test_operator_docs.py
+++ b/tests/unit/test_operator_docs.py
@@ -12,6 +12,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _read(relative_path: str) -> str:
+    """Read one repository file as UTF-8 text."""
     return (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
 
 
@@ -27,6 +28,7 @@ def _markdown_section(document: str, heading: str) -> str:
 
 
 def test_environment_reference_tracks_the_runtime_pr_batch_default():
+    """Keep the documented PR batch default equal to the shell default."""
     script = _read("update-translations.sh")
     reference = _read("docs/environment-variables.md")
 
@@ -45,11 +47,31 @@ def test_environment_reference_tracks_the_runtime_pr_batch_default():
 
 
 def test_server_guide_describes_compose_keys_as_runtime_secrets():
+    """Pin the documented and deployed Compose runtime-secret contract."""
     guide = _read("docs/new-project-deployment.md")
     compose = yaml.safe_load(_read("docker/docker-compose.yml"))
     translator = compose["services"]["translator"]
 
-    assert translator.get("secrets")
+    assert translator["secrets"] == [
+        {
+            "source": "gpg_bot_key",
+            "target": "gpg_bot_key",
+            "mode": 0o400,
+        },
+        {
+            "source": "deploy_key",
+            "target": "deploy_key",
+            "mode": 0o400,
+        },
+    ]
+    assert compose["secrets"] == {
+        "gpg_bot_key": {
+            "file": "${GPG_BOT_KEY_FILE:-../secrets/gpg_bot_key/bot_secret_key.asc}"
+        },
+        "deploy_key": {
+            "file": "${DEPLOY_KEY_FILE:-../secrets/deploy_key/id_ed25519}"
+        },
+    }
     assert "secrets" not in translator.get("build", {})
     assert "runtime secret" in guide.lower()
     assert "build secret" not in guide.lower()
@@ -57,6 +79,7 @@ def test_server_guide_describes_compose_keys_as_runtime_secrets():
 
 
 def test_server_guide_smokes_the_cli_without_running_the_repository_entrypoint():
+    """Require the server smoke check to bypass the production entrypoint."""
     guide = _read("docs/new-project-deployment.md")
 
     assert "--no-deps --entrypoint python3.11 translator" in guide
@@ -65,6 +88,7 @@ def test_server_guide_smokes_the_cli_without_running_the_repository_entrypoint()
 
 
 def test_local_docker_guide_uses_the_root_safe_compose_command_and_runtime_keys():
+    """Keep local commands rooted correctly and runtime-secret-aware."""
     guide = _read("docs/how-to-run-locally.md")
     canonical_compose_prefix = (
         "docker compose --env-file docker/.env -f docker/docker-compose.yml"
@@ -77,6 +101,7 @@ def test_local_docker_guide_uses_the_root_safe_compose_command_and_runtime_keys(
 
 
 def test_cron_template_uses_the_same_explicit_root_compose_command():
+    """Keep the cron template aligned with the root-level Compose command."""
     cron = _read("docker/translator-cron")
     canonical_run = (
         "/usr/bin/docker compose --env-file docker/.env "
@@ -89,6 +114,7 @@ def test_cron_template_uses_the_same_explicit_root_compose_command():
 
 
 def test_profile_edits_do_not_require_an_image_rebuild():
+    """Document that bind-mounted profile edits take effect without a rebuild."""
     guide = _read("docs/new-project-deployment.md")
     checks = _markdown_section(guide, "## Operational Checks")
     rebuild_bullet = next(
@@ -100,6 +126,7 @@ def test_profile_edits_do_not_require_an_image_rebuild():
 
 
 def test_security_strategy_matches_host_cron_and_runtime_secret_boundaries():
+    """Keep the security guide aligned with the deployed runtime boundaries."""
     strategy = _read("SECURITY_STRATEGY.md")
     server = _markdown_section(strategy, "## 1. Server Deployment Security")
     local = _markdown_section(strategy, "## 2. Local Development Security")

--- a/tests/unit/test_operator_docs.py
+++ b/tests/unit/test_operator_docs.py
@@ -1,0 +1,114 @@
+"""Keep operator documentation aligned with the deployed shell and Compose paths."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _markdown_section(document: str, heading: str) -> str:
+    """Return one level-two Markdown section without depending on its prose."""
+    match = re.search(
+        rf"^{re.escape(heading)}\s*$\n(?P<body>.*?)(?=^##\s|\Z)",
+        document,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"missing documentation section: {heading}"
+    return match.group("body")
+
+
+def test_environment_reference_tracks_the_runtime_pr_batch_default():
+    script = _read("update-translations.sh")
+    reference = _read("docs/environment-variables.md")
+
+    runtime_match = re.search(
+        r"^DEFAULT_MAX_FILES_PER_PR=(\d+)$", script, flags=re.MULTILINE
+    )
+    reference_match = re.search(
+        r"^\| `MAX_FILES_PER_PR` \|.*?defaults to `(\d+)`\. \|$",
+        reference,
+        flags=re.MULTILINE,
+    )
+
+    assert runtime_match is not None
+    assert reference_match is not None
+    assert reference_match.group(1) == runtime_match.group(1)
+
+
+def test_server_guide_describes_compose_keys_as_runtime_secrets():
+    guide = _read("docs/new-project-deployment.md")
+    compose = yaml.safe_load(_read("docker/docker-compose.yml"))
+    translator = compose["services"]["translator"]
+
+    assert translator.get("secrets")
+    assert "secrets" not in translator.get("build", {})
+    assert "runtime secret" in guide.lower()
+    assert "build secret" not in guide.lower()
+    assert "/run/secrets/" in guide
+
+
+def test_server_guide_smokes_the_cli_without_running_the_repository_entrypoint():
+    guide = _read("docs/new-project-deployment.md")
+
+    assert "--no-deps --entrypoint python3.11 translator" in guide
+    assert "-m localize.cli formats" in guide
+    assert "format/config check" not in guide
+
+
+def test_local_docker_guide_uses_the_root_safe_compose_command_and_runtime_keys():
+    guide = _read("docs/how-to-run-locally.md")
+    canonical_compose_prefix = (
+        "docker compose --env-file docker/.env -f docker/docker-compose.yml"
+    )
+
+    assert f"{canonical_compose_prefix} build" in guide
+    assert f"{canonical_compose_prefix} run -T --rm translator" in guide
+    assert "runtime secret" in guide.lower()
+    assert "baked-in" not in guide.lower()
+
+
+def test_cron_template_uses_the_same_explicit_root_compose_command():
+    cron = _read("docker/translator-cron")
+    canonical_run = (
+        "/usr/bin/docker compose --env-file docker/.env "
+        "-f docker/docker-compose.yml run -T --rm translator"
+    )
+
+    assert "cd /path/to/your/project && mkdir -p logs &&" in cron
+    assert canonical_run in cron
+    assert "cd /path/to/your/project/docker" not in cron
+
+
+def test_profile_edits_do_not_require_an_image_rebuild():
+    guide = _read("docs/new-project-deployment.md")
+    checks = _markdown_section(guide, "## Operational Checks")
+    rebuild_bullet = next(
+        line for line in checks.splitlines() if line.startswith("- Rebuild after")
+    )
+
+    assert "profile" not in rebuild_bullet.lower()
+    assert "without rebuilding the image" in checks
+
+
+def test_security_strategy_matches_host_cron_and_runtime_secret_boundaries():
+    strategy = _read("SECURITY_STRATEGY.md")
+    server = _markdown_section(strategy, "## 1. Server Deployment Security")
+    local = _markdown_section(strategy, "## 2. Local Development Security")
+
+    assert "host-level cron" in server.lower()
+    assert "runtime secret" in server.lower()
+    assert "/etc/environment" not in strategy
+    assert "All secrets" not in strategy
+    assert "Private deploy and signing keys remain separate host files" in strategy
+    assert "docker-compose.override" not in local
+    assert "**SSH Agent Forwarding**" not in local
+    assert "runtime secret" in local.lower()


### PR DESCRIPTION
## Summary

- document deploy and signing keys as Compose runtime secrets, not Docker build inputs
- exclude project profiles from image layers and retain read-only runtime profile mounts
- align the documented PR batch default, local/cron Compose commands, and safe CLI smoke check
- remove obsolete CI dummy credentials and unused secret-related Docker build arguments
- add behavior-linked regression tests for the operator-facing contracts

## Why

A final v0.1.20 release audit found several pre-existing deployment statements
that no longer matched the runtime. In particular, the guides described
build-time keys and an in-container cron even though Compose mounts keys only
at runtime and scheduling happens on the host. The CI workflow repeated the
obsolete model by manufacturing ignored credential files that the Docker build
never consumed.

Keeping `profiles/` out of the build context also ensures ignored/private
operator profiles cannot enter a locally built image. The supported Compose
path already bind-mounts the selected config and glossary read-only.

## Verification

- all 9 new regression behaviors fail against the untouched base and pass here
- 94 related tests passed
- full suite: 1,438 passed, 1 skipped
- Ruff passed
- workflow and Compose YAML parsed successfully
- `git diff --check` passed

The signed `v0.1.20` tag remains intentionally unpublished until this PR is
reviewed and merged and fresh `main` CI, Docker, and Trivy checks pass on the
resulting merge commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Project profiles are excluded from Docker images and mounted read-only at runtime.
  * Deployment and signing keys are provided as runtime-only secrets, keeping them out of image layers.
  * Improved credential handling for local and server environments.

* **Documentation**
  * Updated local development and deployment guides to reflect runtime secret mounts and current Compose commands.
  * Clarified when image rebuilds are required.
  * Updated the default maximum files per pull request from 150 to 90.

* **Operations**
  * Updated scheduled translation commands for safer, root-compatible Compose execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->