### PR TITLE
Prevent recurrence: Add validation to prevent non-English locale targets from being replaced with the English source te…

### DIFF
--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -1321,6 +1321,7 @@ def run_per_key_validation_with_summary(
         ignore_key_patterns: Optional[List[Pattern[str]]] = None,
         translation_glossary: Optional[Mapping[str, str]] = None,
         existing_translations: Optional[Mapping[str, str]] = None,
+        file_ledger_entries: Optional[Mapping[str, Mapping[str, str]]] = None,
 ) -> Tuple[Dict[str, str], Dict[str, object]]:
     """
     Validates each translation key individually and selectively reverts failed keys.
@@ -1336,6 +1337,8 @@ def run_per_key_validation_with_summary(
         filename: Name of the file being validated (for logging)
         existing_translations: Original target values, used to preserve a
             localized value when generated output falls back to the source.
+        file_ledger_entries: Baseline hashes proving that both the source and
+            previous target are unchanged.
 
     Returns:
         Tuple containing:
@@ -1368,24 +1371,27 @@ def run_per_key_validation_with_summary(
             )
             valid_translations[key] = source_value
             continue
-        existing_value = existing_translations.get(key)
+        existing_value = _ledger_verified_existing_translation(
+            key, source_translations, existing_translations, file_ledger_entries or {}
+        )
+        original_value = existing_translations.get(key)
         if (
                 source_value.strip()
                 and normalize_value(source_value) == normalize_value(target_value)
-                and isinstance(existing_value, str)
-                and existing_value.strip()
-                and normalize_value(existing_value) != normalize_value(source_value)
+                and isinstance(original_value, str)
+                and original_value.strip()
+                and normalize_value(original_value) != normalize_value(source_value)
         ):
             failed_keys.append(key)
             source_identical_keys.append(key)
             logger.warning(
-                "Key '%s' failed validation in '%s' - preserving the existing target "
-                "because the generated value matches the source.",
+                "Key '%s' failed validation in '%s' - generated value matches the "
+                "source; only a ledger-verified target may be reused after validation.",
                 key,
                 filename,
             )
-            valid_translations[key] = existing_value
-            continue
+            if existing_value is not None:
+                target_value = existing_value
         control_character_findings = find_disallowed_control_characters(target_value)
 
         if control_character_findings:
@@ -1445,11 +1451,13 @@ def run_per_key_validation_with_summary(
             # Use source value for this failed key
             valid_translations[key] = source_value
 
+    # A rejected source echo and an invalid fallback can flag the same key.
+    failed_keys = list(dict.fromkeys(failed_keys))
     # Log summary if any keys failed
     if failed_keys:
         logger.warning(
             f"Validation failed for {len(failed_keys)} out of {len(final_translations)} keys in '{filename}'. "
-            f"Failed keys reverted to source: {', '.join(failed_keys[:5])}"
+            f"Failed keys retained a validated baseline or reverted to source: {', '.join(failed_keys[:5])}"
             f"{' ...' if len(failed_keys) > 5 else ''}"
         )
         logger.info(
@@ -3042,6 +3050,7 @@ async def process_translation_queue(
                 ignore_key_patterns=IGNORE_KEY_PATTERNS,
                 translation_glossary=enforced_language_glossary,
                 existing_translations=original_target_translations,
+                file_ledger_entries=file_ledger_entries,
             )
             failed_keys = set(per_key_summary["failed_keys"]).union(model_failed_keys)
             increment_run_metric(run_metrics, "model_translation_failed_count", len(failed_keys))

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -1322,6 +1322,7 @@ def run_per_key_validation_with_summary(
         translation_glossary: Optional[Mapping[str, str]] = None,
         existing_translations: Optional[Mapping[str, str]] = None,
         file_ledger_entries: Optional[Mapping[str, Mapping[str, str]]] = None,
+        selected_keys: Optional[Set[str]] = None,
 ) -> Tuple[Dict[str, str], Dict[str, object]]:
     """
     Validates each translation key individually and selectively reverts failed keys.
