### PR TITLE
Batch Guardian corrections and assess recurrence

### DIFF
--- a/docs/guardian.md
+++ b/docs/guardian.md
@@ -108,6 +108,33 @@ fails closed and is reconsidered on a later run. The separate, opt-in prevention
 author may change executable pipeline code only within its explicit code/test
 allowlists and the additional controls described below.
 
+Oversized open-PR correction proposals are applied in bounded batches, never by
+raising `max_value_edits_per_run`. Each run publishes at most that many eligible
+value edits; a later poll reassesses the remainder against the fresh PR head.
+This also supports a single review comment requesting more edits than the cap.
+Partially corrected and wholly deferred comments remain pending, including after
+publication-reply recovery. Duplicate targets still reject the proposal before
+batch selection; all selected edits retain the normal validation and signing gates.
+A zero edit limit disables edits without repeatedly retrying unchanged policy.
+
+Poll outcomes and the latest Guardian health record expose `deferred_value_edits`,
+`deferred_feedback_items`, and `translation_policy_rejections` separately from
+failed runs. A successful bounded poll does not mean every correction is finished.
+Audit rows use `translation_batch_deferred` with the actual changed/deferred counts
+and published commit where applicable. State schema 11 prevents older runtimes
+from silently treating these skipped-but-pending rows as resolved. Back up the
+idle database before upgrading; do not downgrade a schema-11 database.
+
+Assessment explicitly considers recurring failures, including untranslated
+source-identical text and lost safety warnings, as well as individual corrections.
+Candidates must cite trusted feedback and describe a possible regression test;
+the prevention author must verify any hypothesized root cause against current
+pipeline code. Empty candidate lists require an explanation in the assessment
+summary. This is model assessment, not a guarantee that every systemic defect
+will be detected. Project-specific terminology remains distinct from generic
+pipeline fixes; legitimate source-identical brand or shared-language terms must
+not be changed merely to make them different.
+
 ### Reviewer authorization
 
 Trust is set per repository and locale. Put native human reviewers under

--- a/docs/guardian.md
+++ b/docs/guardian.md
@@ -116,6 +116,10 @@ Partially corrected and wholly deferred comments remain pending, including after
 publication-reply recovery. Duplicate targets still reject the proposal before
 batch selection; all selected edits retain the normal validation and signing gates.
 A zero edit limit disables edits without repeatedly retrying unchanged policy.
+Progressive batching applies only to `apply-owned-translations` and
+`propose-prevention`. `prepare` retains no patch or changed head, so it keeps its
+single-pass bounded validation: an oversized proposal is rejected once under
+the current policy, not repeatedly prepared in identical partial batches.
 
 Poll outcomes and the latest Guardian health record expose `deferred_value_edits`,
 `deferred_feedback_items`, and `translation_policy_rejections` separately from

--- a/localize/guardian/controller.py
+++ b/localize/guardian/controller.py
@@ -530,6 +530,9 @@ class PollOutcome:
     runs_completed: int = 0
     runs_failed: int = 0
     prepared_value_edits: int = 0
+    deferred_value_edits: int = 0
+    deferred_feedback_items: int = 0
+    translation_policy_rejections: int = 0
     applied_commits: tuple[str, ...] = ()
     prevention_drafts_created: int = 0
     prevention_items_skipped: int = 0
@@ -559,6 +562,9 @@ class _PollAccumulator:
     runs_completed: int = 0
     runs_failed: int = 0
     prepared_value_edits: int = 0
+    deferred_value_edits: int = 0
+    deferred_feedback_items: int = 0
+    translation_policy_rejections: int = 0
     applied_commits: list[str] = field(default_factory=list)
     prevention_drafts_created: int = 0
     prevention_items_skipped: int = 0
@@ -589,6 +595,9 @@ class _PollAccumulator:
             runs_completed=self.runs_completed,
             runs_failed=self.runs_failed,
             prepared_value_edits=self.prepared_value_edits,
