### PR TITLE
Prevent recurrence: Hypothesis to verify: add a locale-aware residual source-term check for newly changed strings. Russ…

### DIFF
--- a/localize/semantic_quality.py
+++ b/localize/semantic_quality.py
@@ -535,7 +535,7 @@ def evaluate_retained_source_words(
     locale_allowed_words: Dict[str, set[str]] = {}
     glossary_words = _glossary_words(brand_glossary)
     for change in changes:
-        if change.locale_code in {"en", "pcm"}:
+        if _locale_language_code(change.locale_code) in {"en", "pcm"}:
             continue
         if not change.source_value:
             continue
@@ -595,12 +595,19 @@ def _allowed_source_words_for_locale(
     locale_code: str,
     retained_source_word_allowlist: Mapping[str, Iterable[str]],
 ) -> set[str]:
+    language_code = _locale_language_code(locale_code)
     return _allowlist_words(
         (
             *retained_source_word_allowlist.get("*", ()),
+            *retained_source_word_allowlist.get(language_code, ()),
             *retained_source_word_allowlist.get(locale_code, ()),
         )
     )
+
+
+def _locale_language_code(locale_code: str) -> str:
+    """Return the language component of a BCP 47 or underscore locale code."""
+    return re.split(r"[-_]", locale_code, maxsplit=1)[0].casefold()
 
 
 def _retained_source_words(

--- a/tests/unit/test_semantic_quality.py
+++ b/tests/unit/test_semantic_quality.py
@@ -155,6 +155,56 @@ def test_retained_source_word_allowlist_is_locale_scoped():
     assert "personal" in findings[0].reason
 
 
+def test_retained_source_words_use_language_allowlists_for_regional_locales():
+    changes = [
+        TranslationChange(
+            file="resources/mobile_ru_RU.properties",
+            locale_code="ru_RU",
+            key="mobile.offerbook.open",
+            source_value="Open Offerbook",
+            old_value="Открыть книгу предложений",
+            new_value="Открыть Offerbook",
+        ),
+        TranslationChange(
+            file="resources/mobile_vi_VN.properties",
+            locale_code="vi_VN",
+            key="mobile.offer.take",
+            source_value="Select take-offer",
+            old_value="Chọn đề nghị",
+            new_value="Chọn take-offer",
+        ),
+        TranslationChange(
+            file="resources/mobile_vi_VN.properties",
+            locale_code="vi_VN",
+            key="mobile.lightning",
+            source_value="Use Lightning",
+            old_value="Dùng Lightning",
+            new_value="Sử dụng Lightning",
+        ),
+        TranslationChange(
+            file="resources/mobile_vi_VN.properties",
+            locale_code="vi_VN",
+            key="mobile.personal",
+            source_value="Personal information",
+            old_value="Thông tin cá nhân",
+            new_value="Thông tin personal",
+        ),
+    ]
+
+    findings = evaluate_retained_source_words(
+        changes=changes,
+        brand_glossary=["Lightning"],
+        retained_source_word_allowlist={"vi": ["personal"]},
+    )
+
+    assert [finding.key for finding in findings] == [
+        "mobile.offerbook.open",
+        "mobile.offer.take",
+    ]
+    assert "Offerbook" in findings[0].reason
+    assert "take-offer" in findings[1].reason
+
+
 def test_semantic_warnings_do_not_block_unless_configured(tmp_path):
     repo_root = tmp_path
     input_folder = repo_root / "resources"


### PR DESCRIPTION
<!-- localize-guardian-prevention:v1 evidence=36a66671f3877c9415ea9330118137c6d8ff5f663d0f18c8065945edf944a6fb candidate=8b4e82f85ddbff53afe503a992d44878dcfddb35 -->
## Localize Guardian prevention proposal

Root cause: <code>Hypothesis to verify: add a locale-aware residual source-term check for newly changed strings. Russian “Offerbook” and Vietnamese “take-offer” remained untranslated despite established local wording. Test fixtures should flag those tokens while allowing configured brands and approved shared-language terms.</code>

Evidence fingerprint: <code>36a66671f3877c9415ea9330118137c6d8ff5f663d0f18c8065945edf944a6fb</code>

### Review evidence

- <code>review_comment:3975843331:revision-233</code>
- <code>review_comment:3975843337:revision-235</code>

### Bounded patch

Base: <code>ecda91f047b563575e8619bb38f586ec9a1a67c1</code>

Candidate direct child: <code>8b4e82f85ddbff53afe503a992d44878dcfddb35</code>

Patch fingerprint: <code>c7c9544794b00675cc63f9375f0a432cc553bf8ae222cbf093d5ed91094205e9</code>

- <code>localize/semantic_quality.py</code>
- <code>tests/unit/test_semantic_quality.py</code>

### Regression proof supplied by the controller

The same focused argv failed on the exact base and passed on its direct child:

Portable runner labels below are display-only; exact commands remain private.

- <code>pytest; executable path and arguments retained in private audit; command fingerprint: d3e67e3421603a5aaa54e26da9ee742ddba29304e15e087c9d5423db32db132a</code>

Publication of this proposal requires a separate broker to re-verify current state and publish only this signed candidate. The Guardian cannot merge or deploy prevention proposals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retained-source-word checks for regional locale codes, ensuring language-specific rules apply consistently.
  * Preserved support for global, language-level, and full-locale allowlists.
  * Excluded English and Nigerian Pidgin locale variants from these checks as intended.

* **Tests**
  * Added coverage for regional locale allowlists, brand glossary terms, and retained-word findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->