@@ -1339,6 +1340,8 @@ def run_per_key_validation_with_summary(
             localized value when generated output falls back to the source.
         file_ledger_entries: Baseline hashes proving that both the source and
             previous target are unchanged.
+        selected_keys: Keys translated in this run. Source echoes for these
+            keys stay failed even if the original target was also the source.
 
     Returns:
         Tuple containing:
@@ -1355,6 +1358,7 @@ def run_per_key_validation_with_summary(
     ignore_key_patterns = ignore_key_patterns or []
     translation_glossary = translation_glossary or {}
     existing_translations = existing_translations or {}
+    selected_keys = selected_keys or set()
 
     for key, target_value in final_translations.items():
         source_value = source_translations.get(key, "")
@@ -1378,9 +1382,14 @@ def run_per_key_validation_with_summary(
         if (
                 source_value.strip()
                 and normalize_value(source_value) == normalize_value(target_value)
-                and isinstance(original_value, str)
-                and original_value.strip()
-                and normalize_value(original_value) != normalize_value(source_value)
+                and (
+                    key in selected_keys
+                    or (
+                        isinstance(original_value, str)
+                        and original_value.strip()
+                        and normalize_value(original_value) != normalize_value(source_value)
+                    )
+                )
         ):
             failed_keys.append(key)
             source_identical_keys.append(key)
@@ -3051,6 +3060,7 @@ async def process_translation_queue(
                 translation_glossary=enforced_language_glossary,
                 existing_translations=original_target_translations,
                 file_ledger_entries=file_ledger_entries,
+                selected_keys=set(keys_to_translate),
             )
             failed_keys = set(per_key_summary["failed_keys"]).union(model_failed_keys)
             increment_run_metric(run_metrics, "model_translation_failed_count", len(failed_keys))

--- a/localize/translate_localization_files.py
+++ b/localize/translate_localization_files.py
@@ -1320,6 +1320,7 @@ def run_per_key_validation_with_summary(
         filename: str,
         ignore_key_patterns: Optional[List[Pattern[str]]] = None,
         translation_glossary: Optional[Mapping[str, str]] = None,
+        existing_translations: Optional[Mapping[str, str]] = None,
 ) -> Tuple[Dict[str, str], Dict[str, object]]:
     """
     Validates each translation key individually and selectively reverts failed keys.
@@ -1333,6 +1334,8 @@ def run_per_key_validation_with_summary(
         final_translations: Dictionary of translated key-value pairs to validate
         source_translations: Dictionary of source (English) key-value pairs
         filename: Name of the file being validated (for logging)
+        existing_translations: Original target values, used to preserve a
+            localized value when generated output falls back to the source.
 
     Returns:
         Tuple containing:
@@ -1345,8 +1348,10 @@ def run_per_key_validation_with_summary(
     placeholder_mismatch_keys = []
     empty_target_keys = []
     glossary_mismatch_keys = []
+    source_identical_keys = []
     ignore_key_patterns = ignore_key_patterns or []
     translation_glossary = translation_glossary or {}
+    existing_translations = existing_translations or {}
 
     for key, target_value in final_translations.items():
         source_value = source_translations.get(key, "")
@@ -1362,6 +1367,24 @@ def run_per_key_validation_with_summary(
                 f"  Source: {source_value}"
             )
             valid_translations[key] = source_value
+            continue
+        existing_value = existing_translations.get(key)
+        if (
+                source_value.strip()
+                and normalize_value(source_value) == normalize_value(target_value)
+                and isinstance(existing_value, str)
+                and existing_value.strip()
+                and normalize_value(existing_value) != normalize_value(source_value)
+        ):
+            failed_keys.append(key)
+            source_identical_keys.append(key)
+            logger.warning(
+                "Key '%s' failed validation in '%s' - preserving the existing target "
+                "because the generated value matches the source.",
+                key,
+                filename,
+            )
+            valid_translations[key] = existing_value
             continue
         control_character_findings = find_disallowed_control_characters(target_value)
 
@@ -1441,11 +1464,13 @@ def run_per_key_validation_with_summary(
         "placeholder_mismatch_keys": placeholder_mismatch_keys,
         "empty_target_keys": empty_target_keys,
         "glossary_mismatch_keys": glossary_mismatch_keys,
+        "source_identical_keys": source_identical_keys,
         "reverted_keys_count": len(failed_keys),
         "control_character_findings_count": len(control_character_keys),
         "placeholder_failures_count": len(placeholder_mismatch_keys),
         "empty_target_failures_count": len(empty_target_keys),
         "glossary_failures_count": len(glossary_mismatch_keys),
+        "source_identical_failures_count": len(source_identical_keys),
     }
     return valid_translations, summary
 
@@ -3016,6 +3041,7 @@ async def process_translation_queue(
                 translation_file,
                 ignore_key_patterns=IGNORE_KEY_PATTERNS,
                 translation_glossary=enforced_language_glossary,
+                existing_translations=original_target_translations,
             )
             failed_keys = set(per_key_summary["failed_keys"]).union(model_failed_keys)
             increment_run_metric(run_metrics, "model_translation_failed_count", len(failed_keys))

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -481,6 +481,7 @@ async def test_failed_model_translation_preserves_ledger_verified_target(
         ("Open {0}", "Öffnen {0}", "Öffnen {0}"),
         ("Close {0}", "Schließen {0}", "Open {0}"),
         ("Open {0}", "Öffnen {1}", "Open {0}"),
+        ("Open {0}", "Open {0}", "Open {0}"),
     ],
 )
 async def test_source_echo_preserves_only_valid_current_source_baseline(

--- a/tests/integration/test_translate_localization_files.py
+++ b/tests/integration/test_translate_localization_files.py
@@ -475,6 +475,63 @@ async def test_failed_model_translation_preserves_ledger_verified_target(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "previous_source,existing_value,expected_value",
+    [
+        ("Open {0}", "Öffnen {0}", "Öffnen {0}"),
+        ("Close {0}", "Schließen {0}", "Open {0}"),
+        ("Open {0}", "Öffnen {1}", "Open {0}"),
+    ],
+)
+async def test_source_echo_preserves_only_valid_current_source_baseline(
+    integration_test_environment, previous_source, existing_value, expected_value,
+):
+    """Echoes stay failed; only fresh, placeholder-safe old text reaches output."""
+    env = integration_test_environment
+    pipeline = localize.translate_localization_files
+    source_value = "Open {0}"
+    source_path = os.path.join(env['input_folder'], 'app.properties')
+    target_path = os.path.join(env['translation_queue_folder'], 'app_de.properties')
+    ledger_path = os.path.join(env['input_folder'], 'echo-ledger.json')
+    memory_path = os.path.join(env['input_folder'], 'echo-memory.json')
+    with open(source_path, 'w', encoding='utf-8') as stream:
+        stream.write(f"key.open={source_value}\n")
+    with open(target_path, 'w', encoding='utf-8') as stream:
+        stream.write(f"key.open={existing_value}\n")
+    pipeline.save_translation_key_ledger(ledger_path, {
+        "app_de.properties": pipeline.build_file_key_ledger(
+            {"key.open": previous_source}, {"key.open": existing_value},
+            failed_keys={"key.open"},
+        ),
+    })
+    summary = {}
+    with patch.object(pipeline, 'TRANSLATION_KEY_LEDGER_FILE_PATH', ledger_path), \
+         patch.object(pipeline, 'TRANSLATION_MEMORY_ENABLED', True), \
+         patch.object(pipeline, 'TRANSLATION_MEMORY_FILE_PATH', memory_path), \
+         patch.object(pipeline, 'get_working_tree_changed_keys', return_value=set()), \
+         patch.object(pipeline, 'translate_text_async', new_callable=AsyncMock) as translate, \
+         patch.object(pipeline, 'holistic_review_async', new_callable=AsyncMock) as review:
+        translate.return_value = (0, source_value, True)
+        review.return_value = {"key.open": source_value}
+        await pipeline.process_translation_queue(
+            env['translation_queue_folder'], env['translated_queue_folder'],
+            env['mock_glossary_path_resolved'], validation_summary=summary,
+        )
+    _, output = parse_properties_file(os.path.join(
+        env['translated_queue_folder'], 'app_de.properties'
+    ))
+    assert output["key.open"] == expected_value
+    assert summary["app_de.properties"]["source_identical_keys"] == ["key.open"]
+    assert summary["app_de.properties"]["reverted_keys_count"] == 1
+    ledger = pipeline.load_translation_key_ledger(ledger_path)
+    assert ledger["app_de.properties"]["key.open"]["status"] == "failed"
+    memory = load_translation_memory(memory_path)
+    assert memory.lookup(
+        source_value, locale="de", format_id=JAVA_PROPERTIES_FORMAT.id,
+    ) is None
+
+
+@pytest.mark.asyncio
 async def test_failed_holistic_review_marks_keys_failed(integration_test_environment):
     """A draft is not a successful two-pass translation when review failed."""
     env = integration_test_environment

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -874,6 +874,18 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(valid["key.one"], "Source text")
         self.assertEqual(summary["empty_target_keys"], ["key.one"])
 
+    def test_per_key_validation_preserves_existing_target_when_generated_value_matches_source(self):
+        valid, summary = run_per_key_validation_with_summary(
+            {"key.one": "Open trade chat"},
+            {"key.one": "Open trade chat"},
+            "de.properties",
+            existing_translations={"key.one": "Handels-Chat öffnen"},
+        )
+
+        self.assertEqual(valid["key.one"], "Handels-Chat öffnen")
+        self.assertEqual(summary["source_identical_keys"], ["key.one"])
+        self.assertEqual(summary["source_identical_failures_count"], 1)
+
 
 class TestSourceFilenameExtraction(unittest.TestCase):
     """Tests for extracting source filename from translated filename."""

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -20,6 +20,7 @@ from localize.translate_localization_files import (
     normalize_value,
     prefer_existing_translation_on_failure,
     compute_ledger_hash,
+    build_file_key_ledger,
     extract_texts_to_translate,
     filter_git_changed_keys_by_source,
     get_working_tree_changed_keys,
@@ -875,16 +876,65 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(summary["empty_target_keys"], ["key.one"])
 
     def test_per_key_validation_preserves_existing_target_when_generated_value_matches_source(self):
+        """A matching baseline can retain validated localized text."""
         valid, summary = run_per_key_validation_with_summary(
             {"key.one": "Open trade chat"},
             {"key.one": "Open trade chat"},
             "de.properties",
             existing_translations={"key.one": "Handels-Chat öffnen"},
+            file_ledger_entries=build_file_key_ledger(
+                {"key.one": "Open trade chat"},
+                {"key.one": "Handels-Chat öffnen"},
+            ),
         )
 
         self.assertEqual(valid["key.one"], "Handels-Chat öffnen")
         self.assertEqual(summary["source_identical_keys"], ["key.one"])
         self.assertEqual(summary["source_identical_failures_count"], 1)
+
+    def test_source_echo_does_not_restore_unverified_old_meaning(self):
+        """An old number must not override the current English source."""
+        valid, summary = run_per_key_validation_with_summary(
+            {"key": "Wait 14 days"}, {"key": "Wait 14 days"}, "de.properties",
+            existing_translations={"key": "Warten Sie 7 Tage"},
+        )
+        self.assertEqual(valid["key"], "Wait 14 days")
+        self.assertEqual(summary["failed_keys"], ["key"])
+
+    def test_source_echo_requires_matching_source_and_target_baseline(self):
+        """Changed sources and edited targets cannot reuse an old baseline."""
+        source = {"key": "Wait 14 days"}
+        existing = {"key": "Warten Sie 7 Tage"}
+        for ledger in (
+            build_file_key_ledger({"key": "Wait 7 days"}, existing),
+            build_file_key_ledger(source, {"key": "Anderer Text"}),
+        ):
+            with self.subTest(ledger=ledger):
+                valid, _ = run_per_key_validation_with_summary(
+                    source, source, "de.properties", existing_translations=existing,
+                    file_ledger_entries=ledger,
+                )
+                self.assertEqual(valid, source)
+
+    def test_source_echo_fallback_still_checks_placeholders_controls_and_glossary(self):
+        """A matching baseline does not exempt old text from current validation."""
+        cases = (
+            ("Open {0}", "Öffnen {1}", {}, "placeholder_mismatch_keys"),
+            ("Open chat", "Chat\x00 öffnen", {}, "control_character_keys"),
+            ("Open account", "Konto öffnen", {"account": "Account"}, "glossary_mismatch_keys"),
+        )
+        for source_text, old_text, glossary, failure_category in cases:
+            with self.subTest(category=failure_category):
+                source, existing = {"key": source_text}, {"key": old_text}
+                valid, summary = run_per_key_validation_with_summary(
+                    source, source, "de.properties", existing_translations=existing,
+                    file_ledger_entries=build_file_key_ledger(source, existing),
+                    translation_glossary=glossary,
+                )
+                self.assertEqual(valid, source)
+                self.assertEqual(summary[failure_category], ["key"])
+                self.assertEqual(summary["failed_keys"], ["key"])
+                self.assertEqual(summary["reverted_keys_count"], 1)
 
 
 class TestSourceFilenameExtraction(unittest.TestCase):

--- a/tests/unit/test_core_logic.py
+++ b/tests/unit/test_core_logic.py
@@ -901,6 +901,25 @@ class TestRetryHandling(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(valid["key"], "Wait 14 days")
         self.assertEqual(summary["failed_keys"], ["key"])
 
+    def test_selected_source_echo_stays_failed_when_old_target_is_also_source(self):
+        """Selected untranslated keys must remain retryable after a model echo."""
+        source = {"key": "Open trade chat"}
+        valid, summary = run_per_key_validation_with_summary(
+            source, source, "de.properties", existing_translations=source,
+            selected_keys={"key"},
+        )
+        self.assertEqual(valid, source)
+        self.assertEqual(summary["failed_keys"], ["key"])
+
+    def test_unselected_source_identical_values_are_not_new_failures(self):
+        """Whole-file validation must not mark untouched keys as new failures."""
+        source = {"key": "Bisq"}
+        _, summary = run_per_key_validation_with_summary(
+            source, source, "de.properties", existing_translations=source,
+            selected_keys=set(),
+        )
+        self.assertEqual(summary["failed_keys"], [])
+
     def test_source_echo_requires_matching_source_and_target_baseline(self):
         """Changed sources and edited targets cannot reuse an old baseline."""
         source = {"key": "Wait 14 days"}


### PR DESCRIPTION
<!-- localize-guardian-prevention:v1 evidence=7e8b1e0c8e6a4ac8e5a67208c6f3c8d11e7f8457772ccb0a3390ecf0bbbfcfea candidate=9fec0b51850b6e5abd82cccf9af96930ef0cc353 -->
## Localize Guardian prevention draft

Root cause: <code>Add validation to prevent non-English locale targets from being replaced with the English source text.</code>

Evidence fingerprint: <code>7e8b1e0c8e6a4ac8e5a67208c6f3c8d11e7f8457772ccb0a3390ecf0bbbfcfea</code>

### Review evidence

- <code>review_comment:3964942484:revision-24</code>
- <code>review_comment:3964942506:revision-28</code>
- <code>review_comment:3964942542:revision-32</code>
- <code>review_comment:3964942549:revision-34</code>

### Bounded patch

Base: <code>4e2155bc9518a7dfae84263107f0459d5a45bad8</code>

Candidate direct child: <code>9fec0b51850b6e5abd82cccf9af96930ef0cc353</code>

Patch fingerprint: <code>d87f449537e457ebafc9e75aeb0d0b73dc6b79710f637bf61d40895a25de925b</code>

- <code>localize/translate_localization_files.py</code>
- <code>tests/unit/test_core_logic.py</code>

### Regression proof supplied by the controller

The same focused argv failed on the exact base and passed on its direct child:

- <code>&#91;&quot;pytest&quot;, &quot;-q&quot;, &quot;-p&quot;, &quot;no:cacheprovider&quot;, &quot;--basetemp=.guardian-pytest-tmp&quot;, &quot;--ignore=tests/unit/test_bootstrap_pr.py&quot;, &quot;--ignore-glob=tests/unit/test_guardian_*.py&quot;, &quot;--ignore=tests/unit/test_update_translations_script.py&quot;, &quot;tests/unit&quot;&#93;</code>

Publication of this draft requires a separate broker to re-verify current state and publish only this signed candidate. The Guardian cannot merge or deploy prevention drafts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved translation validation when generated text matches the source text.
  - Preserves an existing localized translation only when it is verified as current and valid.
  - Prevents outdated or unverified translations from being restored.
  - Continues enforcing placeholder, control-character, and glossary checks.
  - Improves failure reporting for source-identical translations and avoids duplicate failure entries.

- **Tests**
  - Added coverage for valid baseline reuse, invalid baseline rejection, and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->