+            deferred_value_edits=self.deferred_value_edits,
+            deferred_feedback_items=self.deferred_feedback_items,
+            translation_policy_rejections=self.translation_policy_rejections,
             applied_commits=tuple(self.applied_commits),
             prevention_drafts_created=self.prevention_drafts_created,
             prevention_items_skipped=self.prevention_items_skipped,
@@ -1884,6 +1893,29 @@ def _eligible_replacements(
     )
 
 
+def _bounded_replacements(
+    replacements: Sequence[ProposedReplacement], *, max_changes: int,
+) -> tuple[tuple[ProposedReplacement, ...], dict[str, int]]:
+    """Take one bounded batch without hiding duplicate targets past its cutoff."""
+    seen: set[tuple[str, str]] = set()
+    changes: list[ProposedReplacement] = []
+    for replacement in replacements:
+        identity = (replacement.path, replacement.key)
+        if identity in seen:
+            raise PatchPolicyError("Replacement batch contains duplicate targets.")
+        seen.add(identity)
+        if replacement.expected_value != replacement.proposed_value:
+            changes.append(replacement)
+    if max_changes < 0:
+        raise PatchPolicyError("Replacement limit must not be negative.")
+    if max_changes == 0 and changes:
+        raise PatchPolicyError("Translation edits are disabled by the configured zero limit.")
+    deferred: dict[str, int] = {}
+    for replacement in changes[max_changes:]:
+        deferred[replacement.feedback_id] = deferred.get(replacement.feedback_id, 0) + 1
+    return tuple(changes[:max_changes]), deferred
+
+
 def _validated_historical_replacements(
     assessments: Sequence[GuardianAssessment],
     *,
@@ -2639,6 +2671,10 @@ class GuardianController:
                                 outcome.historical_policy_rejections
                             ),
                             "runs_failed": outcome.runs_failed,
+                            "prepared_value_edits": outcome.prepared_value_edits,
+                            "deferred_value_edits": outcome.deferred_value_edits,
+                            "deferred_feedback_items": outcome.deferred_feedback_items,
+                            "translation_policy_rejections": outcome.translation_policy_rejections,
                             "prevention_drafts_created": (
                                 outcome.prevention_drafts_created
                             ),
@@ -5632,7 +5668,12 @@ class GuardianController:
                     and publication_mode is GuardianMode.APPLY_OWNED_TRANSLATIONS
                     else addressed_signatures
                 )
+                deferred_revisions = self.state.publication_deferred_revision_ids(
+                    replied_publication
+                )
                 for revision_id in replied_publication.event_revision_ids:
+                    if revision_id in deferred_revisions:
+                        continue
                     prior_revision = self.state.get_event_revision(revision_id)
                     if prior_revision is not None:
                         signature_target.add(
@@ -6324,6 +6365,11 @@ class GuardianController:
                 minimum_confidence=self.config.limits.min_apply_confidence,
                 excluded_feedback_ids=translation_suppressed_feedback_ids,
             )
+            deferred_edits: dict[str, int] = {}
+            if self.config.mode is not GuardianMode.OBSERVE:
+                replacements, deferred_edits = _bounded_replacements(
+                    replacements, max_changes=self.config.limits.max_value_edits_per_run,
+                )
             patch_result = PatchResult(changed_files=(), changed_keys=())
             if self.config.mode is not GuardianMode.OBSERVE and replacements:
                 patch_result = self.replacement_applier(
@@ -6337,6 +6383,9 @@ class GuardianController:
                     expected_source_locale=policy.source_locale,
                 )
                 outcome.prepared_value_edits += len(patch_result.changed_keys)
+
+            outcome.deferred_value_edits += sum(deferred_edits.values())
+            outcome.deferred_feedback_items += len(deferred_edits)
 
             commit_sha: str | None = None
             if (
@@ -6362,6 +6411,7 @@ class GuardianController:
                     run_id=run_id,
                     lease_owner=lease_owner,
                     observed_at=observed_at,
+                    deferred_edits=deferred_edits,
                 )
                 outcome.applied_commits.append(commit_sha)
 
@@ -6376,6 +6426,7 @@ class GuardianController:
                         translation_suppressed_feedback_ids
                     ),
                     observed_at=observed_at,
+                    deferred_edits=deferred_edits,
                 )
                 self.state.finish_run(
                     run_id,
@@ -6389,6 +6440,7 @@ class GuardianController:
         except (_AuthenticationCircuit, _ModelCircuit):
             raise
         except PatchPolicyError as exc:
+            outcome.translation_policy_rejections += 1
             for revision in revisions:
                 self.state.record_action(
                     run_id=run_id,
@@ -6476,6 +6528,7 @@ class GuardianController:
         run_id: str,
         lease_owner: str,
         observed_at: datetime | None = None,
+        deferred_edits: Mapping[str, int] | None = None,
     ) -> str:
         """Publish signed edits and separately account for the authorized status reply."""
         if (
@@ -6549,6 +6602,7 @@ class GuardianController:
             changed_keys=patch_result.changed_keys,
             commit_sha=commit.commit_sha,
             translation_suppressed_feedback_ids=(translation_suppressed_feedback_ids),
+            deferred_edits=deferred_edits,
         )
         publication_metadata = {
             "run_id": run_id,
@@ -6771,6 +6825,7 @@ class GuardianController:
         commit_sha: str | None,
         translation_suppressed_feedback_ids: frozenset[str],
         observed_at: datetime,
+        deferred_edits: Mapping[str, int] | None = None,
     ) -> None:
         for revision_id, status, details in self._completion_action_details(
             actionable=actionable,
@@ -6778,6 +6833,7 @@ class GuardianController:
             changed_keys=changed_keys,
             commit_sha=commit_sha,
             translation_suppressed_feedback_ids=(translation_suppressed_feedback_ids),
+            deferred_edits=deferred_edits,
         ):
             self.state.record_action(
                 run_id=run_id,
@@ -6796,6 +6852,7 @@ class GuardianController:
         changed_keys: Sequence[tuple[str, str]],
         commit_sha: str | None,
         translation_suppressed_feedback_ids: frozenset[str],
+        deferred_edits: Mapping[str, int] | None = None,
     ) -> tuple[tuple[int, str, Mapping[str, object]], ...]:
         """Build exact action rows for normal and atomic publication completion."""
 
@@ -6817,13 +6874,16 @@ class GuardianController:
                 for replacement in assessment.replacements
             }
             applied_keys = changed_key_set & assessment_keys if eligible else set()
+            remaining = (deferred_edits or {}).get(event.feedback_id, 0)
             completion_actions.append(
                 (
                     revision.revision_id,
-                    "completed",
+                    "skipped" if remaining else "completed",
                     {
                         "outcome": (
-                            "applied"
+                            "translation_batch_deferred"
+                            if remaining
+                            else "applied"
                             if commit_sha is not None and applied_keys
                             else "prepared"
                             if applied_keys
@@ -6838,6 +6898,7 @@ class GuardianController:
                         "changed_keys": len(applied_keys),
                         "commit_sha": commit_sha if applied_keys else None,
                         "recurrence_candidates": len(assessment.recurrence_candidates),
+                        **({"deferred_value_edits": remaining} if remaining else {}),
                     },
                 )
             )

--- a/localize/guardian/controller.py
+++ b/localize/guardian/controller.py
@@ -6366,7 +6366,10 @@ class GuardianController:
                 excluded_feedback_ids=translation_suppressed_feedback_ids,
             )
             deferred_edits: dict[str, int] = {}
-            if self.config.mode is not GuardianMode.OBSERVE:
+            if self.config.mode in {
+                GuardianMode.APPLY_OWNED_TRANSLATIONS,
+                GuardianMode.PROPOSE_PREVENTION,
+            }:
                 replacements, deferred_edits = _bounded_replacements(
                     replacements, max_changes=self.config.limits.max_value_edits_per_run,
                 )

--- a/localize/guardian/evidence.py
+++ b/localize/guardian/evidence.py
@@ -20,7 +20,7 @@ from localize.guardian.policy import PatchPolicyError, _load_glossary
 from localize.localization_profiles import LocalizationProfile, load_localization_profiles
 
 
-EVIDENCE_CONTRACT_VERSION = 2
+EVIDENCE_CONTRACT_VERSION = 3
 
 _INSTRUCTIONS = """# Localize Guardian assessment
 
@@ -41,6 +41,21 @@ Under exact glossary enforcement, preserve the required target terms and their
 source occurrence counts; do not substitute synonyms. Brand terms must also
 remain unchanged. If the rules and requested wording conflict, return
 `needs_human` instead of proposing a value that will fail validation.
+
+Independently assess recurrence as well as individual corrections. Look for
+shared failures across keys or locales, including unintended source-identical
+translations, lost safety instructions, and repeated terminology drift. Populate
+`recurrence_candidates` with supported pipeline or project improvements, citing
+the exact manifest feedback IDs. Describe the observed failure and a regression
+test that could prevent it. Do not invent a pipeline root cause: pipeline code
+is not in this bundle, so identify hypotheses for the prevention author to verify
+against current code before proposing a fix. Distinguish generic pipeline defects
+from project-specific terminology or configuration; use the appropriate scope.
+Source-identical brand names and legitimate shared-language wording are not
+automatically defects. Never manufacture candidates just to fill the list.
+In the result summary, explain the recurrence assessment, including why no
+supported recurrence candidate exists when returning an empty list.
+Propose only still-needed corrections; do not repeat already-correct values.
 """
 
 

--- a/localize/guardian/state.py
+++ b/localize/guardian/state.py
@@ -29,7 +29,9 @@ from localize.guardian.prevention import TestCommandResult, TestOutcome
 
 
 _UTC = timezone.utc
-_SCHEMA_VERSION = 10
+# Version 11 prevents older runtimes from mistaking skipped partial batches for
+# resolved feedback. The ledger shape is unchanged; its resolution semantics are not.
+_SCHEMA_VERSION = 11
 _SUPPORTED_SCHEMA_VERSIONS = frozenset(range(_SCHEMA_VERSION + 1))
 _TERMINAL_ACTION_STATUSES = frozenset({"completed", "skipped"})
 _ACTION_STATUSES = _TERMINAL_ACTION_STATUSES | {"failed", "pending"}
@@ -5767,6 +5769,8 @@ class GuardianState:
                 JOIN runs AS r ON r.run_id = a.run_id
                 WHERE a.event_revision_id = e.revision_id
                   AND a.status IN ({terminal_placeholders})
+                  AND json_extract(a.details_json, '$.outcome')
+                      IS NOT 'translation_batch_deferred'
                   {mode_filter}
                   {policy_filter}
             )"""
@@ -8832,7 +8836,7 @@ class GuardianState:
         details: Mapping[str, Any] | None = None,
         occurred_at: datetime | None = None,
     ) -> int:
-        """Append an auditable action; completed/skipped actions resolve a revision."""
+        """Append an action; batch deferrals remain pending despite skipped status."""
 
         if status not in _ACTION_STATUSES:
             raise ValueError(f"Unsupported action status {status!r}.")
@@ -9436,6 +9440,8 @@ class GuardianState:
                 JOIN runs AS r ON r.run_id = a.run_id
                 WHERE a.event_revision_id = e.revision_id
                   AND a.status IN ('completed', 'skipped')
+                  AND json_extract(a.details_json, '$.outcome')
+                      IS NOT 'translation_batch_deferred'
                   AND r.mode IN ({placeholders})
             )
             """,
@@ -10115,6 +10121,23 @@ class GuardianState:
         ).issubset(item[0] for item in canonical):
             raise RuntimeError("Publication completion plan is missing or malformed.")
         return canonical
+
+    def publication_deferred_revision_ids(
+        self, publication: PublicationRecord,
+    ) -> frozenset[int]:
+        """Keep partially corrected reviews actionable on the published head."""
+        exists = self._connection.execute(
+            "SELECT 1 FROM publication_completion_plan_items "
+            "WHERE publication_key = ? LIMIT 1", (publication.publication_key,),
+        ).fetchone()
+        if exists is None:
+            # Pre-plan legacy publications did not support partial batches.
+            return frozenset()
+        plan = self._publication_completion_plan_in_transaction(publication)
+        return frozenset(
+            revision_id for revision_id, _status, details in plan
+            if loads_bounded_json(details).get("outcome") == "translation_batch_deferred"
+        )
 
     def _record_publication_completion_plan_in_transaction(
         self,

--- a/tests/unit/test_guardian_controller.py
+++ b/tests/unit/test_guardian_controller.py
@@ -131,7 +131,7 @@ def _insert_legacy_publication(
     )
     publication_key = hashlib.sha256(payload.encode("utf-8")).hexdigest()
     with sqlite3.connect(database) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 10
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 11
         # Restore the pre-v8 table shape while the production connection is
         # closed. The next GuardianState open performs the real v7 -> v8
         # migration and reinstalls every dropped production trigger.
@@ -3104,7 +3104,7 @@ def test_refuses_to_infer_actor_or_lineage_for_a_legacy_prepared_push(
             state._connection.execute(  # noqa: SLF001
                 "PRAGMA user_version"
             ).fetchone()[0]
-            == 10
+            == 11
         )
         installed_triggers = {
             row["name"]
@@ -3215,7 +3215,7 @@ def test_refuses_to_infer_actor_or_open_authority_for_a_legacy_publication(
             state._connection.execute(  # noqa: SLF001
                 "PRAGMA user_version"
             ).fetchone()[0]
-            == 10
+            == 11
         )
         installed_triggers = {
             row["name"]
@@ -3973,6 +3973,109 @@ def test_changed_edit_limit_retries_policy_rejection_without_rebilling(
         assert poll(limited).runs_started == 0
         assert poll(config).applied_commits == (COMMIT_SHA,)
         assert len(driver.calls) == 1
+
+
+@pytest.mark.parametrize("reply_fails", [False, True])
+def test_oversized_feedback_publishes_bounded_batch_and_keeps_remainder_pending(
+    tmp_path: Path, runtime, reply_fails: bool, monkeypatch,
+) -> None:
+    """Partial feedback stays retryable even after reply recovery and head movement."""
+    base, head, checkout, provider, broker, sequence = runtime
+    for root in (base, head):
+        with (root / "l10n/messages_en.properties").open("a") as stream:
+            stream.write("alpha=Alpha\n")
+        with (root / TARGET_PATH).open("a") as stream:
+            stream.write("alpha=Старый альфа\n")
+    config = _config(GuardianMode.APPLY_OWNED_TRANSLATIONS)
+    config = replace(config, limits=replace(config.limits, max_value_edits_per_run=1))
+    driver = TwoReplacementCodexDriver()
+    if reply_fails:
+        broker.reply_error = RuntimeError("reply transport failed")
+    with GuardianState(tmp_path / "state.sqlite3") as state:
+        controller = _controller(
+            tmp_path=tmp_path, state=state, config=config, checkout=checkout,
+            provider=provider, driver=driver, broker=broker,
+        )
+        first = controller.poll_once()
+        assert first.prepared_value_edits == 1
+        assert first.deferred_value_edits == 1
+        assert first.deferred_feedback_items == 1
+        assert sum(workspace.publications for workspace in checkout.workspaces) == 1
+        assert len(state.pending_event_revisions(mode=config.mode)) == 1
+        health = state.latest_health("guardian")
+        assert health.details["deferred_value_edits"] == 1
+        if reply_fails:
+            pending = state.pending_publications()[0]
+            # Replaying the real atomic finalizer must retain deferred status.
+            state.finalize_replied_publication(
+                publication_key=pending.publication_key,
+                summary="Recovered test publication", occurred_at=NOW,
+            )
+        assert len(state.pending_event_revisions(mode=config.mode)) == 1
+        assert state.status_snapshot(mode=config.mode).pending_revisions == 1
+
+        # Move to the exact published head, including the real applied bytes.
+        # Partial feedback must be reassessed and its remaining edit published.
+        target = head / TARGET_PATH
+        target.write_text(target.read_text().replace(
+            "Старый %0 был отклонён (%1). %2 %3",
+            "Отправка в %0 отклонена (%1). %2 %3",
+        ))
+        provider.snapshots = (_snapshot(pull=_pull(head_sha=COMMIT_SHA)),)
+        broker.reply_error = None
+        sequence.clear()
+        monkeypatch.setattr(__import__(__name__, fromlist=["COMMIT_SHA"]), "COMMIT_SHA", "d" * 40)
+
+        class RemainingDriver(TwoReplacementCodexDriver):
+            @staticmethod
+            def _with_alpha(result):
+                """Propose only the still-unfixed value at the new head."""
+                result = TwoReplacementCodexDriver._with_alpha(result)
+                return replace(result, feedback=(replace(
+                    result.feedback[0], replacements=result.feedback[0].replacements[1:],
+                ),))
+
+        second_driver = RemainingDriver()
+        second = _controller(
+            tmp_path=tmp_path, state=state, config=config, checkout=checkout,
+            provider=provider, driver=second_driver, broker=broker,
+        ).poll_once()
+        assert len(second_driver.calls) == 1
+        assert second.applied_commits == ("d" * 40,)
+        assert second.prepared_value_edits == 1
+        assert second.deferred_value_edits == 0
+        assert second.failures == ()
+        assert state.pending_event_revisions(mode=config.mode) == ()
+        assert state.status_snapshot(mode=config.mode).pending_revisions == 0
+        assert sum(workspace.publications for workspace in checkout.workspaces) == 2
+
+
+@pytest.mark.parametrize("count,limit", [(34, 30), (30, 30), (0, 0), (0, 30)])
+def test_bounded_replacements_account_for_every_unselected_value(count, limit) -> None:
+    """Selected and deferred values exactly partition a multi-feedback proposal."""
+    replacements = tuple(ProposedReplacement(
+        feedback_id=f"review_comment:{index // 3}", path=TARGET_PATH,
+        key=f"key{index}", locale="ru", source_value="Hello",
+        expected_value="Старое", proposed_value="Привет", confidence=0.99,
+        evidence=("Verified review text",),
+    ) for index in range(count))
+    selected, deferred = guardian_controller._bounded_replacements(replacements, max_changes=limit)
+    assert selected == replacements[:limit]
+    assert sum(deferred.values()) == max(count - limit, 0)
+    assert set(deferred) == {item.feedback_id for item in replacements[limit:]}
+
+
+def test_batch_cutoff_does_not_hide_conflicting_targets() -> None:
+    """An over-limit conflicting proposal cannot authorize its leading edit."""
+    replacement = ProposedReplacement(
+        feedback_id="review_comment:1", path=TARGET_PATH, key="greeting",
+        locale="ru", source_value="Hello", expected_value="Старое",
+        proposed_value="Привет", confidence=0.99, evidence="Verified review text",
+    )
+    with pytest.raises(guardian_controller.PatchPolicyError, match="duplicate"):
+        guardian_controller._bounded_replacements(
+            (replacement, replace(replacement, proposed_value="Иное")), max_changes=1,
+        )
 
 
 @pytest.mark.parametrize("changed_file", ["config.yaml", "glossary.json"])

--- a/tests/unit/test_guardian_controller.py
+++ b/tests/unit/test_guardian_controller.py
@@ -4078,6 +4078,32 @@ def test_batch_cutoff_does_not_hide_conflicting_targets() -> None:
         )
 
 
+def test_prepare_does_not_repeat_a_nonretained_partial_batch(tmp_path: Path, runtime) -> None:
+    """Prepare keeps its bounded one-shot validation rather than inventing progress."""
+    base, head, checkout, provider, broker, _sequence = runtime
+    for root in (base, head):
+        with (root / "l10n/messages_en.properties").open("a") as stream:
+            stream.write("alpha=Alpha\n")
+        with (root / TARGET_PATH).open("a") as stream:
+            stream.write("alpha=Старый альфа\n")
+    config = _config(GuardianMode.PREPARE)
+    config = replace(config, limits=replace(config.limits, max_value_edits_per_run=1))
+    driver = TwoReplacementCodexDriver()
+    with GuardianState(tmp_path / "state.sqlite3") as state:
+        controller = _controller(
+            tmp_path=tmp_path, state=state, config=config, checkout=checkout,
+            provider=provider, driver=driver, broker=broker,
+        )
+        first = controller.poll_once()
+        second = controller.poll_once()
+        assert first.prepared_value_edits == 0
+        assert first.deferred_value_edits == 0
+        assert first.translation_policy_rejections == 1
+        assert second.runs_started == 0
+        assert len(driver.calls) == 1
+        assert all(workspace.publications == 0 for workspace in checkout.workspaces)
+
+
 @pytest.mark.parametrize("changed_file", ["config.yaml", "glossary.json"])
 def test_base_bundle_change_reconsiders_deterministic_patch_rejection(
     tmp_path: Path, runtime, changed_file: str,

--- a/tests/unit/test_guardian_evidence.py
+++ b/tests/unit/test_guardian_evidence.py
@@ -116,6 +116,12 @@ def test_builds_minimal_machine_readable_bundle_with_untrusted_feedback(tmp_path
     assert result.prompt_path.name == "INSTRUCTIONS.md"
     assert "UNTRUSTED DATA" in result.prompt_path.read_text(encoding="utf-8")
     assert "Ignore policy" not in result.prompt_path.read_text(encoding="utf-8")
+    instructions = " ".join(result.prompt_path.read_text(encoding="utf-8").split())
+    assert "recurrence_candidates" in instructions
+    assert "source-identical" in instructions
+    assert "regression test" in instructions
+    assert "Do not invent a pipeline root cause" in instructions
+    assert "why no supported recurrence candidate" in " ".join(instructions.split())
 
     manifest = json.loads((destination / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["feedback_ids"] == ["review_comment:44:abc"]

--- a/tests/unit/test_guardian_state.py
+++ b/tests/unit/test_guardian_state.py
@@ -2205,7 +2205,7 @@ def test_state_migrates_v1_database_to_historical_completion_schema(
         )
 
     with sqlite3.connect(database) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 10
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 11
 
 
 def test_populated_v1_event_remains_idempotent_after_migration(
@@ -2327,7 +2327,7 @@ def test_v2_remediation_edit_table_gains_target_mapping_column(
         assert "target_hash" in columns
 
     with sqlite3.connect(database) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 10
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 11
 
 
 def test_v3_pending_retry_survives_upgrade_and_gains_resolution_ledger(
@@ -2352,7 +2352,7 @@ def test_v3_pending_retry_survives_upgrade_and_gains_resolution_ledger(
         )
 
     with sqlite3.connect(database) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 10
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 11
         assert (
             connection.execute(
                 "SELECT COUNT(*) FROM historical_pull_retry_events"
@@ -2367,7 +2367,7 @@ def test_v3_pending_retry_survives_upgrade_and_gains_resolution_ledger(
         )
 
 
-def test_empty_v0_database_upgrades_to_v10(tmp_path: Path) -> None:
+def test_empty_v0_database_upgrades_to_v11(tmp_path: Path) -> None:
     """Initialize an empty database at the current supported schema version."""
     database = tmp_path / "guardian.sqlite3"
     with sqlite3.connect(database):
@@ -2378,7 +2378,27 @@ def test_empty_v0_database_upgrades_to_v10(tmp_path: Path) -> None:
         assert state.status_snapshot(mode=GuardianMode.OBSERVE).pending_revisions == 0
 
     with sqlite3.connect(database) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 10
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 11
+
+
+def test_v10_upgrade_preserves_audit_and_refuses_old_resolution_semantics(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Semantic schema migration preserves history and blocks old readers."""
+    database = tmp_path / "guardian.sqlite3"
+    with GuardianState(database) as state:
+        revision = state.record_feedback_event(_event())
+    with sqlite3.connect(database) as connection:
+        connection.execute("PRAGMA user_version = 10")
+    with GuardianState(database) as state:
+        assert state.get_event_revision(revision.revision_id) is not None
+        assert state.status_snapshot(mode=GuardianMode.PROPOSE_PREVENTION).pending_revisions == 1
+    monkeypatch.setattr(guardian_state, "_SUPPORTED_SCHEMA_VERSIONS", frozenset(range(11)))
+    with pytest.raises(RuntimeError, match="Unsupported guardian state schema version 11"):
+        GuardianState(database)
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 11
 
 
 def test_assessment_cache_and_cost_settlement_are_one_transaction(
@@ -4465,7 +4485,7 @@ def test_v7_publication_actor_migration_is_explicit_and_fails_closed(
             state._connection.execute(  # noqa: SLF001
                 "PRAGMA user_version"
             ).fetchone()[0]
-            == 10
+            == 11
         )
         for table in (
             "publication_events",
@@ -5968,7 +5988,7 @@ def test_migration_accepts_each_remediation_write_run_mode(
             state._connection.execute(  # noqa: SLF001
                 "PRAGMA user_version"
             ).fetchone()[0]
-            == 10
+            == 11
         )
 
 
@@ -7690,7 +7710,7 @@ def test_state_migrates_v1_database_to_remediation_ledger(tmp_path: Path) -> Non
         assert len(state.pending_remediation_drafts()) == 1
 
     with sqlite3.connect(database) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 10
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 11
 
 
 def test_state_migrates_successor_publication_actor_columns_fail_closed(
@@ -10086,7 +10106,7 @@ def test_v4_migration_keeps_unattested_completion_upgradeable_and_is_idempotent(
             state._connection.execute(  # noqa: SLF001
                 "PRAGMA user_version"
             ).fetchone()[0]
-            == 10
+            == 11
         )
         assert "branch_identity_version" in {
             row["name"]


### PR DESCRIPTION
## Summary

- Apply oversized open-PR correction proposals in bounded batches without increasing the configured edit limit. Reassess remaining feedback against the newly observed PR head.
- Preserve partial and deferred review work through atomic publication completion and reply recovery. Report deferred values, deferred feedback items, and deterministic policy rejections separately.
- Explicitly assess recurring untranslated text, lost safety warnings, and terminology drift. Require evidence-linked prevention hypotheses and an explanation when no supported candidate exists; verify causes against current pipeline code before authoring fixes.
- Advance the evidence contract to invalidate outdated assessments and the state version to 11, preventing older runtimes from treating partial corrections as fully resolved.

## Validation

Full pytest suite: 2793 passed, 1 skipped, 13 subtests passed. Regression tests reproduce the former all-or-nothing rejection, exercise two successive bounded publication runs, retain deferred work through reply recovery, reject conflicts beyond the batch cutoff, and protect the state-version boundary.

## Scope and rollout

Depends on #172; its publication changes are temporarily included until that PR merges. The new correction/assessment change is commit 235c1dec8.

No edit-cap increase, reviewer-authority expansion, API fallback, or automatic merging. This does not implement follow-up editing of pipeline-improvement PRs. Model recurrence assessment is not a guarantee of complete defect detection. Back up the idle audit database before upgrading; do not downgrade a schema-11 database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Prevention and remediation pull requests are now created ready for review instead of as drafts.
  - Existing draft and ready-for-review pull requests can be recovered safely without unnecessary duplicate publications.
  - Oversized translation updates are processed in bounded batches, with remaining work kept pending for later runs.
  - Recovery accepts a limited CodeRabbit release-notes annotation while preserving the original pull request content.
  - Recurring issues can now be identified and documented with supporting feedback references.

- **Documentation**
  - Updated Guardian guidance to explain ready-for-review workflows, bounded batching, recovery behavior, and recurrence assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->